### PR TITLE
KAN-123: fix sticky split table header separator

### DIFF
--- a/src/components/Common/SplitDataTable.tsx
+++ b/src/components/Common/SplitDataTable.tsx
@@ -111,13 +111,19 @@ export function SplitDataTable<TData>({
             />
           ))}
         </colgroup>
-        <TableHeader className="sticky top-0 z-10 bg-muted">
+        <TableHeader className="sticky top-0 z-10 bg-muted shadow-[inset_0_-1px_0_0_var(--border)]">
           {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id} className="hover:bg-transparent">
+            <TableRow
+              key={headerGroup.id}
+              className="border-b-0 hover:bg-transparent"
+            >
               {headerGroup.headers.map((header) => {
                 const meta = getColumnMeta(header.column.columnDef)
                 return (
-                  <TableHead key={header.id} className={meta?.headerClassName}>
+                  <TableHead
+                    key={header.id}
+                    className={cn("bg-muted", meta?.headerClassName)}
+                  >
                     {header.isPlaceholder
                       ? null
                       : flexRender(

--- a/tests/topics-cases-ui.spec.ts
+++ b/tests/topics-cases-ui.spec.ts
@@ -155,10 +155,19 @@ test("Topics page matches the primary pane width and truncates long left-table t
     .getByTestId("topics-primary-pane")
     .evaluate((element) => element.getBoundingClientRect().width)
   const tableHeader = page.locator("thead").first()
+  const firstHeaderCell = tableHeader.locator("th").first()
 
   expect(Math.abs(globalSearchWidth - primaryPaneWidth)).toBeLessThanOrEqual(1)
   await expect(tableHeader).toHaveClass(/\bbg-muted\b/)
   await expect(tableHeader).not.toHaveClass(/bg-muted\/50/)
+  expect(
+    await tableHeader.evaluate((element) => getComputedStyle(element).boxShadow),
+  ).not.toBe("none")
+  expect(
+    await firstHeaderCell.evaluate(
+      (element) => getComputedStyle(element).backgroundColor,
+    ),
+  ).not.toBe("rgba(0, 0, 0, 0)")
 
   const firstRow = page.locator("tbody tr").first()
   const topicTitle = firstRow.locator("td").first().locator("span").first()


### PR DESCRIPTION
## Summary
- add an explicit separator shadow to the shared sticky split-table header so the first body row cannot bleed through at the header edge
- give split-table header cells their own opaque background so the sticky header paints cleanly in Topics and Cases
- extend the Topics/Cases Playwright coverage to assert the sticky header separator and non-transparent header cell background

## Validation
- `bun run build`
- `PATH=/usr/bin:/snap/bin:$PATH npx playwright test tests/topics-cases-ui.spec.ts --project=chromium --no-deps`

## Jira
- KAN-123
