### PR TITLE
KAN-139: Always show Connect Agent setup steps

### DIFF
--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -36,6 +36,8 @@ interface RevealedCredential {
   mcpToken: string
 }
 
+const MCP_TOKEN_PLACEHOLDER = "PASTE_MCP_TOKEN_HERE"
+
 function formatTimestamp(value: string | null): string {
   if (!value) {
     return "Never"
@@ -299,16 +301,17 @@ const ConnectAgent = () => {
     revealedCredential?.credentialId === selectedCredentialId
       ? revealedCredential.mcpToken
       : null
-  const hasTokensReady = mcpToken !== null
-  const clientSnippet = hasTokensReady
-    ? buildCodexConfigSnippet(
-        import.meta.env.VITE_HOSTED_MCP_URL ||
-          "https://enderai-mcp.onrender.com/mcp",
-      )
-    : null
+  const selectedCredential = activeCredentials.find(
+    (credential) => credential.id === selectedCredentialId,
+  )
+  const hasSetupCredential = selectedCredential !== undefined
+  const clientSnippet = buildCodexConfigSnippet(
+    import.meta.env.VITE_HOSTED_MCP_URL ||
+      "https://enderai-mcp.onrender.com/mcp",
+  )
   const agentInstructionSnippet = buildAgentInstructionSnippet()
-  const codexPersistentShellSnippet = hasTokensReady
-    ? buildCodexPersistentShellSnippet(mcpToken ?? "")
+  const codexPersistentShellSnippet = hasSetupCredential
+    ? buildCodexPersistentShellSnippet(mcpToken ?? MCP_TOKEN_PLACEHOLDER)
     : null
   const startCodexSnippet = "codex"
 
@@ -404,16 +407,27 @@ const ConnectAgent = () => {
             </div>
           </div>
 
-          {clientSnippet && codexPersistentShellSnippet ? (
+          {hasSetupCredential && codexPersistentShellSnippet ? (
             <div className={styles.tokenSection}>
-              <Alert>
-                <CheckCircle2 className={styles.icon} />
-                <AlertTitle>Fresh tokens ready</AlertTitle>
-                <AlertDescription>
-                  This token is only shown right now. Save it now if you need it
-                  for setup.
-                </AlertDescription>
-              </Alert>
+              {mcpToken ? (
+                <Alert>
+                  <CheckCircle2 className={styles.icon} />
+                  <AlertTitle>Fresh token ready</AlertTitle>
+                  <AlertDescription>
+                    This token is only shown right now. Save it now if you need
+                    it for setup.
+                  </AlertDescription>
+                </Alert>
+              ) : (
+                <Alert>
+                  <RotateCw className={styles.icon} />
+                  <AlertTitle>Setup steps ready</AlertTitle>
+                  <AlertDescription>
+                    Rotate the selected credential to reveal a fresh token for
+                    the persistence command.
+                  </AlertDescription>
+                </Alert>
+              )}
 
               <SnippetBlock
                 title="Persist the token across new terminals"

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -476,13 +476,22 @@ test("Connect agent generates the hosted Codex setup and hides revoked credentia
   await page.reload()
   await page.getByRole("tab", { name: "Connect agent" }).click()
 
-  await expect(page.getByText("Rotate to reveal fresh tokens")).toHaveCount(0)
+  await expect(page.getByText("Setup steps ready")).toBeVisible()
+  await expect(
+    page.getByText("Persist the token across new terminals"),
+  ).toBeVisible()
+  await expect(
+    page.getByTestId("connect-agent-persistent-shell"),
+  ).toContainText('export ENDERAI_MCP_TOKEN="PASTE_MCP_TOKEN_HERE"')
+  await expect(page.getByTestId("connect-agent-config")).toContainText(
+    'bearer_token_env_var = "ENDERAI_MCP_TOKEN"',
+  )
+  await expect(page.getByText("Start Codex from terminal")).toBeVisible()
   await expect(page.getByTestId("connect-agent-instructions")).toContainText(
     "enderai_begin_case",
   )
   await expect(page.getByTestId("connect-agent-instructions")).toContainText(
     "enderai_finish_case",
   )
-  await expect(page.getByTestId("connect-agent-token")).toHaveCount(0)
   await expect(page.getByText("Revoked install")).toHaveCount(0)
 })


### PR DESCRIPTION
## Summary

- Show the Connect Agent setup panel whenever there is a selected active credential, not only when a token was just revealed.
- Keep the real token in the persistence snippet when a fresh token is available.
- Use `PASTE_MCP_TOKEN_HERE` in the persistence snippet after reload/existing-credential flows where the backend cannot return the secret token.
- Add an existing-credential alert that tells the user to rotate the selected credential to reveal a fresh token for the persistence command.
- Extend the focused settings test to cover the reload path with an existing active credential.

## Jira

KAN-139

## Validation

- `bunx biome check --write --unsafe --files-ignore-unknown=true src/components/UserSettings/ConnectAgent.tsx tests/user-settings.spec.ts`
- `bun run build`
- `FIRST_SUPERUSER=test@example.com FIRST_SUPERUSER_PASSWORD=test-password npx playwright test tests/user-settings.spec.ts -g "Connect agent generates the hosted Codex setup" --project=chromium --no-deps`
- `npx playwright test tests/home-docs.spec.ts --project=chromium --no-deps`