### PR TITLE
KAN-124: add demo mode toggle and frontend routing

### DIFF
--- a/src/api/cases.ts
+++ b/src/api/cases.ts
@@ -93,6 +93,7 @@ export interface ReadCasesParams {
   q?: string
   skip?: number
   limit?: number
+  demo?: boolean
 }
 
 export function readCases(
@@ -107,16 +108,23 @@ export function readCases(
       q: params.q?.trim() || undefined,
       skip: params.skip,
       limit: params.limit,
+      demo: params.demo || undefined,
     },
   })
 }
 
-export function readCase(caseId: string): CancelablePromise<CasePublic> {
+export function readCase(
+  caseId: string,
+  options: { demo?: boolean } = {},
+): CancelablePromise<CasePublic> {
   return request(OpenAPI, {
     method: "GET",
     url: "/api/v1/cases/{case_id}",
     path: {
       case_id: caseId,
+    },
+    query: {
+      demo: options.demo || undefined,
     },
   })
 }
@@ -129,6 +137,7 @@ export interface CaseUpdate {
 export function updateCase(
   caseId: string,
   body: CaseUpdate,
+  options: { demo?: boolean } = {},
 ): CancelablePromise<CasePublic> {
   const title = body.title?.trim()
   const summaryCurrent =
@@ -141,6 +150,9 @@ export function updateCase(
     url: "/api/v1/cases/{case_id}",
     path: {
       case_id: caseId,
+    },
+    query: {
+      demo: options.demo || undefined,
     },
     body: {
       ...(title !== undefined ? { title } : {}),

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -27,6 +27,7 @@ export interface SearchResultsPublic {
 export function readGlobalSearch(
   q: string,
   limitPerKind = 5,
+  options: { demo?: boolean } = {},
 ): CancelablePromise<SearchResultsPublic> {
   return request(OpenAPI, {
     method: "GET",
@@ -34,6 +35,7 @@ export function readGlobalSearch(
     query: {
       q: q.trim(),
       limit_per_kind: limitPerKind,
+      demo: options.demo || undefined,
     },
   })
 }

--- a/src/api/topics.ts
+++ b/src/api/topics.ts
@@ -58,6 +58,7 @@ export interface ReadTopicsParams {
   workflow_key?: string
   skip?: number
   limit?: number
+  demo?: boolean
 }
 
 export function readTopics(
@@ -72,28 +73,39 @@ export function readTopics(
       workflow_key: params.workflow_key?.trim() || undefined,
       skip: params.skip,
       limit: params.limit,
+      demo: params.demo || undefined,
     },
   })
 }
 
-export function readTopic(topicId: string): CancelablePromise<TopicPublic> {
+export function readTopic(
+  topicId: string,
+  options: { demo?: boolean } = {},
+): CancelablePromise<TopicPublic> {
   return request(OpenAPI, {
     method: "GET",
     url: "/api/v1/topics/{topic_id}",
     path: {
       topic_id: topicId,
     },
+    query: {
+      demo: options.demo || undefined,
+    },
   })
 }
 
 export function readTopicRollup(
   topicId: string,
+  options: { demo?: boolean } = {},
 ): CancelablePromise<TopicRollupPublic> {
   return request(OpenAPI, {
     method: "GET",
     url: "/api/v1/topics/{topic_id}/rollup",
     path: {
       topic_id: topicId,
+    },
+    query: {
+      demo: options.demo || undefined,
     },
   })
 }
@@ -106,6 +118,7 @@ export interface TopicUpdate {
 export function updateTopic(
   topicId: string,
   body: TopicUpdate,
+  options: { demo?: boolean } = {},
 ): CancelablePromise<TopicPublic> {
   const title = body.title?.trim()
   const description =
@@ -118,6 +131,9 @@ export function updateTopic(
     url: "/api/v1/topics/{topic_id}",
     path: {
       topic_id: topicId,
+    },
+    query: {
+      demo: options.demo || undefined,
     },
     body: {
       ...(title !== undefined ? { title } : {}),

--- a/src/components/Cases/CasesPage.tsx
+++ b/src/components/Cases/CasesPage.tsx
@@ -18,6 +18,7 @@ import {
   updateCase,
 } from "@/api/cases"
 import { SplitDataTable } from "@/components/Common/SplitDataTable"
+import { useDemoMode } from "@/components/demo-mode-provider"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -327,6 +328,7 @@ export function CasesPage({
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const isMobile = useIsMobile()
+  const { isDemoMode } = useDemoMode()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const [selectedCaseId, setSelectedCaseId] = useState<string | null>(
     initialSelectedCaseId,
@@ -341,6 +343,7 @@ export function CasesPage({
     useState<HTMLDivElement | null>(null)
   const [isSplitViewOpen, setIsSplitViewOpen] = useState(true)
   const [isFocusedViewOpen, setIsFocusedViewOpen] = useState(false)
+  const lastDemoModeRef = useRef(isDemoMode)
 
   useEffect(() => {
     if (initialSelectedCaseId) {
@@ -349,13 +352,28 @@ export function CasesPage({
     }
   }, [initialSelectedCaseId])
 
+  useEffect(() => {
+    if (lastDemoModeRef.current === isDemoMode) return
+
+    lastDemoModeRef.current = isDemoMode
+    setSelectedCaseId(null)
+    setIsSplitViewOpen(true)
+    setIsFocusedViewOpen(false)
+    void navigate({
+      to: "/cases",
+      search: {},
+      replace: true,
+    })
+  }, [isDemoMode, navigate])
+
   const casesQuery = useInfiniteQuery({
-    queryKey: ["cases"],
+    queryKey: ["cases", isDemoMode],
     initialPageParam: 0,
     queryFn: ({ pageParam }) =>
       readCases({
         skip: pageParam,
         limit: CASES_PAGE_SIZE,
+        demo: isDemoMode,
       }),
     getNextPageParam: (lastPage, allPages) => {
       const loaded = allPages.reduce(
@@ -384,8 +402,8 @@ export function CasesPage({
 
   const detailQuery = useQuery({
     enabled: Boolean(resolvedSelectedCaseId),
-    queryKey: ["case", resolvedSelectedCaseId],
-    queryFn: () => readCase(resolvedSelectedCaseId ?? ""),
+    queryKey: ["case", resolvedSelectedCaseId, isDemoMode],
+    queryFn: () => readCase(resolvedSelectedCaseId ?? "", { demo: isDemoMode }),
   })
 
   const detail = detailQuery.data ?? selectedCase
@@ -423,16 +441,23 @@ export function CasesPage({
       title?: string
       summaryCurrent?: string | null
     }) =>
-      updateCase(caseId, {
-        title,
-        summary_current: summaryCurrent,
-      }),
+      updateCase(
+        caseId,
+        {
+          title,
+          summary_current: summaryCurrent,
+        },
+        { demo: isDemoMode },
+      ),
     onSuccess: (updatedCase) => {
       queryClient.setQueryData<InfiniteData<CasesPublic> | undefined>(
-        ["cases"],
+        ["cases", isDemoMode],
         (current) => replaceCaseInPages(current, updatedCase),
       )
-      queryClient.setQueryData(["case", updatedCase.id], updatedCase)
+      queryClient.setQueryData(
+        ["case", updatedCase.id, isDemoMode],
+        updatedCase,
+      )
     },
     onError: handleError.bind(showErrorToast),
   })

--- a/src/components/Search/GlobalSearchBar.tsx
+++ b/src/components/Search/GlobalSearchBar.tsx
@@ -4,6 +4,7 @@ import { Loader2, Search as SearchIcon } from "lucide-react"
 import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react"
 
 import { readGlobalSearch, type SearchHitPublic } from "@/api/search"
+import { useDemoMode } from "@/components/demo-mode-provider"
 import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
@@ -20,7 +21,9 @@ type SearchEntry = {
 
 export function GlobalSearchBar() {
   const navigate = useNavigate()
+  const { isDemoMode } = useDemoMode()
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const lastDemoModeRef = useRef(isDemoMode)
   const [query, setQuery] = useState("")
   const [debouncedQuery, setDebouncedQuery] = useState("")
   const [isFocused, setIsFocused] = useState(false)
@@ -46,9 +49,22 @@ export function GlobalSearchBar() {
     return () => document.removeEventListener("mousedown", handlePointerDown)
   }, [])
 
+  useEffect(() => {
+    if (lastDemoModeRef.current === isDemoMode) return
+
+    lastDemoModeRef.current = isDemoMode
+    setQuery("")
+    setDebouncedQuery("")
+    setIsFocused(false)
+    setActiveIndex(-1)
+  }, [isDemoMode])
+
   const searchQuery = useQuery({
-    queryKey: ["globalSearch", debouncedQuery],
-    queryFn: () => readGlobalSearch(debouncedQuery, LIMIT_PER_KIND),
+    queryKey: ["globalSearch", debouncedQuery, isDemoMode],
+    queryFn: () =>
+      readGlobalSearch(debouncedQuery, LIMIT_PER_KIND, {
+        demo: isDemoMode,
+      }),
     enabled: debouncedQuery.length >= MIN_QUERY_LENGTH,
     staleTime: 15_000,
   })

--- a/src/components/Sidebar/AppSidebar.tsx
+++ b/src/components/Sidebar/AppSidebar.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Boxes,
+  FlaskConical,
   Home,
   PanelLeftClose,
   PanelLeftOpen,
@@ -9,6 +10,7 @@ import {
 
 import { SidebarAppearance } from "@/components/Common/Appearance"
 import { Logo } from "@/components/Common/Logo"
+import { useDemoMode } from "@/components/demo-mode-provider"
 import {
   Sidebar,
   SidebarContent,
@@ -19,6 +21,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar"
 import useAuth from "@/hooks/useAuth"
+import { cn } from "@/lib/utils"
 import { type Item, Main } from "./Main"
 import { User } from "./User"
 
@@ -50,6 +53,40 @@ function SidebarCollapseToggle() {
   )
 }
 
+function DemoModeToggle() {
+  const { isDemoMode, toggleDemoMode } = useDemoMode()
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        tooltip={isDemoMode ? "Disable demo mode" : "Enable demo mode"}
+        data-testid="demo-mode-toggle"
+        role="switch"
+        aria-checked={isDemoMode}
+        onClick={toggleDemoMode}
+      >
+        <FlaskConical className="size-[18px] text-muted-foreground" />
+        <span>Demo mode</span>
+        <div
+          aria-hidden="true"
+          className={cn(
+            "ml-auto hidden h-6 w-11 rounded-full border border-sidebar-border/70 bg-sidebar-accent/60 p-0.5 transition-colors group-data-[collapsible=icon]:hidden md:block",
+            isDemoMode && "bg-sidebar-primary/25",
+          )}
+        >
+          <div
+            className={cn(
+              "h-5 w-5 rounded-full bg-sidebar-foreground/50 shadow-sm transition-transform",
+              isDemoMode &&
+                "translate-x-5 bg-sidebar-primary text-sidebar-primary-foreground",
+            )}
+          />
+        </div>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  )
+}
+
 export function AppSidebar() {
   const { user: currentUser } = useAuth()
 
@@ -66,6 +103,7 @@ export function AppSidebar() {
         <Main items={items} />
       </SidebarContent>
       <SidebarFooter className="gap-1">
+        <DemoModeToggle />
         <SidebarCollapseToggle />
         <SidebarAppearance />
         <User user={currentUser} />

--- a/src/components/Topics/TopicsPage.tsx
+++ b/src/components/Topics/TopicsPage.tsx
@@ -20,6 +20,7 @@ import {
   updateTopic,
 } from "@/api/topics"
 import { SplitDataTable } from "@/components/Common/SplitDataTable"
+import { useDemoMode } from "@/components/demo-mode-provider"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -154,6 +155,7 @@ export function TopicsPage({
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const isMobile = useIsMobile()
+  const { isDemoMode } = useDemoMode()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const [selectedTopicId, setSelectedTopicId] = useState<string | null>(
     initialSelectedTopicId,
@@ -168,6 +170,7 @@ export function TopicsPage({
     useState<HTMLDivElement | null>(null)
   const [isSplitViewOpen, setIsSplitViewOpen] = useState(true)
   const [isFocusedViewOpen, setIsFocusedViewOpen] = useState(false)
+  const lastDemoModeRef = useRef(isDemoMode)
 
   useEffect(() => {
     if (initialSelectedTopicId) {
@@ -176,13 +179,28 @@ export function TopicsPage({
     }
   }, [initialSelectedTopicId])
 
+  useEffect(() => {
+    if (lastDemoModeRef.current === isDemoMode) return
+
+    lastDemoModeRef.current = isDemoMode
+    setSelectedTopicId(null)
+    setIsSplitViewOpen(true)
+    setIsFocusedViewOpen(false)
+    void navigate({
+      to: "/topics",
+      search: {},
+      replace: true,
+    })
+  }, [isDemoMode, navigate])
+
   const topicsQuery = useInfiniteQuery({
-    queryKey: ["topics"],
+    queryKey: ["topics", isDemoMode],
     initialPageParam: 0,
     queryFn: ({ pageParam }) =>
       readTopics({
         skip: pageParam,
         limit: TOPICS_PAGE_SIZE,
+        demo: isDemoMode,
       }),
     getNextPageParam: (lastPage, allPages) => {
       const loaded = allPages.reduce(
@@ -211,8 +229,9 @@ export function TopicsPage({
 
   const selectedTopicQuery = useQuery({
     enabled: Boolean(resolvedSelectedTopicId),
-    queryKey: ["topic", resolvedSelectedTopicId],
-    queryFn: () => readTopic(resolvedSelectedTopicId ?? ""),
+    queryKey: ["topic", resolvedSelectedTopicId, isDemoMode],
+    queryFn: () =>
+      readTopic(resolvedSelectedTopicId ?? "", { demo: isDemoMode }),
   })
 
   const selectedTopic = selectedTopicQuery.data ?? selectedTopicFromList
@@ -225,15 +244,20 @@ export function TopicsPage({
 
   const topicCasesQuery = useQuery({
     enabled: Boolean(selectedTopic?.id),
-    queryKey: ["topicCases", selectedTopic?.id],
+    queryKey: ["topicCases", selectedTopic?.id, isDemoMode],
     queryFn: () =>
-      readCases({ topic_id: selectedTopic?.id ?? undefined, limit: 20 }),
+      readCases({
+        topic_id: selectedTopic?.id ?? undefined,
+        limit: 20,
+        demo: isDemoMode,
+      }),
   })
 
   const topicRollupQuery = useQuery({
     enabled: Boolean(selectedTopic?.id),
-    queryKey: ["topicRollup", selectedTopic?.id],
-    queryFn: () => readTopicRollup(selectedTopic?.id ?? ""),
+    queryKey: ["topicRollup", selectedTopic?.id, isDemoMode],
+    queryFn: () =>
+      readTopicRollup(selectedTopic?.id ?? "", { demo: isDemoMode }),
   })
 
   const updateTopicMutation = useMutation({
@@ -245,15 +269,18 @@ export function TopicsPage({
       topicId: string
       title?: string
       description?: string | null
-    }) => updateTopic(topicId, { title, description }),
+    }) => updateTopic(topicId, { title, description }, { demo: isDemoMode }),
     onSuccess: (updatedTopic) => {
       queryClient.setQueryData<InfiniteData<TopicsPublic> | undefined>(
-        ["topics"],
+        ["topics", isDemoMode],
         (current) => replaceTopicInPages(current, updatedTopic),
       )
-      queryClient.setQueryData(["topic", updatedTopic.id], updatedTopic)
+      queryClient.setQueryData(
+        ["topic", updatedTopic.id, isDemoMode],
+        updatedTopic,
+      )
       queryClient.invalidateQueries({
-        queryKey: ["topicRollup", updatedTopic.id],
+        queryKey: ["topicRollup", updatedTopic.id, isDemoMode],
       })
     },
     onError: handleError.bind(showErrorToast),

--- a/src/components/demo-mode-provider.tsx
+++ b/src/components/demo-mode-provider.tsx
@@ -1,0 +1,77 @@
+import {
+  createContext,
+  startTransition,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react"
+
+type DemoModeProviderProps = {
+  children: React.ReactNode
+  storageKey?: string
+}
+
+type DemoModeProviderState = {
+  isDemoMode: boolean
+  setDemoMode: (enabled: boolean) => void
+  toggleDemoMode: () => void
+}
+
+const initialState: DemoModeProviderState = {
+  isDemoMode: false,
+  setDemoMode: () => null,
+  toggleDemoMode: () => null,
+}
+
+const DemoModeProviderContext =
+  createContext<DemoModeProviderState>(initialState)
+
+export function DemoModeProvider({
+  children,
+  storageKey = "enderai-demo-mode",
+}: DemoModeProviderProps) {
+  const [isDemoMode, setIsDemoMode] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false
+    return window.localStorage.getItem(storageKey) === "true"
+  })
+
+  const setDemoMode = useCallback(
+    (enabled: boolean) => {
+      window.localStorage.setItem(storageKey, String(enabled))
+      startTransition(() => {
+        setIsDemoMode(enabled)
+      })
+    },
+    [storageKey],
+  )
+
+  const toggleDemoMode = useCallback(() => {
+    setDemoMode(!isDemoMode)
+  }, [isDemoMode, setDemoMode])
+
+  const value = useMemo(
+    () => ({
+      isDemoMode,
+      setDemoMode,
+      toggleDemoMode,
+    }),
+    [isDemoMode, setDemoMode, toggleDemoMode],
+  )
+
+  return (
+    <DemoModeProviderContext.Provider value={value}>
+      {children}
+    </DemoModeProviderContext.Provider>
+  )
+}
+
+export const useDemoMode = () => {
+  const context = useContext(DemoModeProviderContext)
+
+  if (context === undefined) {
+    throw new Error("useDemoMode must be used within a DemoModeProvider")
+  }
+
+  return context
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { createRouter, RouterProvider } from "@tanstack/react-router"
 import { StrictMode } from "react"
 import ReactDOM from "react-dom/client"
 import { ApiError, OpenAPI } from "./client"
+import { DemoModeProvider } from "./components/demo-mode-provider"
 import { ThemeProvider } from "./components/theme-provider"
 import { Toaster } from "./components/ui/sonner"
 import "./index.css"
@@ -61,10 +62,12 @@ if (redirectParam) {
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-      <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
-        <Toaster richColors closeButton />
-      </QueryClientProvider>
+      <DemoModeProvider>
+        <QueryClientProvider client={queryClient}>
+          <RouterProvider router={router} />
+          <Toaster richColors closeButton />
+        </QueryClientProvider>
+      </DemoModeProvider>
     </ThemeProvider>
   </StrictMode>,
 )

--- a/tests/global-search.spec.ts
+++ b/tests/global-search.spec.ts
@@ -9,6 +9,13 @@ const currentUser = {
   created_at: "2026-03-24T00:00:00Z",
 }
 
+test.use({
+  storageState: {
+    cookies: [],
+    origins: [],
+  },
+})
+
 test("Global search navigates to a case result and loads it by route param", async ({
   page,
 }) => {
@@ -114,6 +121,53 @@ test("Global search navigates to a case result and loads it by route param", asy
       )
       .first(),
   ).toBeVisible()
+})
+
+test("Global search sends demo=true when demo mode is enabled", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "test-token")
+  })
+
+  await page.route("**/api/v1/users/me", async (route) => {
+    await route.fulfill({ json: currentUser })
+  })
+
+  const searchRequests: string[] = []
+  await page.route("**/api/v1/search/*", async (route) => {
+    searchRequests.push(route.request().url())
+    await route.fulfill({
+      json: {
+        topics: [],
+        cases: [],
+        topic_count: 0,
+        case_count: 0,
+      },
+    })
+  })
+
+  await page.goto("/")
+
+  await page.getByTestId("global-search-input").fill("Global")
+  await expect
+    .poll(() =>
+      searchRequests.some(
+        (url) => new URL(url).searchParams.get("demo") === null,
+      ),
+    )
+    .toBeTruthy()
+
+  await page.getByTestId("demo-mode-toggle").click()
+  await page.getByTestId("global-search-input").fill("Global")
+
+  await expect
+    .poll(() =>
+      searchRequests.some(
+        (url) => new URL(url).searchParams.get("demo") === "true",
+      ),
+    )
+    .toBeTruthy()
 })
 
 test("Global search navigates to a topic result and loads it by route param", async ({

--- a/tests/topics-cases-ui.spec.ts
+++ b/tests/topics-cases-ui.spec.ts
@@ -43,6 +43,83 @@ test("Home route sets the browser tab title to Home", async ({ page }) => {
   await expect(page).toHaveTitle("Home")
 })
 
+test("Sidebar demo mode toggle sits above collapse and scopes Topics/Cases requests", async ({
+  page,
+}) => {
+  await mockAuth(page)
+
+  const topicRequests: string[] = []
+  const caseRequests: string[] = []
+
+  await page.route("**/api/v1/topics/**", async (route) => {
+    const url = new URL(route.request().url())
+
+    if (url.pathname === "/api/v1/topics/") {
+      topicRequests.push(route.request().url())
+      await route.fulfill({ json: { data: [], count: 0 } })
+      return
+    }
+
+    await route.fulfill({ status: 404, json: { detail: "Topic not found" } })
+  })
+
+  await page.route("**/api/v1/cases/**", async (route) => {
+    const url = new URL(route.request().url())
+
+    if (url.pathname === "/api/v1/cases/") {
+      caseRequests.push(route.request().url())
+      await route.fulfill({ json: { data: [], count: 0 } })
+      return
+    }
+
+    await route.fulfill({ status: 404, json: { detail: "Case not found" } })
+  })
+
+  await page.goto("/topics")
+
+  const demoToggle = page.getByTestId("demo-mode-toggle")
+  const collapseToggle = page.getByTestId("sidebar-collapse-toggle")
+
+  await expect(demoToggle).toBeVisible()
+  await expect(collapseToggle).toBeVisible()
+
+  const demoBox = await demoToggle.boundingBox()
+  const collapseBox = await collapseToggle.boundingBox()
+
+  expect(demoBox).not.toBeNull()
+  expect(collapseBox).not.toBeNull()
+  expect(demoBox!.y).toBeLessThan(collapseBox!.y)
+
+  await expect
+    .poll(() =>
+      topicRequests.some(
+        (url) => new URL(url).searchParams.get("demo") === null,
+      ),
+    )
+    .toBeTruthy()
+
+  await demoToggle.click()
+  await expect(demoToggle).toHaveAttribute("aria-checked", "true")
+
+  await expect
+    .poll(() =>
+      topicRequests.some(
+        (url) => new URL(url).searchParams.get("demo") === "true",
+      ),
+    )
+    .toBeTruthy()
+
+  await page.getByRole("link", { name: "Cases" }).click()
+
+  await expect
+    .poll(() =>
+      caseRequests.some(
+        (url) => new URL(url).searchParams.get("demo") === "true",
+      ),
+    )
+    .toBeTruthy()
+})
+
 test("Topics page matches the primary pane width and truncates long left-table text", async ({
   page,
 }) => {
@@ -161,7 +238,9 @@ test("Topics page matches the primary pane width and truncates long left-table t
   await expect(tableHeader).toHaveClass(/\bbg-muted\b/)
   await expect(tableHeader).not.toHaveClass(/bg-muted\/50/)
   expect(
-    await tableHeader.evaluate((element) => getComputedStyle(element).boxShadow),
+    await tableHeader.evaluate(
+      (element) => getComputedStyle(element).boxShadow,
+    ),
   ).not.toBe("none")
   expect(
     await firstHeaderCell.evaluate(


### PR DESCRIPTION
## Summary
- add a persistent demo-mode provider and sidebar switch above the expand/collapse control
- thread demo mode into Topics, Cases, and global search query keys and API calls
- reset route-selected Topic/Case state when switching modes so stale live/demo IDs do not leak across views
- add Playwright coverage for the new toggle placement and demo query behavior

## Jira
- KAN-124

## Validation
- `bun run build`
- `env FIRST_SUPERUSER=admin@example.com FIRST_SUPERUSER_PASSWORD=kan124-super-password npx playwright test --project=chromium --no-deps tests/topics-cases-ui.spec.ts tests/global-search.spec.ts`

## Notes
- the UI only sends `demo=true` when demo mode is enabled, so existing live-mode mocks and behavior stay unchanged by default
- this frontend PR depends on the backend demo-mode route support from the matching backend PR