### PR TITLE
KAN-135: add homepage documentation

### DIFF
--- a/src/routes/_layout/index.module.css
+++ b/src/routes/_layout/index.module.css
@@ -1,0 +1,210 @@
+@reference "../../index.css";
+
+.page {
+  @apply min-h-0 flex-1 overflow-y-auto pr-1;
+}
+
+.shell {
+  @apply mx-auto flex w-full max-w-7xl flex-col gap-6 pb-8;
+}
+
+.hero {
+  @apply relative isolate overflow-hidden border bg-card p-6 shadow-sm md:p-8;
+}
+
+.hero::before {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  content: "";
+  background:
+    radial-gradient(circle at 12% 12%, rgb(132 71 255 / 0.22), transparent 32%),
+    radial-gradient(circle at 88% 18%, rgb(16 185 129 / 0.16), transparent 28%),
+    linear-gradient(135deg, rgb(132 71 255 / 0.08), transparent 46%);
+}
+
+.hero::after {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgb(132 71 255 / 0.09) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(132 71 255 / 0.09) 1px, transparent 1px);
+  background-size: 36px 36px;
+  mask-image: linear-gradient(135deg, black, transparent 78%);
+}
+
+.heroGrid {
+  @apply relative grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(20rem,0.8fr)] lg:items-end;
+}
+
+.heroCopy {
+  @apply flex flex-col items-start gap-6;
+}
+
+.heroBadge,
+.connectBadge {
+  @apply gap-2 px-3 py-1;
+}
+
+.badgeIcon,
+.icon {
+  @apply size-4;
+}
+
+.heroText {
+  @apply max-w-4xl space-y-4;
+}
+
+.greeting,
+.sectionEyebrow,
+.panelKicker {
+  @apply text-xs font-semibold uppercase tracking-[0.24em] text-primary;
+}
+
+.heroTitle {
+  @apply max-w-4xl text-4xl font-semibold tracking-tight text-foreground md:text-6xl;
+}
+
+.heroDescription {
+  @apply max-w-3xl text-base leading-7 text-muted-foreground md:text-lg;
+}
+
+.heroActions,
+.connectActions {
+  @apply flex flex-wrap gap-3;
+}
+
+.heroPanel {
+  @apply border bg-background/85 p-5 shadow-sm backdrop-blur;
+}
+
+.panelHeader {
+  @apply flex items-start justify-between gap-4 border-b pb-4;
+}
+
+.panelTitle {
+  @apply mt-2 text-xl font-semibold tracking-tight;
+}
+
+.panelIcon {
+  @apply size-10 shrink-0 text-primary;
+}
+
+.flowList {
+  @apply mt-5 space-y-4;
+}
+
+.flowItem {
+  @apply grid grid-cols-[3.5rem_minmax(0,1fr)] gap-4;
+}
+
+.flowItem h3,
+.setupStep h3 {
+  @apply font-medium;
+}
+
+.flowItem p,
+.setupStep p {
+  @apply mt-1 text-sm leading-6 text-muted-foreground;
+}
+
+.flowNumber {
+  @apply border bg-primary/10 px-3 py-2 text-center font-mono text-sm font-semibold text-primary;
+}
+
+.section {
+  @apply space-y-4;
+}
+
+.sectionHeader {
+  @apply grid gap-3 md:grid-cols-[minmax(0,0.8fr)_minmax(0,1fr)] md:items-end;
+}
+
+.sectionTitle {
+  @apply mt-1 text-2xl font-semibold tracking-tight md:text-3xl;
+}
+
+.sectionDescription {
+  @apply max-w-3xl text-sm leading-6 text-muted-foreground md:text-base;
+}
+
+.modelGrid,
+.navigationGrid {
+  @apply grid gap-4 lg:grid-cols-3;
+}
+
+.modelCard,
+.navigationCard {
+  @apply overflow-hidden border shadow-sm transition-colors hover:border-primary/45;
+}
+
+.modelCardTop {
+  @apply flex items-start justify-between gap-3;
+}
+
+.cardIconWrap {
+  @apply flex size-11 items-center justify-center border bg-primary/10 text-primary;
+}
+
+.cardIcon {
+  @apply size-5;
+}
+
+.detailList {
+  @apply space-y-3 text-sm leading-6 text-muted-foreground;
+}
+
+.detailList li {
+  @apply flex gap-2;
+}
+
+.checkIcon {
+  @apply mt-0.5 size-4 shrink-0 text-emerald-500;
+}
+
+.cardContent {
+  @apply flex h-full flex-col items-start justify-between gap-4 text-sm leading-6 text-muted-foreground;
+}
+
+.connectSection {
+  @apply grid gap-6 border bg-card p-6 shadow-sm lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:items-center;
+}
+
+.connectCopy {
+  @apply space-y-4;
+}
+
+.inlineCode {
+  @apply bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground;
+}
+
+.setupSteps {
+  @apply grid gap-3;
+}
+
+.setupStep {
+  @apply grid grid-cols-[2.75rem_minmax(0,1fr)] gap-4 border bg-background/70 p-4;
+}
+
+.setupIcon {
+  @apply size-6 text-primary;
+}
+
+.workflowSection {
+  @apply space-y-4;
+}
+
+.commandPanel {
+  @apply overflow-hidden border bg-zinc-950 text-zinc-50 shadow-sm;
+}
+
+.commandPanel pre {
+  @apply overflow-x-auto p-5 text-xs leading-6 md:text-sm;
+}
+
+.commandPanel code {
+  @apply font-mono;
+}

--- a/src/routes/_layout/index.tsx
+++ b/src/routes/_layout/index.tsx
@@ -1,6 +1,31 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Link as RouterLink } from "@tanstack/react-router"
+import type { LucideIcon } from "lucide-react"
+import {
+  ArrowRight,
+  BookOpen,
+  Box,
+  Boxes,
+  CheckCircle2,
+  FileText,
+  KeyRound,
+  Search,
+  Settings,
+  Shield,
+  Terminal,
+  Zap,
+} from "lucide-react"
 
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import useAuth from "@/hooks/useAuth"
+import styles from "./index.module.css"
 
 export const Route = createFileRoute("/_layout/")({
   component: Dashboard,
@@ -15,15 +40,360 @@ export const Route = createFileRoute("/_layout/")({
 
 function Dashboard() {
   const { user: currentUser } = useAuth()
+  const displayName = currentUser?.full_name || currentUser?.email || "there"
 
   return (
-    <div>
-      <div>
-        <h1 className="text-2xl truncate max-w-sm">
-          Hi, {currentUser?.full_name || currentUser?.email} 👋
-        </h1>
-        <p className="text-muted-foreground">It's nice to see you here!</p>
+    <div className={styles.page}>
+      <div className={styles.shell}>
+        <section className={styles.hero}>
+          <div className={styles.heroGrid}>
+            <div className={styles.heroCopy}>
+              <Badge variant="secondary" className={styles.heroBadge}>
+                <BookOpen className={styles.badgeIcon} />
+                Home docs
+              </Badge>
+              <div className={styles.heroText}>
+                <p className={styles.greeting}>Welcome back, {displayName}</p>
+                <h1 className={styles.heroTitle}>
+                  EnderAI is product memory for AI-assisted work.
+                </h1>
+                <p className={styles.heroDescription}>
+                  It gives agents a shared place to remember durable work,
+                  active sessions, commands, decisions, and outcomes so each new
+                  task can start with relevant context instead of rediscovery.
+                </p>
+              </div>
+              <div className={styles.heroActions}>
+                <Button asChild size="lg">
+                  <RouterLink to="/topics">
+                    Open Topics
+                    <ArrowRight className={styles.icon} />
+                  </RouterLink>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <RouterLink
+                    to="/settings"
+                    search={{ tab: "connect-agent" }}
+                    data-testid="home-connect-agent-link"
+                  >
+                    Connect agent
+                  </RouterLink>
+                </Button>
+              </div>
+            </div>
+
+            <div className={styles.heroPanel}>
+              <div className={styles.panelHeader}>
+                <div>
+                  <p className={styles.panelKicker}>Core loop</p>
+                  <h2 className={styles.panelTitle}>
+                    Start work. Hydrate context. Finish with memory.
+                  </h2>
+                </div>
+                <Zap className={styles.panelIcon} />
+              </div>
+              <div className={styles.flowList}>
+                {workflowSteps.map((step) => (
+                  <div className={styles.flowItem} key={step.title}>
+                    <span className={styles.flowNumber}>{step.step}</span>
+                    <div>
+                      <h3>{step.title}</h3>
+                      <p>{step.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <div>
+              <p className={styles.sectionEyebrow}>What to use</p>
+              <h2 className={styles.sectionTitle}>The product model</h2>
+            </div>
+            <p className={styles.sectionDescription}>
+              EnderAI is organized around two user-facing objects. A third
+              system object, the ContextPack, powers agent hydration behind the
+              scenes.
+            </p>
+          </div>
+
+          <div className={styles.modelGrid}>
+            {modelCards.map((card) => (
+              <ModelCard key={card.title} {...card} />
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.navigationGrid}>
+          <Card className={styles.navigationCard}>
+            <CardHeader>
+              <div className={styles.cardIconWrap}>
+                <Box className={styles.cardIcon} />
+              </div>
+              <CardTitle>Topics</CardTitle>
+              <CardDescription>
+                Reusable workstreams such as a feature area, bug family, repo
+                subsystem, customer issue, or operational concern.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className={styles.cardContent}>
+              <p>
+                Use Topics to keep stable descriptions, aliases, status,
+                canonical files, symbols, errors, symptoms, and recent Cases in
+                one place.
+              </p>
+              <Button asChild variant="outline">
+                <RouterLink to="/topics">
+                  Browse Topics
+                  <ArrowRight className={styles.icon} />
+                </RouterLink>
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card className={styles.navigationCard}>
+            <CardHeader>
+              <div className={styles.cardIconWrap}>
+                <Boxes className={styles.cardIcon} />
+              </div>
+              <CardTitle>Cases</CardTitle>
+              <CardDescription>
+                Bounded work sessions under a Topic. Cases are where agents
+                record what happened during a specific task.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className={styles.cardContent}>
+              <p>
+                A Case can capture the request, current summary, files,
+                commands, hypotheses, changes, outcome, and next steps.
+              </p>
+              <Button asChild variant="outline">
+                <RouterLink to="/cases">
+                  Review Cases
+                  <ArrowRight className={styles.icon} />
+                </RouterLink>
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card className={styles.navigationCard}>
+            <CardHeader>
+              <div className={styles.cardIconWrap}>
+                <Search className={styles.cardIcon} />
+              </div>
+              <CardTitle>Search and demo mode</CardTitle>
+              <CardDescription>
+                Use the top search bar to jump across Topics and Cases. Use the
+                sidebar demo switch when you want safe sample data.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className={styles.cardContent}>
+              <p>
+                Demo mode scopes Topics, Cases, and Search to demo data so you
+                can explore the interface without touching real work history.
+              </p>
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className={styles.connectSection}>
+          <div className={styles.connectCopy}>
+            <Badge variant="outline" className={styles.connectBadge}>
+              <Terminal className={styles.badgeIcon} />
+              MCP setup
+            </Badge>
+            <h2 className={styles.sectionTitle}>Connect your agent</h2>
+            <p className={styles.sectionDescription}>
+              Open Settings, create a per-user MCP credential, add the generated
+              config to your client, then ask the agent to verify the connection
+              with{" "}
+              <code className={styles.inlineCode}>enderai_session_info</code>.
+            </p>
+            <div className={styles.connectActions}>
+              <Button asChild>
+                <RouterLink to="/settings" search={{ tab: "connect-agent" }}>
+                  Open Connect Agent
+                  <ArrowRight className={styles.icon} />
+                </RouterLink>
+              </Button>
+            </div>
+          </div>
+
+          <div className={styles.setupSteps}>
+            {connectionSteps.map((step) => (
+              <div className={styles.setupStep} key={step.title}>
+                <step.icon className={styles.setupIcon} />
+                <div>
+                  <h3>{step.title}</h3>
+                  <p>{step.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.workflowSection}>
+          <div className={styles.sectionHeader}>
+            <div>
+              <p className={styles.sectionEyebrow}>Agent instruction</p>
+              <h2 className={styles.sectionTitle}>
+                The minimum workflow your agent should follow
+              </h2>
+            </div>
+            <p className={styles.sectionDescription}>
+              Add this guidance to your agent instructions so meaningful work is
+              captured consistently.
+            </p>
+          </div>
+
+          <div className={styles.commandPanel}>
+            <pre>
+              <code>{agentInstructionSnippet}</code>
+            </pre>
+          </div>
+        </section>
       </div>
     </div>
   )
 }
+
+type ModelCardProps = {
+  icon: LucideIcon
+  label: string
+  title: string
+  description: string
+  details: string[]
+}
+
+function ModelCard({
+  icon: Icon,
+  label,
+  title,
+  description,
+  details,
+}: ModelCardProps) {
+  return (
+    <Card className={styles.modelCard}>
+      <CardHeader>
+        <div className={styles.modelCardTop}>
+          <div className={styles.cardIconWrap}>
+            <Icon className={styles.cardIcon} />
+          </div>
+          <Badge variant="outline">{label}</Badge>
+        </div>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className={styles.detailList}>
+          {details.map((detail) => (
+            <li key={detail}>
+              <CheckCircle2 className={styles.checkIcon} />
+              <span>{detail}</span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  )
+}
+
+const workflowSteps = [
+  {
+    step: "01",
+    title: "Begin a Case",
+    description: "The agent starts meaningful work with enderai_begin_case.",
+  },
+  {
+    step: "02",
+    title: "Hydrate context",
+    description: "EnderAI finds relevant prior Topics and Cases automatically.",
+  },
+  {
+    step: "03",
+    title: "Capture progress",
+    description:
+      "Updates, commands, files, and decisions are written as work develops.",
+  },
+  {
+    step: "04",
+    title: "Close the loop",
+    description: "The agent finishes the Case with outcome and next steps.",
+  },
+]
+
+const modelCards: ModelCardProps[] = [
+  {
+    icon: Box,
+    label: "User-facing",
+    title: "Topics",
+    description:
+      "A Topic is a durable area of work that should be reused across related sessions.",
+    details: [
+      "Best for subsystems, features, recurring bugs, and operational areas.",
+      "Holds aliases, status, summaries, files, symbols, errors, and symptoms.",
+      "Gives future Cases a stable place to attach context.",
+    ],
+  },
+  {
+    icon: Boxes,
+    label: "User-facing",
+    title: "Cases",
+    description:
+      "A Case is one bounded work session under a Topic, usually one request or task.",
+    details: [
+      "Tracks input, current summary, commands, hypotheses, changes, and outcome.",
+      "Keeps next steps visible when work pauses or continues later.",
+      "Provides the history that future agents can reuse.",
+    ],
+  },
+  {
+    icon: Shield,
+    label: "System-powered",
+    title: "ContextPacks",
+    description:
+      "A ContextPack is the synthesized briefing EnderAI builds for an agent at case start.",
+    details: [
+      "Selects relevant prior Topics and Cases.",
+      "Includes matched signals, pinned takeaways, ambiguity notes, and confidence.",
+      "Works behind the scenes, so navigation stays focused on Topics and Cases.",
+    ],
+  },
+]
+
+const connectionSteps: Array<{
+  icon: LucideIcon
+  title: string
+  description: string
+}> = [
+  {
+    icon: Settings,
+    title: "Open Settings -> Connect agent",
+    description:
+      "Generate or rotate the one MCP token your hosted EnderAI client needs.",
+  },
+  {
+    icon: KeyRound,
+    title: "Install the generated snippets",
+    description:
+      "Use the export command and Codex TOML block, or adapt the hosted MCP config for another client.",
+  },
+  {
+    icon: FileText,
+    title: "Add the workflow instruction",
+    description:
+      "Tell the agent to begin, update, and finish Cases with EnderAI tools.",
+  },
+]
+
+const agentInstructionSnippet = [
+  "If EnderAI tools are available:",
+  "- Start meaningful user-initiated work with `enderai_begin_case`.",
+  "- Let EnderAI auto-hydrate relevant prior context before work begins.",
+  "- Use `enderai_update_case` as material progress develops.",
+  "- Use `enderai_finish_case` when the work is complete.",
+  "- Prefer the guided case tools over raw `enderai_request` calls.",
+].join("\n")

--- a/src/routes/_layout/settings.tsx
+++ b/src/routes/_layout/settings.tsx
@@ -1,4 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import type { ComponentType } from "react"
+import { z } from "zod"
 
 import ChangePassword from "@/components/UserSettings/ChangePassword"
 import ConnectAgent from "@/components/UserSettings/ConnectAgent"
@@ -7,7 +9,24 @@ import UserInformation from "@/components/UserSettings/UserInformation"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import useAuth from "@/hooks/useAuth"
 
-const tabsConfig = [
+const tabValues = [
+  "my-profile",
+  "connect-agent",
+  "password",
+  "danger-zone",
+] as const
+
+type SettingsTab = (typeof tabValues)[number]
+
+const searchSchema = z.object({
+  tab: z.enum(tabValues).optional(),
+})
+
+const tabsConfig: Array<{
+  value: SettingsTab
+  title: string
+  component: ComponentType
+}> = [
   { value: "my-profile", title: "My profile", component: UserInformation },
   { value: "connect-agent", title: "Connect agent", component: ConnectAgent },
   { value: "password", title: "Password", component: ChangePassword },
@@ -16,6 +35,7 @@ const tabsConfig = [
 
 export const Route = createFileRoute("/_layout/settings")({
   component: UserSettings,
+  validateSearch: searchSchema,
   head: () => ({
     meta: [
       {
@@ -27,6 +47,9 @@ export const Route = createFileRoute("/_layout/settings")({
 
 function UserSettings() {
   const { user: currentUser } = useAuth()
+  const navigate = useNavigate()
+  const { tab } = Route.useSearch()
+  const activeTab = tab ?? "my-profile"
   const finalTabs = tabsConfig
 
   if (!currentUser) {
@@ -43,7 +66,14 @@ function UserSettings() {
       </div>
 
       <Tabs
-        defaultValue="my-profile"
+        value={activeTab}
+        onValueChange={(value) => {
+          void navigate({
+            to: "/settings",
+            search: { tab: value as SettingsTab },
+            replace: true,
+          })
+        }}
         className="flex min-h-0 flex-1 flex-col overflow-hidden"
       >
         <TabsList className="shrink-0">

--- a/tests/home-docs.spec.ts
+++ b/tests/home-docs.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test"
+
+const currentUser = {
+  id: "user-1",
+  email: "alex@example.com",
+  is_active: true,
+  is_superuser: true,
+  full_name: "Alex Lee",
+  created_at: "2026-03-24T00:00:00Z",
+}
+
+test.use({
+  storageState: {
+    cookies: [],
+    origins: [],
+  },
+})
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "test-token")
+  })
+
+  await page.route("**/api/v1/users/me", async (route) => {
+    await route.fulfill({ json: currentUser })
+  })
+
+  await page.route("**/api/v1/agent-credentials/", async (route) => {
+    await route.fulfill({ json: { data: [], count: 0 } })
+  })
+})
+
+test("Home page explains EnderAI and the product model", async ({ page }) => {
+  await page.goto("/")
+
+  await expect(
+    page.getByText("EnderAI is product memory for AI-assisted work."),
+  ).toBeVisible()
+  await expect(page.getByText("The product model")).toBeVisible()
+  await expect(
+    page.getByText(
+      "EnderAI is organized around two user-facing objects. A third system object, the ContextPack, powers agent hydration behind the scenes.",
+    ),
+  ).toBeVisible()
+  await expect(page.getByText("Topics").first()).toBeVisible()
+  await expect(page.getByText("Cases").first()).toBeVisible()
+  await expect(page.getByText("ContextPacks")).toBeVisible()
+  await expect(page.getByText("Search and demo mode")).toBeVisible()
+  await expect(page.getByText("Open Settings -> Connect agent")).toBeVisible()
+  await expect(page.getByText("enderai_begin_case").first()).toBeVisible()
+  await expect(page.getByText("enderai_finish_case").first()).toBeVisible()
+})
+
+test("Connect agent CTA opens the settings tab directly", async ({ page }) => {
+  await page.goto("/")
+
+  await page.getByTestId("home-connect-agent-link").click()
+
+  await expect(page).toHaveURL(/\/settings\?tab=connect-agent$/)
+  await expect(
+    page.getByRole("tab", { name: "Connect agent" }),
+  ).toHaveAttribute("aria-selected", "true")
+  await expect(
+    page.getByText(
+      "Generate a per-user MCP token and the minimal EnderAI workflow snippet your agent needs.",
+    ),
+  ).toBeVisible()
+})


### PR DESCRIPTION
## Jira
KAN-135: https://alexlee4190.atlassian.net/browse/KAN-135

## Summary
- Replace the bare Home greeting with a styled EnderAI documentation landing page that explains the product, Topics, Cases, ContextPacks, navigation, demo mode, and MCP setup.
- Add validated Settings tab search params so `/settings?tab=connect-agent` opens the Connect Agent panel directly from the homepage CTA.
- Add focused Playwright coverage for the homepage docs content and Connect Agent deep link.

## Source Material
- `docs/topic-case-contextpack-model.md`
- `docs/hosted-mcp-onboarding.md`
- Existing `ConnectAgent` setup copy and snippets

## Validation
- `bunx biome check --write --unsafe --files-ignore-unknown=true src/routes/_layout/index.tsx src/routes/_layout/index.module.css src/routes/_layout/settings.tsx tests/home-docs.spec.ts`
- `bun run build` (passes; existing large chunk warning remains)
- `npx playwright test tests/home-docs.spec.ts --project=chromium --no-deps`
- `git diff --check`