### PR TITLE
KAN-128/KAN-129: clean up detail panes and demo toggle spacing

### DIFF
--- a/src/api/topics.ts
+++ b/src/api/topics.ts
@@ -113,6 +113,7 @@ export function readTopicRollup(
 export interface TopicUpdate {
   title?: string
   description?: string | null
+  status?: string
 }
 
 export function updateTopic(
@@ -125,6 +126,7 @@ export function updateTopic(
     typeof body.description === "string"
       ? body.description.trim() || null
       : body.description
+  const status = body.status?.trim() || undefined
 
   return request(OpenAPI, {
     method: "PATCH",
@@ -138,6 +140,7 @@ export function updateTopic(
     body: {
       ...(title !== undefined ? { title } : {}),
       ...(body.description !== undefined ? { description } : {}),
+      ...(status !== undefined ? { status } : {}),
     },
   })
 }

--- a/src/components/Cases/CasesPage.tsx
+++ b/src/components/Cases/CasesPage.tsx
@@ -40,6 +40,8 @@ import { handleError } from "@/utils"
 import styles from "./CasesPage.module.css"
 
 const CASES_PAGE_SIZE = 25
+const JIRA_BROWSE_BASE_URL = "https://alexlee4190.atlassian.net/browse"
+const GITHUB_PR_SEARCH_BASE_URL = "https://github.com/search"
 
 function formatTimestamp(value: string | null): string {
   if (!value) return "—"
@@ -89,12 +91,29 @@ function describeLoadedCount(
   return `${total} ${total === 1 ? singular : plural}`
 }
 
+function resolveChangeRefUrl(ref: string): string | null {
+  const normalized = ref.trim()
+
+  if (!normalized) return null
+  if (/^https?:\/\//i.test(normalized)) return normalized
+  if (/^KAN-\d+$/i.test(normalized)) {
+    return `${JIRA_BROWSE_BASE_URL}/${normalized.toUpperCase()}`
+  }
+  if (/^PR-\d+$/i.test(normalized)) {
+    return `${GITHUB_PR_SEARCH_BASE_URL}?q=${encodeURIComponent(`is:pr ${normalized.toUpperCase()}`)}&type=pullrequests`
+  }
+
+  return null
+}
+
 function ChipList({
   items,
   emptyText,
+  resolveUrl,
 }: {
   items: string[]
   emptyText: string
+  resolveUrl?: (item: string) => string | null
 }) {
   if (items.length === 0) {
     return <p className={styles.smallMutedText}>{emptyText}</p>
@@ -104,12 +123,29 @@ function ChipList({
     <div className={styles.chipList}>
       {items.map((item, index) => {
         const display = getSignalChipDisplay(item)
+        const url = resolveUrl?.(item) ?? null
+
+        if (url) {
+          return (
+            <Badge
+              key={`${item}-${index}`}
+              asChild
+              variant="outline"
+              className={cn(styles.chip, "normal-case")}
+              title={display.title}
+            >
+              <a href={url} target="_blank" rel="noreferrer">
+                <span className={styles.chipLabel}>{display.label}</span>
+              </a>
+            </Badge>
+          )
+        }
 
         return (
           <Badge
             key={`${item}-${index}`}
             variant="outline"
-            className={styles.chip}
+            className={cn(styles.chip, "normal-case")}
             title={display.title}
           >
             <span className={styles.chipLabel}>{display.label}</span>
@@ -239,6 +275,7 @@ function ChangeList({ changes }: { changes: CasePublic["changes"] }) {
               <ChipList
                 items={change.refs}
                 emptyText="No refs captured for this change."
+                resolveUrl={resolveChangeRefUrl}
               />
             </div>
           ) : null}

--- a/src/components/Sidebar/AppSidebar.tsx
+++ b/src/components/Sidebar/AppSidebar.tsx
@@ -81,7 +81,7 @@ function DemoModeToggle() {
           aria-hidden="true"
           data-testid="demo-mode-toggle-track"
           className={cn(
-            "ml-auto hidden h-6 w-11 items-center rounded-full border border-sidebar-border/70 bg-sidebar-accent/60 px-0.5 transition-colors group-data-[collapsible=icon]:hidden md:flex",
+            "ml-auto hidden h-6 w-11 items-center rounded-full border border-sidebar-border/70 bg-sidebar-accent/60 px-[3px] transition-colors group-data-[collapsible=icon]:hidden md:flex",
             isDemoMode && "border-violet-300/30 bg-white/15",
           )}
         >
@@ -89,7 +89,7 @@ function DemoModeToggle() {
             data-testid="demo-mode-toggle-thumb"
             className={cn(
               "h-[15px] w-[15px] rounded-full bg-sidebar-foreground/50 shadow-sm transition-transform",
-              isDemoMode && "translate-x-[25px] bg-white text-violet-700",
+              isDemoMode && "translate-x-[21px] bg-white text-violet-700",
             )}
           />
         </div>

--- a/src/components/Topics/TopicsPage.module.css
+++ b/src/components/Topics/TopicsPage.module.css
@@ -104,6 +104,30 @@
   @apply block max-w-full truncate;
 }
 
+.recordStack {
+  @apply space-y-3;
+}
+
+.recordCard {
+  @apply rounded-lg border p-3;
+}
+
+.monoText {
+  @apply font-mono text-xs;
+}
+
+.metaStack {
+  @apply mt-2 space-y-1 text-sm text-muted-foreground;
+}
+
+.signalGroups {
+  @apply space-y-3;
+}
+
+.signalTitle {
+  @apply mb-2 text-sm font-medium;
+}
+
 .recentCasesList {
   @apply space-y-3;
 }

--- a/src/components/Topics/TopicsPage.tsx
+++ b/src/components/Topics/TopicsPage.tsx
@@ -10,10 +10,9 @@ import type { ColumnDef } from "@tanstack/react-table"
 import { Maximize2, Minimize2, X } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 
-import { readCases } from "@/api/cases"
+import { readCases, type CasePublic } from "@/api/cases"
 import {
   readTopic,
-  readTopicRollup,
   readTopics,
   type TopicPublic,
   type TopicsPublic,
@@ -32,6 +31,13 @@ import {
 } from "@/components/ui/card"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { useAutoLoadMore } from "@/hooks/useAutoLoadMore"
 import useCustomToast from "@/hooks/useCustomToast"
@@ -42,6 +48,13 @@ import { handleError } from "@/utils"
 import styles from "./TopicsPage.module.css"
 
 const TOPICS_PAGE_SIZE = 25
+const DEFAULT_TOPIC_STATUSES = [
+  "open",
+  "in progress",
+  "blocked",
+  "resolved",
+  "closed",
+] as const
 
 function formatTimestamp(value: string | null): string {
   if (!value) return "—"
@@ -60,6 +73,36 @@ function badgeVariant(
   if (["running", "active", "in progress"].includes(normalized))
     return "secondary"
   return "outline"
+}
+
+function formatStatusLabel(status: string): string {
+  return status.replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+function getTopicStatusOptions(status: string | null | undefined): string[] {
+  const normalizedStatus = status?.trim().toLowerCase()
+
+  if (!normalizedStatus) return [...DEFAULT_TOPIC_STATUSES]
+
+  return Array.from(new Set([normalizedStatus, ...DEFAULT_TOPIC_STATUSES]))
+}
+
+function topicStatusTriggerClassName(status: string): string {
+  const normalized = status.trim().toLowerCase()
+
+  if (["done", "closed", "resolved"].includes(normalized)) {
+    return "border-transparent bg-emerald-500 text-white hover:bg-emerald-500/90 focus-visible:ring-emerald-500/20"
+  }
+
+  if (["failed", "error", "blocked"].includes(normalized)) {
+    return "border-transparent bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20"
+  }
+
+  if (["running", "active", "in progress"].includes(normalized)) {
+    return "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/90"
+  }
+
+  return "border-border bg-background text-foreground hover:bg-accent hover:text-accent-foreground"
 }
 
 function replaceTopicInPages(
@@ -91,6 +134,63 @@ function describeLoadedCount(
   return `${total} ${total === 1 ? singular : plural}`
 }
 
+function SignalChipList({
+  items,
+  emptyText,
+}: {
+  items: string[]
+  emptyText: string
+}) {
+  if (items.length === 0) {
+    return <p className={styles.smallMutedText}>{emptyText}</p>
+  }
+
+  return (
+    <div className={styles.chipList}>
+      {items.map((item, index) => {
+        const display = getSignalChipDisplay(item)
+
+        return (
+          <Badge
+            key={`${item}-${index}`}
+            variant="outline"
+            className={cn(styles.chip, "normal-case")}
+            title={display.title}
+          >
+            <span className={styles.chipLabel}>{display.label}</span>
+          </Badge>
+        )
+      })}
+    </div>
+  )
+}
+
+function CommandList({ commands }: { commands: CasePublic["commands"] }) {
+  if (commands.length === 0) {
+    return <p className={styles.smallMutedText}>No commands captured yet.</p>
+  }
+
+  return (
+    <div className={styles.recordStack}>
+      {commands.map((command, index) => (
+        <div
+          key={`${command.cmd}-${command.ts ?? index}`}
+          className={styles.recordCard}
+        >
+          <div className={styles.monoText}>{command.cmd}</div>
+          {command.purpose || command.salient_result || command.ts ? (
+            <div className={styles.metaStack}>
+              {command.purpose ? <p>{command.purpose}</p> : null}
+              {command.salient_result ? <p>{command.salient_result}</p> : null}
+              {command.ts ? <p>{formatTimestamp(command.ts)}</p> : null}
+            </div>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  )
+}
+
 const TOPIC_COLUMNS: ColumnDef<TopicPublic>[] = [
   {
     accessorKey: "title",
@@ -101,7 +201,10 @@ const TOPIC_COLUMNS: ColumnDef<TopicPublic>[] = [
     },
     cell: ({ row }) => {
       const title = getClippedTextDisplay(row.original.title)
-      const subtitle = getClippedTextDisplay(row.original.workflow_key)
+      const subtitle = getClippedTextDisplay(
+        row.original.description?.trim() ||
+          "No description captured for this topic yet.",
+      )
 
       return (
         <div className={styles.tableTitleCell}>
@@ -248,28 +351,46 @@ export function TopicsPage({
     queryFn: () =>
       readCases({
         topic_id: selectedTopic?.id ?? undefined,
-        limit: 20,
+        limit: 500,
         demo: isDemoMode,
       }),
   })
 
-  const topicRollupQuery = useQuery({
-    enabled: Boolean(selectedTopic?.id),
-    queryKey: ["topicRollup", selectedTopic?.id, isDemoMode],
-    queryFn: () =>
-      readTopicRollup(selectedTopic?.id ?? "", { demo: isDemoMode }),
-  })
+  const aggregatedSignals = useMemo(() => {
+    const cases = topicCasesQuery.data?.data ?? []
+    const dedupe = (values: string[]) => Array.from(new Set(values))
+
+    return {
+      files: dedupe(cases.flatMap((caseItem) => caseItem.files)),
+      symbols: dedupe(cases.flatMap((caseItem) => caseItem.symbols)),
+      errors: dedupe(cases.flatMap((caseItem) => caseItem.errors)),
+      symptoms: dedupe(cases.flatMap((caseItem) => caseItem.symptoms)),
+    }
+  }, [topicCasesQuery.data])
+
+  const aggregatedCommands = useMemo(
+    () => topicCasesQuery.data?.data.flatMap((caseItem) => caseItem.commands) ?? [],
+    [topicCasesQuery.data],
+  )
+
+  const recentCases = useMemo(
+    () => topicCasesQuery.data?.data.slice(0, 20) ?? [],
+    [topicCasesQuery.data],
+  )
 
   const updateTopicMutation = useMutation({
     mutationFn: ({
       topicId,
       title,
       description,
+      status,
     }: {
       topicId: string
       title?: string
       description?: string | null
-    }) => updateTopic(topicId, { title, description }, { demo: isDemoMode }),
+      status?: string
+    }) =>
+      updateTopic(topicId, { title, description, status }, { demo: isDemoMode }),
     onSuccess: (updatedTopic) => {
       queryClient.setQueryData<InfiniteData<TopicsPublic> | undefined>(
         ["topics", isDemoMode],
@@ -279,9 +400,6 @@ export function TopicsPage({
         ["topic", updatedTopic.id, isDemoMode],
         updatedTopic,
       )
-      queryClient.invalidateQueries({
-        queryKey: ["topicRollup", updatedTopic.id, isDemoMode],
-      })
     },
     onError: handleError.bind(showErrorToast),
   })
@@ -356,6 +474,27 @@ export function TopicsPage({
         nextDescription
           ? "Topic description updated"
           : "Topic description cleared",
+      )
+    } catch {
+      return
+    }
+  }
+
+  const saveStatus = async (nextStatus: string) => {
+    if (!selectedTopic) return
+
+    const normalizedStatus = nextStatus.trim().toLowerCase()
+    const currentStatus = selectedTopic.status.trim().toLowerCase()
+
+    if (!normalizedStatus || normalizedStatus === currentStatus) return
+
+    try {
+      await updateTopicMutation.mutateAsync({
+        topicId: selectedTopic.id,
+        status: normalizedStatus,
+      })
+      showSuccessToast(
+        `Topic status updated to ${formatStatusLabel(normalizedStatus)}`,
       )
     } catch {
       return
@@ -515,10 +654,32 @@ export function TopicsPage({
         )}
       >
         <div className={styles.badgeRow}>
-          <Badge variant={badgeVariant(selectedTopic?.status ?? "open")}>
-            {selectedTopic?.status ?? "open"}
-          </Badge>
-          <Badge variant="outline">{selectedTopic?.workflow_key}</Badge>
+          <Select
+            value={(selectedTopic?.status ?? "open").trim().toLowerCase()}
+            disabled={!selectedTopic || updateTopicMutation.isPending}
+            onValueChange={(value) => {
+              void saveStatus(value)
+            }}
+          >
+            <SelectTrigger
+              size="sm"
+              aria-label="Topic status"
+              data-testid="topic-status-trigger"
+              className={cn(
+                "h-7 min-w-[8rem] rounded-full px-2.5 py-1 text-xs font-medium capitalize shadow-none [&_svg]:text-current",
+                topicStatusTriggerClassName(selectedTopic?.status ?? "open"),
+              )}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start">
+              {getTopicStatusOptions(selectedTopic?.status).map((status) => (
+                <SelectItem key={status} value={status}>
+                  {formatStatusLabel(status)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <Badge variant="outline">
             {selectedTopic?.case_count ?? 0} cases
           </Badge>
@@ -540,41 +701,59 @@ export function TopicsPage({
         </div>
 
         <div className={styles.section}>
-          <div className={styles.sectionTitle}>Canonical signals</div>
-          {topicRollupQuery.isLoading ? (
-            <p className={styles.smallMutedText}>Loading rollup…</p>
-          ) : topicRollupQuery.isError ? (
-            <p className={styles.errorText}>Couldn’t load the Topic rollup.</p>
+          <div className={styles.sectionTitle}>Signals</div>
+          {topicCasesQuery.isLoading ? (
+            <p className={styles.smallMutedText}>Loading Cases…</p>
+          ) : topicCasesQuery.isError ? (
+            <p className={styles.errorText}>
+              Couldn’t aggregate signals for this Topic.
+            </p>
           ) : (
-            <div className={styles.chipList}>
-              {[
-                ...(topicRollupQuery.data?.canonical_files ?? []),
-                ...(topicRollupQuery.data?.canonical_errors ?? []),
-              ]
-                .slice(0, 8)
-                .map((signal) => {
-                  const display = getSignalChipDisplay(signal)
-
-                  return (
-                    <Badge
-                      key={signal}
-                      variant="outline"
-                      className={styles.chip}
-                      title={display.title}
-                    >
-                      <span className={styles.chipLabel}>{display.label}</span>
-                    </Badge>
-                  )
-                })}
-              {!(
-                topicRollupQuery.data?.canonical_files.length ||
-                topicRollupQuery.data?.canonical_errors.length
-              ) ? (
-                <span className={styles.mutedText}>
-                  No canonical signals yet.
-                </span>
-              ) : null}
+            <div className={styles.signalGroups}>
+              <div>
+                <div className={styles.signalTitle}>Files</div>
+                <SignalChipList
+                  items={aggregatedSignals.files}
+                  emptyText="No files captured yet."
+                />
+              </div>
+              <div>
+                <div className={styles.signalTitle}>Symbols</div>
+                <SignalChipList
+                  items={aggregatedSignals.symbols}
+                  emptyText="No symbols captured yet."
+                />
+              </div>
+              <div>
+                <div className={styles.signalTitle}>Errors</div>
+                <SignalChipList
+                  items={aggregatedSignals.errors}
+                  emptyText="No errors captured yet."
+                />
+              </div>
+              <div>
+                <div className={styles.signalTitle}>Symptoms</div>
+                <SignalChipList
+                  items={aggregatedSignals.symptoms}
+                  emptyText="No symptoms captured yet."
+                />
+              </div>
             </div>
+          )}
+        </div>
+
+        <div className={styles.section}>
+          <div
+            className={styles.sectionTitle}
+          >{`Commands (${aggregatedCommands.length})`}</div>
+          {topicCasesQuery.isLoading ? (
+            <p className={styles.smallMutedText}>Loading Cases…</p>
+          ) : topicCasesQuery.isError ? (
+            <p className={styles.errorText}>
+              Couldn’t aggregate commands for this Topic.
+            </p>
+          ) : (
+            <CommandList commands={aggregatedCommands} />
           )}
         </div>
 
@@ -586,13 +765,13 @@ export function TopicsPage({
             <p className={styles.errorText}>
               Couldn’t load Cases for this Topic.
             </p>
-          ) : (topicCasesQuery.data?.data.length ?? 0) === 0 ? (
+          ) : recentCases.length === 0 ? (
             <p className={styles.smallMutedText}>
               No Cases under this Topic yet.
             </p>
           ) : (
             <div className={styles.recentCasesList}>
-              {topicCasesQuery.data?.data.map((caseItem) => (
+              {recentCases.map((caseItem) => (
                 <button
                   key={caseItem.id}
                   type="button"

--- a/src/lib/display.ts
+++ b/src/lib/display.ts
@@ -34,6 +34,21 @@ function looksLikePath(value: string): boolean {
   return value.includes("/") || value.includes("\\")
 }
 
+function formatSentenceCase(value: string): string {
+  if (!/\s/.test(value)) return value
+
+  const normalized = value
+    .split(/(\s+)/)
+    .map((part) => {
+      if (!part.trim()) return part
+      if (part.toUpperCase() === part && /[A-Z]/.test(part)) return part
+      return part.toLowerCase()
+    })
+    .join("")
+
+  return `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`
+}
+
 function normalizePath(value: string): string {
   const normalized = normalizeText(value).replace(/\\/g, "/")
   const segments = normalized.split("/").filter(Boolean)
@@ -77,9 +92,11 @@ export function getSignalChipDisplay(value: string | null | undefined): {
   }
 
   if (!looksLikePath(full)) {
+    const sentenceCased = formatSentenceCase(full)
+
     return {
-      label: truncateWithEllipsis(full),
-      title: full,
+      label: truncateWithEllipsis(sentenceCased),
+      title: sentenceCased,
     }
   }
 

--- a/tests/topics-cases-ui.spec.ts
+++ b/tests/topics-cases-ui.spec.ts
@@ -166,101 +166,197 @@ test("Topics page matches the primary pane width and truncates long left-table t
 }) => {
   await mockAuth(page)
 
+  const statusUpdates: string[] = []
+  const topicCaseSignals = {
+    files: [
+      "mobile/src/sync/optimisticMerge.ts",
+      "backend/app/core/conflicts.py",
+      "mobile/tests/sync/optimistic-merge.spec.ts",
+    ],
+    symbols: [
+      "optimisticMerge",
+      "reconcile_conflict",
+      "ConflictResolutionError",
+    ],
+    errors: ["conflict reconciliation rejected client patch"],
+    symptoms: [
+      "notes visibly rewrote themselves after reconnect",
+      "support tickets mentioned disappearing bullet points",
+    ],
+  }
+  const topicCases = [
+    {
+      id: "case-1",
+      topic_id: "topic-1",
+      topic_title: longTopicTitle,
+      title: "Optimistic merge backend mismatch",
+      opened_at: "2026-03-24T00:00:00Z",
+      updated_at: "2026-03-24T00:00:00Z",
+      closed_at: null,
+      status: "open",
+      actor_id: null,
+      source: null,
+      input_summary: null,
+      summary_current: "Investigating merge-rule mismatch.",
+      files: topicCaseSignals.files.slice(0, 2),
+      symbols: topicCaseSignals.symbols.slice(0, 2),
+      errors: topicCaseSignals.errors,
+      symptoms: topicCaseSignals.symptoms.slice(0, 1),
+      commands: [
+        {
+          cmd: "pytest backend/tests/test_conflicts.py",
+          purpose: "compare backend reconciliation to optimistic merge",
+          salient_result: "backend rejected combinations the client accepted",
+          ts: null,
+        },
+      ],
+      hypotheses: [],
+      changes: [],
+      outcome: null,
+      next_steps: [],
+      context_pack_snapshot: {
+        topic_id: "topic-1",
+        case_id: "case-1",
+        confidence: "high",
+        alternative_topic_ids: [],
+        topic_summary: null,
+        matched_signals: [],
+        representative_cases: [],
+        recent_cases: [],
+        relevant_cases: [],
+        canonical_files: [],
+        canonical_symbols: [],
+        canonical_errors: [],
+        canonical_symptoms: [],
+        pinned_takeaways: [],
+        ambiguities: [],
+        questions: [],
+        negative_history: [],
+        builder_version: null,
+        created_at: null,
+      },
+    },
+    {
+      id: "case-2",
+      topic_id: "topic-1",
+      topic_title: longTopicTitle,
+      title: "Optimistic merge preview drift",
+      opened_at: "2026-03-24T00:00:00Z",
+      updated_at: "2026-03-24T00:00:00Z",
+      closed_at: null,
+      status: "open",
+      actor_id: null,
+      source: null,
+      input_summary: null,
+      summary_current: "Tracking frontend merge preview instability.",
+      files: topicCaseSignals.files.slice(2),
+      symbols: topicCaseSignals.symbols.slice(2),
+      errors: [],
+      symptoms: topicCaseSignals.symptoms.slice(1),
+      commands: [
+        {
+          cmd: "pnpm test optimistic-merge.spec.ts",
+          purpose: "reproduce jarring overwrite behavior",
+          salient_result: "UI showed divergent merge previews",
+          ts: null,
+        },
+      ],
+      hypotheses: [],
+      changes: [],
+      outcome: null,
+      next_steps: [],
+      context_pack_snapshot: {
+        topic_id: "topic-1",
+        case_id: "case-2",
+        confidence: "high",
+        alternative_topic_ids: [],
+        topic_summary: null,
+        matched_signals: [],
+        representative_cases: [],
+        recent_cases: [],
+        relevant_cases: [],
+        canonical_files: [],
+        canonical_symbols: [],
+        canonical_errors: [],
+        canonical_symptoms: [],
+        pinned_takeaways: [],
+        ambiguities: [],
+        questions: [],
+        negative_history: [],
+        builder_version: null,
+        created_at: null,
+      },
+    },
+  ]
+  let topic = {
+    id: "topic-1",
+    title: longTopicTitle,
+    slug: "topic-1",
+    description: "Topic description",
+    aliases: [],
+    status: "open",
+    workflow_key: longWorkflowKey,
+    owner_ids: [],
+    created_at: "2026-03-24T00:00:00Z",
+    updated_at: "2026-03-24T00:00:00Z",
+    last_used_at: "2026-03-24T00:00:00Z",
+    rollup_summary: "Topic summary",
+    rollup_version: 1,
+    canonical_files: [tempPath],
+    canonical_symbols: [],
+    canonical_errors: [],
+    canonical_symptoms: [],
+    pinned_takeaways: [],
+    ambiguity_notes: [],
+    open_questions: [],
+    negative_history: [],
+    representative_case_ids: [],
+    recent_case_ids: [],
+    vocabulary: [],
+    case_count: 2,
+  }
+
   await page.route("**/api/v1/topics/?skip=0&limit=25", async (route) => {
     await route.fulfill({
       json: {
-        data: [
-          {
-            id: "topic-1",
-            title: longTopicTitle,
-            slug: "topic-1",
-            description: "Topic description",
-            aliases: [],
-            status: "open",
-            workflow_key: longWorkflowKey,
-            owner_ids: [],
-            created_at: "2026-03-24T00:00:00Z",
-            updated_at: "2026-03-24T00:00:00Z",
-            last_used_at: "2026-03-24T00:00:00Z",
-            rollup_summary: "Topic summary",
-            rollup_version: 1,
-            canonical_files: [tempPath],
-            canonical_symbols: [],
-            canonical_errors: [],
-            canonical_symptoms: [],
-            pinned_takeaways: [],
-            ambiguity_notes: [],
-            open_questions: [],
-            negative_history: [],
-            representative_case_ids: [],
-            recent_case_ids: [],
-            vocabulary: [],
-            case_count: 1,
-          },
-        ],
+        data: [topic],
         count: 1,
       },
     })
   })
 
-  await page.route("**/api/v1/topics/topic-1", async (route) => {
-    await route.fulfill({
-      json: {
-        id: "topic-1",
-        title: longTopicTitle,
-        slug: "topic-1",
-        description: "Topic description",
-        aliases: [],
-        status: "open",
-        workflow_key: longWorkflowKey,
-        owner_ids: [],
-        created_at: "2026-03-24T00:00:00Z",
-        updated_at: "2026-03-24T00:00:00Z",
-        last_used_at: "2026-03-24T00:00:00Z",
-        rollup_summary: "Topic summary",
-        rollup_version: 1,
-        canonical_files: [tempPath],
-        canonical_symbols: [],
-        canonical_errors: [],
-        canonical_symptoms: [],
-        pinned_takeaways: [],
-        ambiguity_notes: [],
-        open_questions: [],
-        negative_history: [],
-        representative_case_ids: [],
-        recent_case_ids: [],
-        vocabulary: [],
-        case_count: 1,
-      },
-    })
-  })
+  await page.route("**/api/v1/topics/topic-1*", async (route) => {
+    if (route.request().method() === "PATCH") {
+      const patch = route.request().postDataJSON() as {
+        title?: string
+        description?: string | null
+        status?: string
+      }
 
-  await page.route("**/api/v1/topics/topic-1/rollup", async (route) => {
-    await route.fulfill({
-      json: {
-        brief: "Topic summary",
-        canonical_files: [tempPath],
-        canonical_symbols: [],
-        canonical_errors: [],
-        canonical_symptoms: [],
-        pinned_takeaways: [],
-        negative_history: [],
-        representative_case_ids: [],
-        aliases: [],
-        vocabulary: [],
-        ambiguity_notes: [],
-        open_questions: [],
-        case_count: 1,
-        recent_case_ids: [],
-        updated_at: "2026-03-24T00:00:00Z",
-      },
-    })
+      if (patch.status) statusUpdates.push(patch.status)
+
+      topic = {
+        ...topic,
+        ...(patch.title !== undefined ? { title: patch.title } : {}),
+        ...(patch.description !== undefined
+          ? { description: patch.description }
+          : {}),
+        ...(patch.status !== undefined ? { status: patch.status } : {}),
+      }
+
+      await route.fulfill({ json: topic })
+      return
+    }
+
+    await route.fulfill({ json: topic })
   })
 
   await page.route(
-    "**/api/v1/cases/?topic_id=topic-1&limit=20",
+    "**/api/v1/cases/?topic_id=topic-1&limit=500",
     async (route) => {
-      await route.fulfill({ json: { data: [], count: 0 } })
+      await route.fulfill({
+        json: { data: topicCases, count: topicCases.length },
+      })
     },
   )
 
@@ -291,15 +387,51 @@ test("Topics page matches the primary pane width and truncates long left-table t
 
   const firstRow = page.locator("tbody tr").first()
   const topicTitle = firstRow.locator("td").first().locator("span").first()
-  const workflowKey = firstRow.locator("td").first().locator("span").nth(1)
+  const topicSubtitle = firstRow.locator("td").first().locator("span").nth(1)
 
   await expect(topicTitle).toHaveText(/…$/)
   await expect(topicTitle).toHaveAttribute("title", longTopicTitle)
-  await expect(workflowKey).toHaveText(/…$/)
-  await expect(workflowKey).toHaveAttribute("title", longWorkflowKey)
+  await expect(topicSubtitle).toHaveText("Topic description")
+  await expect(topicSubtitle).toHaveAttribute("title", "Topic description")
+  await expect(page.getByText(longWorkflowKey)).toHaveCount(0)
 
-  const canonicalFileChip = page.getByTitle(normalizedPath).first()
-  await expect(canonicalFileChip).toContainText("…/Context_packs.py")
+  const topicStatusTrigger = page.getByTestId("topic-status-trigger")
+  await expect(topicStatusTrigger).toContainText("Open")
+
+  await topicStatusTrigger.click()
+  await page.getByRole("option", { name: "Closed" }).click()
+
+  await expect.poll(() => statusUpdates.at(-1)).toBe("closed")
+  await expect(topicStatusTrigger).toContainText("Closed")
+
+  await expect(page.getByText("Signals")).toBeVisible()
+  await expect(page.getByText("Commands (2)")).toBeVisible()
+  await expect(page.getByTitle("src/sync/optimisticMerge.ts")).toContainText(
+    "…/optimisticMerge.ts",
+  )
+  await expect(
+    page.getByTitle("backend/app/core/conflicts.py"),
+  ).toContainText("…/conflicts.py")
+  const errorSignal = page.getByText(
+    "Conflict reconciliation rejected client patch",
+  )
+  const symptomSignal = page.getByText(
+    "Notes visibly rewrote themselves after reconnect",
+  )
+  await expect(errorSignal).toBeVisible()
+  await expect(symptomSignal).toBeVisible()
+  await expect(errorSignal).toHaveText(
+    "Conflict reconciliation rejected client patch",
+  )
+  await expect(symptomSignal).toHaveText(
+    "Notes visibly rewrote themselves after reconnect",
+  )
+  await expect(
+    page.getByText("pytest backend/tests/test_conflicts.py"),
+  ).toBeVisible()
+  await expect(
+    page.getByText("pnpm test optimistic-merge.spec.ts"),
+  ).toBeVisible()
 })
 
 test("Cases page truncates long table text and normalizes file chips", async ({
@@ -387,7 +519,7 @@ test("Cases page truncates long table text and normalizes file chips", async ({
             kind: "code",
             summary: "Normalize displayed file paths in case detail.",
             files: [tempPath],
-            refs: [],
+            refs: ["PR-1019"],
             ts: "2026-03-24T00:00:00Z",
           },
         ],
@@ -434,5 +566,9 @@ test("Cases page truncates long table text and normalizes file chips", async ({
 
   const normalizedFileChip = page.getByTitle(normalizedPath).first()
   await expect(normalizedFileChip).toContainText("…/Context_packs.py")
+  await expect(page.getByRole("link", { name: "PR-1019" })).toHaveAttribute(
+    "href",
+    /github\.com\/search/,
+  )
   await expect(page.getByText("/Tmp/Enderai-Kan-119-Main")).toHaveCount(0)
 })


### PR DESCRIPTION
## Summary
- replace topic row workflow-key subtitles with descriptions and remove the workflow-key badge from topic detail
- make topic status editable from the right-hand detail pane
- aggregate topic detail signals and commands from the child cases under that topic
- preserve real signal/file casing, render human-readable signal text in sentence case, and link change refs to GitHub PR search or Jira when applicable
- rebalance the demo-mode toggle thumb inset so the active white thumb has matching side/top-bottom breathing room

## Jira
- KAN-128
- KAN-129

## Validation
- `bun run build`
- `./node_modules/.bin/playwright test --project=chromium --no-deps tests/topics-cases-ui.spec.ts`