### PR TITLE
[codex] Add AI assisted Connect Agent setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,12 @@
 # EnderAI — MCP-First Agent Rules (Portable Template)
 
-Last updated: 2026-03-22
+Last updated: 2026-04-26
+
+## Integration Pause
+- Do not use EnderAI MCP tools unless Alex explicitly asks to use EnderAI MCP again.
+- Do not use Jira or Atlassian tools unless Alex explicitly asks to use Jira again.
+- Ignore the MCP-first workflow and Jira delivery workflow below while this pause is active.
+- For code changes, work locally and use git/GitHub only when requested by the user or by normal repo workflow.
 
 This template is intended for agents and IDEs that use EnderAI through MCP.
 

--- a/src/components/UserSettings/ConnectAgent.module.css
+++ b/src/components/UserSettings/ConnectAgent.module.css
@@ -124,6 +124,22 @@
   @apply space-y-4;
 }
 
+.setupTabs {
+  @apply space-y-4;
+}
+
+.setupTabsList {
+  @apply grid h-10 w-full grid-cols-2;
+}
+
+.setupTabTrigger {
+  @apply w-full;
+}
+
+.setupTab {
+  @apply space-y-4;
+}
+
 .credentialsContent {
   @apply space-y-3;
 }

--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { LoadingButton } from "@/components/ui/loading-button"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
@@ -75,6 +76,50 @@ function buildAgentInstructionSnippet(): string {
     "- Use `enderai_update_case` as material progress develops.",
     "- Use `enderai_finish_case` when the work is complete.",
     "- Prefer the guided case tools over raw `enderai_request` calls.",
+  ].join("\n")
+}
+
+function buildAiAssistedSetupSnippet({
+  persistentShellSnippet,
+  clientSnippet,
+  agentInstructionSnippet,
+  startCodexSnippet,
+}: {
+  persistentShellSnippet: string
+  clientSnippet: string
+  agentInstructionSnippet: string
+  startCodexSnippet: string
+}): string {
+  return [
+    "Complete this EnderAI MCP setup for me.",
+    "",
+    "# Persist the token",
+    "Save the token for me using these commands:",
+    "",
+    "```sh",
+    persistentShellSnippet,
+    "```",
+    "",
+    "# Setup CLI config",
+    "Add the following MCP server config to ~/.codex/config.toml or the relevant config file for this AI client:",
+    "",
+    "```toml",
+    clientSnippet,
+    "```",
+    "",
+    "# Add agent instruction",
+    "Add the following to the AI agent's instruction file, AGENTS.md, agent.md, or equivalent core instruction file:",
+    "",
+    "```text",
+    agentInstructionSnippet,
+    "```",
+    "",
+    "# Start Codex",
+    "After setup is complete, launch the Codex CLI from a terminal:",
+    "",
+    "```sh",
+    startCodexSnippet,
+    "```",
   ].join("\n")
 }
 
@@ -311,6 +356,15 @@ const ConnectAgent = () => {
     ? buildCodexPersistentShellSnippet(mcpToken)
     : null
   const startCodexSnippet = "codex"
+  const aiAssistedSetupSnippet =
+    clientSnippet && codexPersistentShellSnippet
+      ? buildAiAssistedSetupSnippet({
+          persistentShellSnippet: codexPersistentShellSnippet,
+          clientSnippet,
+          agentInstructionSnippet,
+          startCodexSnippet,
+        })
+      : null
 
   return (
     <div className={styles.page}>
@@ -406,47 +460,90 @@ const ConnectAgent = () => {
 
           {clientSnippet && codexPersistentShellSnippet ? (
             <div className={styles.tokenSection}>
-              <Alert>
-                <CheckCircle2 className={styles.icon} />
-                <AlertTitle>Fresh token ready</AlertTitle>
-                <AlertDescription>
-                  This token is only shown right now. Save it now if you need it
-                  for setup.
-                </AlertDescription>
-              </Alert>
+              <Tabs defaultValue="ai-assisted" className={styles.setupTabs}>
+                <TabsList className={styles.setupTabsList}>
+                  <TabsTrigger
+                    value="ai-assisted"
+                    className={styles.setupTabTrigger}
+                  >
+                    AI assisted setup
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="manual"
+                    className={styles.setupTabTrigger}
+                  >
+                    Manual setup
+                  </TabsTrigger>
+                </TabsList>
 
-              <SnippetBlock
-                title="Persist the token across new terminals"
-                description="Stores the token locally so Codex can launch with EnderAI connected."
-                snippet={codexPersistentShellSnippet}
-                copiedText={copiedText}
-                onCopy={(value) => {
-                  void copy(value)
-                }}
-                testId="connect-agent-persistent-shell"
-              />
+                <Alert>
+                  <CheckCircle2 className={styles.icon} />
+                  <AlertTitle>Fresh token ready</AlertTitle>
+                  <AlertDescription>
+                    This token is only shown right now. Save it now if you need
+                    it for setup.
+                  </AlertDescription>
+                </Alert>
 
-              <SnippetBlock
-                title="Codex CLI config"
-                description="Add this block to `~/.codex/config.toml`."
-                snippet={clientSnippet}
-                copiedText={copiedText}
-                onCopy={(value) => {
-                  void copy(value)
-                }}
-                testId="connect-agent-config"
-              />
+                <TabsContent value="ai-assisted" className={styles.setupTab}>
+                  <SnippetBlock
+                    title="Leverage AI to complete setup"
+                    description="Pass the following instructions to your AI of choice to help you complete setup."
+                    snippet={aiAssistedSetupSnippet ?? ""}
+                    copiedText={copiedText}
+                    onCopy={(value) => {
+                      void copy(value)
+                    }}
+                    testId="connect-agent-ai-setup"
+                  />
+                </TabsContent>
 
-              <SnippetBlock
-                title="Start Codex from terminal"
-                description="After the setup above, launch the Codex CLI from a terminal."
-                snippet={startCodexSnippet}
-                copiedText={copiedText}
-                onCopy={(value) => {
-                  void copy(value)
-                }}
-                testId="connect-agent-start-codex"
-              />
+                <TabsContent value="manual" className={styles.setupTab}>
+                  <SnippetBlock
+                    title="Persist the token across new terminals"
+                    description="Stores the token locally so Codex can launch with EnderAI connected."
+                    snippet={codexPersistentShellSnippet}
+                    copiedText={copiedText}
+                    onCopy={(value) => {
+                      void copy(value)
+                    }}
+                    testId="connect-agent-persistent-shell"
+                  />
+
+                  <SnippetBlock
+                    title="Codex CLI config"
+                    description="Add this block to `~/.codex/config.toml`."
+                    snippet={clientSnippet}
+                    copiedText={copiedText}
+                    onCopy={(value) => {
+                      void copy(value)
+                    }}
+                    testId="connect-agent-config"
+                  />
+
+                  <SnippetBlock
+                    title="Minimal agent instruction"
+                    description="Add this to your AI workflow's instruction file to start using EnderAI."
+                    snippet={agentInstructionSnippet}
+                    copiedText={copiedText}
+                    onCopy={(value) => {
+                      void copy(value)
+                    }}
+                    testId="connect-agent-instructions"
+                  />
+
+                  <SnippetBlock
+                    title="Start Codex from terminal"
+                    description="After the setup above, launch the Codex CLI from a terminal."
+                    snippet={startCodexSnippet}
+                    copiedText={copiedText}
+                    onCopy={(value) => {
+                      void copy(value)
+                    }}
+                    testId="connect-agent-start-codex"
+                  />
+                </TabsContent>
+              </Tabs>
             </div>
           ) : (
             <Alert>
@@ -458,17 +555,6 @@ const ConnectAgent = () => {
               </AlertDescription>
             </Alert>
           )}
-
-          <SnippetBlock
-            title="Minimal agent instruction"
-            description="Add this to your AI workflow’s instruction file to start using EnderAI."
-            snippet={agentInstructionSnippet}
-            copiedText={copiedText}
-            onCopy={(value) => {
-              void copy(value)
-            }}
-            testId="connect-agent-instructions"
-          />
         </CardContent>
       </Card>
 

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -407,6 +407,48 @@ test("Connect agent generates the hosted Codex setup and hides revoked credentia
     ),
   ).toHaveCount(0)
   await expect(
+    page.getByText("then launch `codex` from that same shell"),
+  ).toHaveCount(0)
+  await expect(
+    page.getByText("Optional: persist the token across new terminals"),
+  ).toHaveCount(0)
+  await expect(
+    page.getByRole("tab", { name: "AI assisted setup" }),
+  ).toHaveAttribute("aria-selected", "true")
+  await expect(page.getByRole("tab", { name: "Manual setup" })).toBeVisible()
+  await expect(page.getByText("Leverage AI to complete setup")).toBeVisible()
+  await expect(
+    page.getByText(
+      "Pass the following instructions to your AI of choice to help you complete setup.",
+    ),
+  ).toBeVisible()
+  await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
+    "# Persist the token",
+  )
+  await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
+    'export ENDERAI_MCP_TOKEN="mcp-token-abc"',
+  )
+  await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
+    "# Setup CLI config",
+  )
+  await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
+    'bearer_token_env_var = "ENDERAI_MCP_TOKEN"',
+  )
+  await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
+    "# Add agent instruction",
+  )
+  await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
+    "enderai_begin_case",
+  )
+  await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
+    "# Start Codex",
+  )
+  await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
+    "codex",
+  )
+
+  await page.getByRole("tab", { name: "Manual setup" }).click()
+  await expect(
     page.getByText("Persist the token across new terminals"),
   ).toBeVisible()
   await expect(
@@ -424,22 +466,15 @@ test("Connect agent generates the hosted Codex setup and hides revoked credentia
   await expect(
     page.getByTestId("connect-agent-persistent-shell"),
   ).not.toContainText("ENDERAI_BACKEND_TOKEN")
-
   await expect(page.getByTestId("connect-agent-config")).toContainText(
     'bearer_token_env_var = "ENDERAI_MCP_TOKEN"',
   )
   await expect(
     page.getByText("Add this block to `~/.codex/config.toml`."),
   ).toBeVisible()
-  await expect(
-    page.getByText("then launch `codex` from that same shell"),
-  ).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-config")).not.toContainText(
     "X-EnderAI-Backend-Token",
   )
-  await expect(
-    page.getByText("Optional: persist the token across new terminals"),
-  ).toHaveCount(0)
   const persistStepTop = await page
     .getByText("Persist the token across new terminals")
     .boundingBox()
@@ -469,6 +504,14 @@ test("Connect agent generates the hosted Codex setup and hides revoked credentia
   await expect(page.getByTestId("connect-agent-instructions")).toContainText(
     "Prefer the guided case tools over raw `enderai_request` calls.",
   )
+  const instructionStepTop = await page
+    .getByText("Minimal agent instruction")
+    .boundingBox()
+  const startStepTop = await page
+    .getByText("Start Codex from terminal")
+    .boundingBox()
+  expect(configStepTop?.y).toBeLessThan(instructionStepTop?.y ?? 0)
+  expect(instructionStepTop?.y).toBeLessThan(startStepTop?.y ?? 0)
   await expect(
     page.locator('[data-slot="card-title"]').filter({ hasText: "Credentials" }),
   ).toBeVisible()
@@ -486,12 +529,19 @@ test("Connect agent generates the hosted Codex setup and hides revoked credentia
     0,
   )
   await expect(page.getByTestId("connect-agent-config")).toHaveCount(0)
+  await expect(
+    page.getByRole("tab", { name: "AI assisted setup" }),
+  ).toHaveCount(0)
+  await expect(page.getByRole("tab", { name: "Manual setup" })).toHaveCount(0)
+  await expect(page.getByTestId("connect-agent-ai-setup")).toHaveCount(0)
   await expect(page.getByText("Start Codex from terminal")).toHaveCount(0)
-  await expect(page.getByTestId("connect-agent-instructions")).toContainText(
-    "enderai_begin_case",
-  )
-  await expect(page.getByTestId("connect-agent-instructions")).toContainText(
-    "enderai_finish_case",
-  )
+  await expect(page.getByTestId("connect-agent-instructions")).toHaveCount(0)
+  await expect(page.getByText("Minimal agent instruction")).toHaveCount(0)
+  await expect(page.getByText("Leverage AI to complete setup")).toHaveCount(0)
+  await expect(page.getByText("enderai_finish_case")).toHaveCount(0)
+  await expect(page.getByText("enderai_begin_case")).toHaveCount(0)
+  await expect(page.getByText("# Add agent instruction")).toHaveCount(0)
+  await expect(page.getByText("# Start Codex")).toHaveCount(0)
+  await expect(page.getByText("# Setup CLI config")).toHaveCount(0)
   await expect(page.getByText("Revoked install")).toHaveCount(0)
 })


### PR DESCRIPTION
## What changed
- Added a two-tab setup choice for Connect Agent: AI assisted setup and Manual setup.
- Combined the token persistence, Codex CLI config, agent instruction, and Codex launch command into one AI-assisted instruction block.
- Kept manual setup available with the same setup snippets and updated the ordering so Start Codex follows the minimal agent instruction.
- Added a repo-level agent integration pause note for Jira/Atlassian and EnderAI MCP usage.

## Validation
- `bunx biome check --write --unsafe --files-ignore-unknown=true src/components/UserSettings/ConnectAgent.tsx src/components/UserSettings/ConnectAgent.module.css tests/user-settings.spec.ts`
- `bun run build`
- `FIRST_SUPERUSER=test@example.com FIRST_SUPERUSER_PASSWORD=test-password npx playwright test tests/user-settings.spec.ts -g "Connect agent generates the hosted Codex setup" --project=chromium --no-deps`