### PR TITLE
KAN-133: add Pages entrypoints for app routes

### DIFF
--- a/.github/workflows/deploy-frontend-pages.yml
+++ b/.github/workflows/deploy-frontend-pages.yml
@@ -72,6 +72,13 @@ jobs:
       - name: SPA fallback for GitHub Pages
         run: cp dist/index.html dist/404.html
 
+      - name: Static route entrypoints for GitHub Pages
+        run: |
+          for route in login signup recover-password reset-password topics cases settings admin; do
+            mkdir -p "dist/$route"
+            cp dist/index.html "dist/$route/index.html"
+          done
+
       - name: Configure Pages
         uses: actions/configure-pages@v5
 


### PR DESCRIPTION
## Summary
- Add real GitHub Pages entrypoints for known TanStack Router paths: `/login`, `/signup`, `/recover-password`, `/reset-password`, `/topics`, `/cases`, `/settings`, and `/admin`.
- Keep `404.html` as the fallback for unknown paths.

## Context
The custom-domain base path fix makes assets load from `/assets/...`, but GitHub Pages still returns HTTP 404 for direct history-router URLs unless a matching static file exists. This makes the known app routes return 200 on `www.enderai.xyz`.

Jira: KAN-133

## Validation
- `VITE_BASE_PATH=/ VITE_API_URL=https://enderai-backend.onrender.com npm run build`
- Simulated deploy route copy and verified `dist/login/index.html` exists with root-relative assets.

Note: local shell has Node 18.19.1, so Vite emitted a Node version warning; the build still completed, and the GitHub workflow uses Node 20.