### PR TITLE
KAN-133: fix Pages base path for custom domain

### DIFF
--- a/.github/workflows/deploy-frontend-pages.yml
+++ b/.github/workflows/deploy-frontend-pages.yml
@@ -31,7 +31,19 @@ jobs:
 
       - name: Compute Vite base path
         id: base
+        env:
+          CONFIGURED_BASE_PATH: ${{ vars.VITE_BASE_PATH || secrets.VITE_BASE_PATH }}
         run: |
+          if [[ -n "$CONFIGURED_BASE_PATH" ]]; then
+            echo "value=$CONFIGURED_BASE_PATH" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$GITHUB_REPOSITORY" == "al-exe/EnderAI-frontend" ]]; then
+            echo "value=/" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
           if [[ "$REPO_NAME" == *.github.io ]]; then
             echo "value=/" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fix the GitHub Pages deployment base path for the `www.enderai.xyz` custom domain.
- Keep an explicit `VITE_BASE_PATH` repo variable/secret override for future hosting changes.
- Preserve the repo-name fallback for non-custom-domain Pages deployments.

## Context
`https://www.enderai.xyz/login` returned a GitHub Pages 404. DNS correctly points to GitHub Pages and the custom-domain claim is on `al-exe/EnderAI-frontend`, but the deployed artifact was built with `/EnderAI-frontend/` asset paths instead of `/`, which is wrong for the root custom domain.

Jira: KAN-133

## Validation
- `VITE_BASE_PATH=/ VITE_API_URL=https://enderai-backend.onrender.com npm run build`
- Verified generated `dist/index.html` references `/assets/...` for custom-domain hosting.

Note: local shell has Node 18.19.1, so Vite emitted a Node version warning; the build still completed, and the GitHub workflow uses Node 20.