### PR TITLE
KAN-138: Simplify Connect Agent setup copy

### DIFF
--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -47,12 +47,9 @@ function formatTimestamp(value: string | null): string {
   }).format(new Date(value))
 }
 
-function buildEnvSnippet(mcpToken: string): string {
-  return `export ENDERAI_MCP_TOKEN="${mcpToken}"`
-}
-
 function buildCodexPersistentShellSnippet(mcpToken: string): string {
   const lines = [
+    `export ENDERAI_MCP_TOKEN="${mcpToken}"`,
     `printf '%s\n' '${mcpToken}' > ~/.enderai_mcp_token`,
     "chmod 600 ~/.enderai_mcp_token",
     `echo 'export ENDERAI_MCP_TOKEN="$(tr -d "\\r\\n" < ~/.enderai_mcp_token)"' >> ~/.bashrc`,
@@ -303,7 +300,6 @@ const ConnectAgent = () => {
       ? revealedCredential.mcpToken
       : null
   const hasTokensReady = mcpToken !== null
-  const envSnippet = hasTokensReady ? buildEnvSnippet(mcpToken ?? "") : null
   const clientSnippet = hasTokensReady
     ? buildCodexConfigSnippet(
         import.meta.env.VITE_HOSTED_MCP_URL ||
@@ -314,6 +310,7 @@ const ConnectAgent = () => {
   const codexPersistentShellSnippet = hasTokensReady
     ? buildCodexPersistentShellSnippet(mcpToken ?? "")
     : null
+  const startCodexSnippet = "codex"
 
   return (
     <div className={styles.page}>
@@ -324,8 +321,7 @@ const ConnectAgent = () => {
             Connect agent
           </CardTitle>
           <p className={styles.mutedText}>
-            Generate a per-user MCP token and the minimal EnderAI workflow
-            snippet your agent needs.
+            Generate an MCP token to get your agent connected to EnderAI.
           </p>
         </CardHeader>
         <CardContent className={styles.cardContent}>
@@ -375,7 +371,7 @@ const ConnectAgent = () => {
                       styles.benefitIconSuccess,
                     )}
                   />
-                  One per-user MCP token for the hosted EnderAI workflow.
+                  MCP token for EnderAI.
                 </li>
                 <li className={styles.benefitItem}>
                   <Shield
@@ -384,7 +380,7 @@ const ConnectAgent = () => {
                       styles.benefitIconPrimary,
                     )}
                   />
-                  Codex CLI setup snippets with the fixed hosted MCP endpoint.
+                  Codex setup snippets.
                 </li>
                 <li className={styles.benefitItem}>
                   <RotateCw
@@ -393,8 +389,7 @@ const ConnectAgent = () => {
                       styles.benefitIconPrimary,
                     )}
                   />
-                  A visible rotate/revoke path later without reusing your normal
-                  login token.
+                  Rotate and revoke controls.
                 </li>
                 <li className={styles.benefitItem}>
                   <LaptopMinimal
@@ -403,25 +398,13 @@ const ConnectAgent = () => {
                       styles.benefitIconPrimary,
                     )}
                   />
-                  A minimal workflow reminder so your AI workflow starts using
-                  EnderAI correctly.
+                  Agent workflow reminder.
                 </li>
               </ul>
             </div>
           </div>
 
-          <Alert>
-            <CheckCircle2 className={styles.icon} />
-            <AlertTitle>Where this goes</AlertTitle>
-            <AlertDescription>
-              Run the export snippet in the same shell that will launch terminal
-              `codex`, then add the TOML block to `~/.codex/config.toml`. If you
-              want future bash shells to pick up the token automatically, use
-              the persistent shell setup below.
-            </AlertDescription>
-          </Alert>
-
-          {envSnippet && clientSnippet ? (
+          {clientSnippet && codexPersistentShellSnippet ? (
             <div className={styles.tokenSection}>
               <Alert>
                 <CheckCircle2 className={styles.icon} />
@@ -433,19 +416,19 @@ const ConnectAgent = () => {
               </Alert>
 
               <SnippetBlock
-                title="Export this env var"
-                description="Run this in the same shell that will launch `codex`."
-                snippet={envSnippet}
+                title="Persist the token across new terminals"
+                description="Stores the token locally so Codex can launch with EnderAI connected."
+                snippet={codexPersistentShellSnippet}
                 copiedText={copiedText}
                 onCopy={(value) => {
                   void copy(value)
                 }}
-                testId="connect-agent-token"
+                testId="connect-agent-persistent-shell"
               />
 
               <SnippetBlock
                 title="Codex CLI config"
-                description="Add this block to `~/.codex/config.toml`, then launch `codex` from that same shell."
+                description="Add this block to `~/.codex/config.toml`."
                 snippet={clientSnippet}
                 copiedText={copiedText}
                 onCopy={(value) => {
@@ -454,30 +437,16 @@ const ConnectAgent = () => {
                 testId="connect-agent-config"
               />
 
-              {codexPersistentShellSnippet ? (
-                <SnippetBlock
-                  title="Optional: persist the token across new terminals"
-                  description="Stores the token in a local file with chmod 600 and loads it from ~/.bashrc so future shells can launch `codex` without re-running `export`."
-                  snippet={codexPersistentShellSnippet}
-                  copiedText={copiedText}
-                  onCopy={(value) => {
-                    void copy(value)
-                  }}
-                  testId="connect-agent-persistent-shell"
-                />
-              ) : null}
-
-              <Alert>
-                <Shield className={styles.icon} />
-                <AlertTitle>Why use the file-based shell setup</AlertTitle>
-                <AlertDescription>
-                  Directly writing `export ENDERAI_MCP_TOKEN="..."` into
-                  `~/.bashrc` also works, but it leaves the raw token in a
-                  config file that is easier to copy, sync, diff, or share by
-                  accident. The file-based flow is mainly about reducing that
-                  accidental disclosure risk.
-                </AlertDescription>
-              </Alert>
+              <SnippetBlock
+                title="Start Codex from terminal"
+                description="After the setup above, launch the Codex CLI from a terminal."
+                snippet={startCodexSnippet}
+                copiedText={copiedText}
+                onCopy={(value) => {
+                  void copy(value)
+                }}
+                testId="connect-agent-start-codex"
+              />
             </div>
           ) : (
             <Alert>

--- a/tests/home-docs.spec.ts
+++ b/tests/home-docs.spec.ts
@@ -90,7 +90,7 @@ test("Connect agent CTA opens the settings tab directly", async ({ page }) => {
   ).toHaveAttribute("aria-selected", "true")
   await expect(
     page.getByText(
-      "Generate a per-user MCP token and the minimal EnderAI workflow snippet your agent needs.",
+      "Generate an MCP token to get your agent connected to EnderAI.",
     ),
   ).toBeVisible()
 })

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -384,7 +384,7 @@ test("Connect agent generates the hosted Codex setup and hides revoked credentia
   await expect(page.getByText("Revoked install")).toHaveCount(0)
   await expect(
     page.getByText(
-      "Generate a per-user MCP token and the minimal EnderAI workflow snippet your agent needs.",
+      "Generate an MCP token to get your agent connected to EnderAI.",
     ),
   ).toBeVisible()
   await expect(page.getByText("Hosted MCP URL")).toHaveCount(0)
@@ -399,27 +399,19 @@ test("Connect agent generates the hosted Codex setup and hides revoked credentia
   await page.getByTestId("create-agent-credential").click()
 
   await expect(page.getByText("Agent credential created")).toBeVisible()
-  await expect(page.getByText("Export this env var")).toBeVisible()
-  await expect(page.getByTestId("connect-agent-token")).toContainText(
-    "mcp-token-abc",
-  )
+  await expect(page.getByText("Where this goes")).toHaveCount(0)
+  await expect(page.getByText("Export this env var")).toHaveCount(0)
   await expect(
     page.getByText(
       "Run the export snippet in the same shell that will launch terminal `codex`, then add the TOML block to `~/.codex/config.toml`.",
     ),
+  ).toHaveCount(0)
+  await expect(
+    page.getByText("Persist the token across new terminals"),
   ).toBeVisible()
-  await expect(page.getByTestId("connect-agent-token")).toContainText(
-    "ENDERAI_MCP_TOKEN",
-  )
-  await expect(page.getByTestId("connect-agent-token")).not.toContainText(
-    "ENDERAI_BACKEND_TOKEN",
-  )
-  await expect(page.getByTestId("connect-agent-config")).toContainText(
-    'bearer_token_env_var = "ENDERAI_MCP_TOKEN"',
-  )
-  await expect(page.getByTestId("connect-agent-config")).not.toContainText(
-    "X-EnderAI-Backend-Token",
-  )
+  await expect(
+    page.getByTestId("connect-agent-persistent-shell"),
+  ).toContainText('export ENDERAI_MCP_TOKEN="mcp-token-abc"')
   await expect(
     page.getByTestId("connect-agent-persistent-shell"),
   ).toContainText("~/.enderai_mcp_token")
@@ -430,13 +422,41 @@ test("Connect agent generates the hosted Codex setup and hides revoked credentia
     page.getByTestId("connect-agent-persistent-shell"),
   ).toContainText("echo 'export ENDERAI_MCP_TOKEN=")
   await expect(
-    page.getByText("Why use the file-based shell setup"),
+    page.getByTestId("connect-agent-persistent-shell"),
+  ).not.toContainText("ENDERAI_BACKEND_TOKEN")
+
+  await expect(page.getByTestId("connect-agent-config")).toContainText(
+    'bearer_token_env_var = "ENDERAI_MCP_TOKEN"',
+  )
+  await expect(
+    page.getByText("Add this block to `~/.codex/config.toml`."),
   ).toBeVisible()
+  await expect(
+    page.getByText("then launch `codex` from that same shell"),
+  ).toHaveCount(0)
+  await expect(page.getByTestId("connect-agent-config")).not.toContainText(
+    "X-EnderAI-Backend-Token",
+  )
+  await expect(
+    page.getByText("Optional: persist the token across new terminals"),
+  ).toHaveCount(0)
+  const persistStepTop = await page
+    .getByText("Persist the token across new terminals")
+    .boundingBox()
+  const configStepTop = await page.getByText("Codex CLI config").boundingBox()
+  expect(persistStepTop?.y).toBeLessThan(configStepTop?.y ?? 0)
+  await expect(page.getByText("Start Codex from terminal")).toBeVisible()
+  await expect(page.getByTestId("connect-agent-start-codex")).toContainText(
+    "codex",
+  )
+  await expect(
+    page.getByText("Why use the file-based shell setup"),
+  ).toHaveCount(0)
   await expect(
     page.getByText(
       'Directly writing `export ENDERAI_MCP_TOKEN="..."` into `~/.bashrc` also works',
     ),
-  ).toBeVisible()
+  ).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-instructions")).toContainText(
     "enderai_begin_case",
   )


### PR DESCRIPTION
## Summary

- Remove the Connect Agent "Where this goes" and file-based shell setup explanation copy.
- Combine the standalone env export snippet into the token persistence snippet while keeping the export command visible in that block.
- Make token persistence required language by removing `Optional:`.
- Reorder setup steps to persist token first, then add Codex CLI config, then start Codex from terminal.
- Simplify the Connect Agent page subtitle and benefit bullets.
- Keep product references as `Codex` and reserve `codex` for the actual command snippet.

## Jira

KAN-138

## Validation

- `bunx biome check --write --unsafe --files-ignore-unknown=true src/components/UserSettings/ConnectAgent.tsx tests/user-settings.spec.ts tests/home-docs.spec.ts`
- `bun run build`
- `FIRST_SUPERUSER=test@example.com FIRST_SUPERUSER_PASSWORD=test-password npx playwright test tests/user-settings.spec.ts -g "Connect agent generates the hosted Codex setup" --project=chromium --no-deps`
- `npx playwright test tests/home-docs.spec.ts --project=chromium --no-deps`