### PR TITLE
KAN-137: Normalize homepage Context Packs copy

### DIFF
--- a/src/routes/_layout/index.module.css
+++ b/src/routes/_layout/index.module.css
@@ -130,14 +130,12 @@
   @apply max-w-3xl text-sm leading-6 text-muted-foreground md:text-base;
 }
 
-.modelGrid,
-.navigationGrid {
+.modelGrid {
   @apply grid gap-4 lg:grid-cols-3;
 }
 
-.modelCard,
-.navigationCard {
-  @apply overflow-hidden border shadow-sm transition-colors hover:border-primary/45;
+.modelCard {
+  @apply flex flex-col overflow-hidden border shadow-sm transition-colors hover:border-primary/45;
 }
 
 .modelCardTop {
@@ -152,6 +150,10 @@
   @apply size-5;
 }
 
+.modelCardContent {
+  @apply flex h-full flex-col items-start justify-between gap-6;
+}
+
 .detailList {
   @apply space-y-3 text-sm leading-6 text-muted-foreground;
 }
@@ -162,10 +164,6 @@
 
 .checkIcon {
   @apply mt-0.5 size-4 shrink-0 text-emerald-500;
-}
-
-.cardContent {
-  @apply flex h-full flex-col items-start justify-between gap-4 text-sm leading-6 text-muted-foreground;
 }
 
 .connectSection {

--- a/src/routes/_layout/index.tsx
+++ b/src/routes/_layout/index.tsx
@@ -7,7 +7,6 @@ import {
   CheckCircle2,
   FileText,
   KeyRound,
-  Search,
   Settings,
   Shield,
   Terminal,
@@ -118,78 +117,6 @@ function Dashboard() {
           </div>
         </section>
 
-        <section className={styles.navigationGrid}>
-          <Card className={styles.navigationCard}>
-            <CardHeader>
-              <div className={styles.cardIconWrap}>
-                <Box className={styles.cardIcon} />
-              </div>
-              <CardTitle>Topics</CardTitle>
-              <CardDescription>
-                Reusable workstreams such as a feature area, bug family, repo
-                subsystem, customer issue, or operational concern.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className={styles.cardContent}>
-              <p>
-                Use Topics to keep stable descriptions, aliases, status,
-                canonical files, symbols, errors, symptoms, and recent Cases in
-                one place.
-              </p>
-              <Button asChild variant="outline">
-                <RouterLink to="/topics">
-                  Browse Topics
-                  <ArrowRight className={styles.icon} />
-                </RouterLink>
-              </Button>
-            </CardContent>
-          </Card>
-
-          <Card className={styles.navigationCard}>
-            <CardHeader>
-              <div className={styles.cardIconWrap}>
-                <Boxes className={styles.cardIcon} />
-              </div>
-              <CardTitle>Cases</CardTitle>
-              <CardDescription>
-                Bounded work sessions under a Topic. Cases are where agents
-                record what happened during a specific task.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className={styles.cardContent}>
-              <p>
-                A Case can capture the request, current summary, files,
-                commands, hypotheses, changes, outcome, and next steps.
-              </p>
-              <Button asChild variant="outline">
-                <RouterLink to="/cases">
-                  Review Cases
-                  <ArrowRight className={styles.icon} />
-                </RouterLink>
-              </Button>
-            </CardContent>
-          </Card>
-
-          <Card className={styles.navigationCard}>
-            <CardHeader>
-              <div className={styles.cardIconWrap}>
-                <Search className={styles.cardIcon} />
-              </div>
-              <CardTitle>Search and demo mode</CardTitle>
-              <CardDescription>
-                Use the top search bar to jump across Topics and Cases. Use the
-                sidebar demo switch when you want safe sample data.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className={styles.cardContent}>
-              <p>
-                Demo mode scopes Topics, Cases, and Search to demo data so you
-                can explore the interface without touching real work history.
-              </p>
-            </CardContent>
-          </Card>
-        </section>
-
         <section className={styles.connectSection}>
           <div className={styles.connectCopy}>
             <Badge variant="outline" className={styles.connectBadge}>
@@ -252,6 +179,10 @@ type ModelCardProps = {
   title: string
   description: string
   details: string[]
+  action?: {
+    label: string
+    to: "/topics" | "/cases"
+  }
 }
 
 function ModelCard({
@@ -260,6 +191,7 @@ function ModelCard({
   title,
   description,
   details,
+  action,
 }: ModelCardProps) {
   return (
     <Card className={styles.modelCard}>
@@ -273,7 +205,7 @@ function ModelCard({
         <CardTitle>{title}</CardTitle>
         <CardDescription>{description}</CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className={styles.modelCardContent}>
         <ul className={styles.detailList}>
           {details.map((detail) => (
             <li key={detail}>
@@ -282,6 +214,14 @@ function ModelCard({
             </li>
           ))}
         </ul>
+        {action ? (
+          <Button asChild variant="outline">
+            <RouterLink to={action.to}>
+              {action.label}
+              <ArrowRight className={styles.icon} />
+            </RouterLink>
+          </Button>
+        ) : null}
       </CardContent>
     </Card>
   )
@@ -323,6 +263,10 @@ const modelCards: ModelCardProps[] = [
       "Holds aliases, status, summaries, files, symbols, errors, and symptoms.",
       "Gives future Cases a stable place to attach context.",
     ],
+    action: {
+      label: "Browse Topics",
+      to: "/topics",
+    },
   },
   {
     icon: Boxes,
@@ -335,13 +279,17 @@ const modelCards: ModelCardProps[] = [
       "Keeps next steps visible when work pauses or continues later.",
       "Provides the history that future agents can reuse.",
     ],
+    action: {
+      label: "Review Cases",
+      to: "/cases",
+    },
   },
   {
     icon: Shield,
     label: "System-powered",
-    title: "ContextPacks",
+    title: "Context Packs",
     description:
-      "A ContextPack is the synthesized briefing EnderAI builds for an agent at Case start.",
+      "A Context Pack is the synthesized briefing EnderAI builds for an agent at Case start.",
     details: [
       "Selects relevant prior Topics and Cases.",
       "Includes matched signals, pinned takeaways, ambiguity notes, and confidence.",
@@ -357,7 +305,7 @@ const connectionSteps: Array<{
 }> = [
   {
     icon: Settings,
-    title: "Open Settings -> Connect agent",
+    title: "Open Settings → Connect agent",
     description:
       "Generate or rotate the one MCP token your hosted EnderAI client needs.",
   },

--- a/tests/home-docs.spec.ts
+++ b/tests/home-docs.spec.ts
@@ -56,17 +56,20 @@ test("Home page explains EnderAI and the product model", async ({ page }) => {
   ).toHaveCount(0)
   await expect(page.getByText("Topics").first()).toBeVisible()
   await expect(page.getByText("Cases").first()).toBeVisible()
-  await expect(page.getByText("ContextPacks")).toBeVisible()
+  await expect(page.getByText("Context Packs")).toBeVisible()
+  await expect(page.getByText("ContextPacks")).toHaveCount(0)
   await expect(
     page.getByText(
-      "A ContextPack is the synthesized briefing EnderAI builds for an agent at Case start.",
+      "A Context Pack is the synthesized briefing EnderAI builds for an agent at Case start.",
     ),
   ).toBeVisible()
-  await expect(page.getByText("Search and demo mode")).toBeVisible()
+  await expect(page.getByText("Search and demo mode")).toHaveCount(0)
+  await expect(page.getByText("Browse Topics")).toBeVisible()
+  await expect(page.getByText("Review Cases")).toBeVisible()
   await expect(
     page.getByText("The agent starts meaningful work by starting a Case."),
   ).toBeVisible()
-  await expect(page.getByText("Open Settings -> Connect agent")).toBeVisible()
+  await expect(page.getByText("Open Settings → Connect agent")).toBeVisible()
   await expect(
     page.getByText(
       "Open Settings, create an MCP credential, add the generated config to your client, then ask the agent to verify the connection with",


### PR DESCRIPTION
## Summary

- Normalize visible homepage copy from `ContextPacks` / `ContextPack` to `Context Packs` / `Context Pack`.
- Remove the second row of product-model/navigation boxes, including the Search and demo mode card.
- Preserve the useful `Browse Topics` and `Review Cases` link buttons by moving them into the top Topics and Cases cards.
- Replace `Open Settings -> Connect agent` with `Open Settings → Connect agent`.

## Jira

KAN-137

## Validation

- `bunx biome check --write --unsafe --files-ignore-unknown=true src/routes/_layout/index.tsx src/routes/_layout/index.module.css tests/home-docs.spec.ts`
- `bun run build`
- `npx playwright test tests/home-docs.spec.ts --project=chromium --no-deps` against the existing local Vite server at `http://127.0.0.1:5173/`

Note: the initial Playwright invocation tried to start the configured web server and failed with `/usr/bin/env: ‘node’: No such file or directory`; after starting Vite directly with `bun run dev --host 127.0.0.1`, the focused test passed.