### PR TITLE
KAN-140: Hide setup snippets after refresh

### DIFF
--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -36,8 +36,6 @@ interface RevealedCredential {
   mcpToken: string
 }
 
-const MCP_TOKEN_PLACEHOLDER = "PASTE_MCP_TOKEN_HERE"
-
 function formatTimestamp(value: string | null): string {
   if (!value) {
     return "Never"
@@ -301,17 +299,16 @@ const ConnectAgent = () => {
     revealedCredential?.credentialId === selectedCredentialId
       ? revealedCredential.mcpToken
       : null
-  const selectedCredential = activeCredentials.find(
-    (credential) => credential.id === selectedCredentialId,
-  )
-  const hasSetupCredential = selectedCredential !== undefined
-  const clientSnippet = buildCodexConfigSnippet(
-    import.meta.env.VITE_HOSTED_MCP_URL ||
-      "https://enderai-mcp.onrender.com/mcp",
-  )
+  const hasFreshToken = mcpToken !== null
+  const clientSnippet = hasFreshToken
+    ? buildCodexConfigSnippet(
+        import.meta.env.VITE_HOSTED_MCP_URL ||
+          "https://enderai-mcp.onrender.com/mcp",
+      )
+    : null
   const agentInstructionSnippet = buildAgentInstructionSnippet()
-  const codexPersistentShellSnippet = hasSetupCredential
-    ? buildCodexPersistentShellSnippet(mcpToken ?? MCP_TOKEN_PLACEHOLDER)
+  const codexPersistentShellSnippet = hasFreshToken
+    ? buildCodexPersistentShellSnippet(mcpToken)
     : null
   const startCodexSnippet = "codex"
 
@@ -407,27 +404,16 @@ const ConnectAgent = () => {
             </div>
           </div>
 
-          {hasSetupCredential && codexPersistentShellSnippet ? (
+          {clientSnippet && codexPersistentShellSnippet ? (
             <div className={styles.tokenSection}>
-              {mcpToken ? (
-                <Alert>
-                  <CheckCircle2 className={styles.icon} />
-                  <AlertTitle>Fresh token ready</AlertTitle>
-                  <AlertDescription>
-                    This token is only shown right now. Save it now if you need
-                    it for setup.
-                  </AlertDescription>
-                </Alert>
-              ) : (
-                <Alert>
-                  <RotateCw className={styles.icon} />
-                  <AlertTitle>Setup steps ready</AlertTitle>
-                  <AlertDescription>
-                    Rotate the selected credential to reveal a fresh token for
-                    the persistence command.
-                  </AlertDescription>
-                </Alert>
-              )}
+              <Alert>
+                <CheckCircle2 className={styles.icon} />
+                <AlertTitle>Fresh token ready</AlertTitle>
+                <AlertDescription>
+                  This token is only shown right now. Save it now if you need it
+                  for setup.
+                </AlertDescription>
+              </Alert>
 
               <SnippetBlock
                 title="Persist the token across new terminals"

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -476,17 +476,17 @@ test("Connect agent generates the hosted Codex setup and hides revoked credentia
   await page.reload()
   await page.getByRole("tab", { name: "Connect agent" }).click()
 
-  await expect(page.getByText("Setup steps ready")).toBeVisible()
   await expect(
     page.getByText("Persist the token across new terminals"),
-  ).toBeVisible()
+  ).toHaveCount(0)
   await expect(
-    page.getByTestId("connect-agent-persistent-shell"),
-  ).toContainText('export ENDERAI_MCP_TOKEN="PASTE_MCP_TOKEN_HERE"')
-  await expect(page.getByTestId("connect-agent-config")).toContainText(
-    'bearer_token_env_var = "ENDERAI_MCP_TOKEN"',
+    page.getByText('export ENDERAI_MCP_TOKEN="PASTE_MCP_TOKEN_HERE"'),
+  ).toHaveCount(0)
+  await expect(page.getByTestId("connect-agent-persistent-shell")).toHaveCount(
+    0,
   )
-  await expect(page.getByText("Start Codex from terminal")).toBeVisible()
+  await expect(page.getByTestId("connect-agent-config")).toHaveCount(0)
+  await expect(page.getByText("Start Codex from terminal")).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-instructions")).toContainText(
     "enderai_begin_case",
   )


### PR DESCRIPTION
## Summary

- Remove the `PASTE_MCP_TOKEN_HERE` placeholder-token flow from Connect Agent setup.
- Show setup snippets only when a fresh MCP token is currently revealed from create or rotate.
- Hide `Persist the token across new terminals`, `Codex CLI config`, and `Start Codex from terminal` after refresh/reload when existing credentials are present but no token secret is available.
- Update the focused settings test to assert setup snippets disappear after reload and the placeholder export never appears.

## Jira

KAN-140

## Validation

- `bunx biome check --write --unsafe --files-ignore-unknown=true src/components/UserSettings/ConnectAgent.tsx tests/user-settings.spec.ts`
- `bun run build`
- `FIRST_SUPERUSER=test@example.com FIRST_SUPERUSER_PASSWORD=test-password npx playwright test tests/user-settings.spec.ts -g "Connect agent generates the hosted Codex setup" --project=chromium --no-deps`