### PR TITLE
KAN-127: center and shrink demo mode slider knob

### DIFF
--- a/src/components/Sidebar/AppSidebar.tsx
+++ b/src/components/Sidebar/AppSidebar.tsx
@@ -79,15 +79,17 @@ function DemoModeToggle() {
         <span>Demo mode</span>
         <div
           aria-hidden="true"
+          data-testid="demo-mode-toggle-track"
           className={cn(
-            "ml-auto hidden h-6 w-11 rounded-full border border-sidebar-border/70 bg-sidebar-accent/60 p-0.5 transition-colors group-data-[collapsible=icon]:hidden md:block",
+            "ml-auto hidden h-6 w-11 items-center rounded-full border border-sidebar-border/70 bg-sidebar-accent/60 px-0.5 transition-colors group-data-[collapsible=icon]:hidden md:flex",
             isDemoMode && "border-violet-300/30 bg-white/15",
           )}
         >
           <div
+            data-testid="demo-mode-toggle-thumb"
             className={cn(
-              "h-5 w-5 rounded-full bg-sidebar-foreground/50 shadow-sm transition-transform",
-              isDemoMode && "translate-x-5 bg-white text-violet-700",
+              "h-[15px] w-[15px] rounded-full bg-sidebar-foreground/50 shadow-sm transition-transform",
+              isDemoMode && "translate-x-[25px] bg-white text-violet-700",
             )}
           />
         </div>

--- a/tests/topics-cases-ui.spec.ts
+++ b/tests/topics-cases-ui.spec.ts
@@ -124,6 +124,21 @@ test("Sidebar demo mode toggle sits above collapse and scopes Topics/Cases reque
   )
   expect(activeBackground).not.toBe("rgba(0, 0, 0, 0)")
 
+  const track = page.getByTestId("demo-mode-toggle-track")
+  const thumb = page.getByTestId("demo-mode-toggle-thumb")
+  const trackBox = await track.boundingBox()
+  const thumbBox = await thumb.boundingBox()
+
+  expect(trackBox).not.toBeNull()
+  expect(thumbBox).not.toBeNull()
+  expect(thumbBox!.height).toBeLessThan(trackBox!.height)
+  expect(thumbBox!.width).toBeLessThan(trackBox!.height)
+  expect(
+    Math.abs(
+      thumbBox!.y + thumbBox!.height / 2 - (trackBox!.y + trackBox!.height / 2),
+    ),
+  ).toBeLessThanOrEqual(1)
+
   await collapseToggle.click()
   await expect(demoToggle).toBeVisible()
 


### PR DESCRIPTION
## Summary
- center the demo-mode slider thumb within the track
- shrink the active thumb to 15px so it reads less oversized in the control
- add Playwright coverage for the slider thumb geometry

## Jira
- KAN-127

## Validation
- `bun run build`
- `./node_modules/.bin/playwright test --project=chromium --no-deps tests/topics-cases-ui.spec.ts`