### PR TITLE
[codex] Add generated skills UI

### DIFF
--- a/src/api/skills.ts
+++ b/src/api/skills.ts
@@ -1,0 +1,111 @@
+import { type CancelablePromise, OpenAPI } from "@/client"
+import { request } from "@/client/core/request"
+
+export type SkillConfidence = "high" | "medium" | "low"
+
+export interface SkillPublic {
+  id: string
+  title: string
+  slug: string
+  description: string | null
+  status: string
+  source_type: string
+  source_topic_id: string | null
+  source_case_ids: string[]
+  owner_ids: string[]
+  is_demo: boolean
+  trigger_phrases: string[]
+  files: string[]
+  symbols: string[]
+  errors: string[]
+  symptoms: string[]
+  instructions_md: string
+  confidence: SkillConfidence
+  source_snapshot: Record<string, unknown>
+  usage_count: number
+  created_at: string | null
+  updated_at: string | null
+  last_used_at: string | null
+}
+
+export interface SkillsPublic {
+  data: SkillPublic[]
+  count: number
+}
+
+export interface SkillMatchCandidate {
+  skill: SkillPublic
+  score: number
+  confidence: SkillConfidence
+  matched_signals: string[]
+  reasoning: string[]
+}
+
+export interface SkillUseResult {
+  selected_skill: SkillPublic | null
+  matched_skills: SkillMatchCandidate[]
+  instructions_md: string | null
+  confidence: SkillConfidence
+  matched_signals: string[]
+  provenance: Record<string, unknown>
+  agent_usage_note: string
+}
+
+export interface ReadSkillsParams {
+  status?: string
+  source_type?: string
+  q?: string
+  skip?: number
+  limit?: number
+  demo?: boolean
+}
+
+export function readSkills(
+  params: ReadSkillsParams = {},
+): CancelablePromise<SkillsPublic> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/skills/",
+    query: {
+      status: params.status?.trim() || undefined,
+      source_type: params.source_type?.trim() || undefined,
+      q: params.q?.trim() || undefined,
+      skip: params.skip,
+      limit: params.limit,
+      demo: params.demo || undefined,
+    },
+  })
+}
+
+export function readSkill(
+  skillId: string,
+  options: { demo?: boolean } = {},
+): CancelablePromise<SkillPublic> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/skills/{skill_id}",
+    path: {
+      skill_id: skillId,
+    },
+    query: {
+      demo: options.demo || undefined,
+    },
+  })
+}
+
+export function useSkillById(
+  skillId: string,
+  options: { demo?: boolean } = {},
+): CancelablePromise<SkillUseResult> {
+  return request(OpenAPI, {
+    method: "POST",
+    url: "/api/v1/skills/{skill_id}/use",
+    path: {
+      skill_id: skillId,
+    },
+    query: {
+      demo: options.demo || undefined,
+    },
+    body: {},
+  })
+}

--- a/src/components/Sidebar/AppSidebar.tsx
+++ b/src/components/Sidebar/AppSidebar.tsx
@@ -5,6 +5,7 @@ import {
   Home,
   PanelLeftClose,
   PanelLeftOpen,
+  Sparkles,
   Users,
 } from "lucide-react"
 
@@ -29,6 +30,7 @@ const baseItems: Item[] = [
   { icon: Home, title: "Home", path: "/home" },
   { icon: Box, title: "Topics", path: "/topics" },
   { icon: Boxes, title: "Cases", path: "/cases" },
+  { icon: Sparkles, title: "Skills", path: "/skills" },
 ]
 
 function SidebarCollapseToggle() {

--- a/src/components/Skills/SkillsPage.module.css
+++ b/src/components/Skills/SkillsPage.module.css
@@ -1,0 +1,215 @@
+@reference "../../index.css";
+
+.page {
+  @apply flex min-h-0 flex-1 flex-col gap-5 overflow-hidden;
+}
+
+.heroCard {
+  @apply shrink-0 overflow-hidden border-0 bg-[linear-gradient(135deg,hsl(var(--card))_0%,hsl(var(--muted))_52%,rgba(16,185,129,0.12)_100%)] shadow-sm;
+}
+
+.heroHeader {
+  @apply flex flex-wrap items-start justify-between gap-4;
+}
+
+.eyebrow {
+  @apply mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.22em] text-emerald-700 dark:text-emerald-300;
+}
+
+.heroTitle {
+  @apply text-2xl;
+}
+
+.heroDescription {
+  @apply max-w-3xl;
+}
+
+.heroBadges {
+  @apply flex flex-wrap gap-2;
+}
+
+.toolbar {
+  @apply shrink-0;
+}
+
+.searchBox {
+  @apply relative max-w-2xl;
+}
+
+.searchIcon {
+  @apply pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground;
+}
+
+.searchInput {
+  @apply pl-9;
+}
+
+.layout {
+  @apply grid min-h-0 flex-1 gap-5 overflow-hidden;
+}
+
+.listCard {
+  @apply min-h-0 overflow-hidden;
+}
+
+.listTitle {
+  @apply flex items-center gap-2;
+}
+
+.listContent {
+  @apply min-h-0 overflow-y-auto;
+}
+
+.skillList {
+  @apply space-y-3;
+}
+
+.skillCard {
+  @apply w-full rounded-xl border bg-card p-4 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring;
+}
+
+.skillCardSelected {
+  @apply border-emerald-500 bg-emerald-50/70 dark:bg-emerald-950/20;
+}
+
+.skillCardHeader {
+  @apply flex items-start justify-between gap-3;
+}
+
+.skillCardTitle {
+  @apply font-medium leading-snug;
+}
+
+.skillCardDescription {
+  @apply mt-2 line-clamp-2 text-sm text-muted-foreground;
+}
+
+.skillCardMeta {
+  @apply mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground;
+}
+
+.detailCard {
+  @apply flex min-h-0 flex-col overflow-hidden;
+}
+
+.detailHeader {
+  @apply flex flex-wrap items-start justify-between gap-4;
+}
+
+.detailHeaderMain {
+  @apply min-w-0 flex-1 space-y-3;
+}
+
+.detailTitle {
+  @apply break-words text-2xl;
+}
+
+.detailContent {
+  @apply min-h-0 flex-1 space-y-6 overflow-y-auto;
+}
+
+.badgeRow {
+  @apply flex flex-wrap gap-2;
+}
+
+.section {
+  @apply space-y-3;
+}
+
+.sectionHeading {
+  @apply flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground;
+}
+
+.sectionIcon {
+  @apply size-4 text-emerald-600;
+}
+
+.provenanceGrid {
+  @apply grid gap-3 rounded-xl border bg-muted/30 p-4 text-sm;
+}
+
+.provenanceLabel {
+  @apply text-xs uppercase tracking-[0.14em] text-muted-foreground;
+}
+
+.sourceSummary {
+  @apply rounded-xl border-l-4 border-emerald-500 bg-emerald-50/70 p-4 text-sm text-emerald-950 dark:bg-emerald-950/20 dark:text-emerald-100;
+}
+
+.signalGrid {
+  @apply grid gap-4;
+}
+
+.notesGrid {
+  @apply grid gap-4;
+}
+
+.signalGroup {
+  @apply min-w-0 space-y-2;
+}
+
+.signalTitle {
+  @apply text-sm font-medium;
+}
+
+.chipList {
+  @apply flex flex-wrap gap-2;
+}
+
+.chip {
+  @apply max-w-full normal-case;
+}
+
+.chipLabel {
+  @apply block max-w-full truncate;
+}
+
+.instructionsPre {
+  @apply max-h-[34rem] overflow-auto rounded-xl border bg-slate-950 p-4 text-xs leading-relaxed text-slate-100;
+}
+
+.smallMutedText {
+  @apply text-sm text-muted-foreground;
+}
+
+.errorContent {
+  @apply text-sm text-destructive;
+}
+
+.emptyState {
+  @apply flex min-h-64 items-center justify-center gap-4 text-center;
+}
+
+.emptyList {
+  @apply flex min-h-52 flex-col items-center justify-center gap-2 rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground;
+}
+
+.emptyIcon {
+  @apply size-8 text-emerald-600;
+}
+
+.emptyTitle {
+  @apply font-medium text-foreground;
+}
+
+.icon {
+  @apply size-4;
+}
+
+@media (min-width: 1024px) {
+  .layout {
+    grid-template-columns: minmax(20rem, 0.82fr) minmax(0, 1.35fr);
+  }
+
+  .signalGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .notesGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .provenanceGrid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}

--- a/src/components/Skills/SkillsPage.tsx
+++ b/src/components/Skills/SkillsPage.tsx
@@ -1,0 +1,417 @@
+import { useQuery } from "@tanstack/react-query"
+import {
+  BookOpenCheck,
+  Boxes,
+  Copy,
+  FileCode2,
+  Fingerprint,
+  Search,
+  Sparkles,
+} from "lucide-react"
+import { useEffect, useState } from "react"
+
+import { readSkills, type SkillPublic } from "@/api/skills"
+import { useDemoMode } from "@/components/demo-mode-provider"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
+import { cn } from "@/lib/utils"
+import styles from "./SkillsPage.module.css"
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return "Never"
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value))
+}
+
+function badgeVariant(
+  value: string,
+): "default" | "secondary" | "success" | "destructive" | "outline" {
+  const normalized = value.trim().toLowerCase()
+  if (normalized === "high" || normalized === "published") return "success"
+  if (normalized === "medium" || normalized === "draft") return "secondary"
+  if (normalized === "archived" || normalized === "low") return "outline"
+  return "default"
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === "string")
+}
+
+function getSourceTopic(skill: SkillPublic): {
+  title: string | null
+  workflowKey: string | null
+  summary: string | null
+} {
+  const topic = asRecord(skill.source_snapshot.topic)
+  return {
+    title: stringValue(topic.title),
+    workflowKey: stringValue(topic.workflow_key),
+    summary: stringValue(topic.summary),
+  }
+}
+
+function sourceLabel(skill: SkillPublic): string {
+  const topic = getSourceTopic(skill)
+  if (topic.title) return topic.title
+  if (skill.source_type === "context_pack") return "ContextPack"
+  if (skill.source_type === "case") return "Case"
+  return "Topic"
+}
+
+function sourceTypeLabel(sourceType: string): string {
+  return sourceType
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+}
+
+function SignalList({
+  title,
+  items,
+  emptyText,
+}: {
+  title: string
+  items: string[]
+  emptyText: string
+}) {
+  return (
+    <div className={styles.signalGroup}>
+      <div className={styles.signalTitle}>{title}</div>
+      {items.length > 0 ? (
+        <div className={styles.chipList}>
+          {items.map((item, index) => (
+            <Badge
+              key={`${title}-${item}-${index}`}
+              variant="outline"
+              className={styles.chip}
+              title={item}
+            >
+              <span className={styles.chipLabel}>{item}</span>
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        <p className={styles.smallMutedText}>{emptyText}</p>
+      )}
+    </div>
+  )
+}
+
+function SkillCard({
+  skill,
+  isSelected,
+  onSelect,
+}: {
+  skill: SkillPublic
+  isSelected: boolean
+  onSelect: () => void
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(styles.skillCard, isSelected && styles.skillCardSelected)}
+      onClick={onSelect}
+    >
+      <div className={styles.skillCardHeader}>
+        <div className={styles.skillCardTitle}>{skill.title}</div>
+        <Badge variant={badgeVariant(skill.confidence)}>
+          {skill.confidence}
+        </Badge>
+      </div>
+      <p className={styles.skillCardDescription}>
+        {skill.description ?? `Generated from ${sourceLabel(skill)}.`}
+      </p>
+      <div className={styles.skillCardMeta}>
+        <Badge variant="outline">{sourceTypeLabel(skill.source_type)}</Badge>
+        <span>{skill.source_case_ids.length} source cases</span>
+        <span>Used {skill.usage_count} times</span>
+      </div>
+    </button>
+  )
+}
+
+function SkillDetail({ skill }: { skill: SkillPublic | null }) {
+  const [copiedText, copy] = useCopyToClipboard()
+
+  if (!skill) {
+    return (
+      <Card className={styles.detailCard}>
+        <CardContent className={styles.emptyState}>
+          <Sparkles className={styles.emptyIcon} />
+          <div>
+            <h3 className={styles.emptyTitle}>Select a generated skill</h3>
+            <p className={styles.smallMutedText}>
+              Skills turn Topic and Case history into reusable agent workflow
+              instructions.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const topic = getSourceTopic(skill)
+  const pinnedTakeaways = stringList(skill.source_snapshot.pinned_takeaways)
+  const openQuestions = stringList(skill.source_snapshot.open_questions)
+  const negativeHistory = stringList(skill.source_snapshot.negative_history)
+
+  return (
+    <Card className={styles.detailCard}>
+      <CardHeader className={styles.detailHeader}>
+        <div className={styles.detailHeaderMain}>
+          <div className={styles.badgeRow}>
+            <Badge variant={badgeVariant(skill.status)}>{skill.status}</Badge>
+            <Badge variant={badgeVariant(skill.confidence)}>
+              {skill.confidence} confidence
+            </Badge>
+            {skill.is_demo ? <Badge variant="secondary">Demo</Badge> : null}
+          </div>
+          <CardTitle className={styles.detailTitle}>{skill.title}</CardTitle>
+          <CardDescription>
+            {skill.description ?? `Generated from ${sourceLabel(skill)}.`}
+          </CardDescription>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => {
+            void copy(skill.instructions_md)
+          }}
+        >
+          <Copy className={styles.icon} />
+          {copiedText === skill.instructions_md ? "Copied" : "Copy skill"}
+        </Button>
+      </CardHeader>
+      <CardContent className={styles.detailContent}>
+        <section className={styles.section}>
+          <div className={styles.sectionHeading}>
+            <Fingerprint className={styles.sectionIcon} />
+            Provenance
+          </div>
+          <div className={styles.provenanceGrid}>
+            <div>
+              <span className={styles.provenanceLabel}>Source</span>
+              <p>{sourceTypeLabel(skill.source_type)}</p>
+            </div>
+            <div>
+              <span className={styles.provenanceLabel}>Topic</span>
+              <p>{topic.title ?? skill.source_topic_id ?? "Unknown"}</p>
+            </div>
+            <div>
+              <span className={styles.provenanceLabel}>Workflow key</span>
+              <p>{topic.workflowKey ?? "Not captured"}</p>
+            </div>
+            <div>
+              <span className={styles.provenanceLabel}>Updated</span>
+              <p>{formatTimestamp(skill.updated_at)}</p>
+            </div>
+          </div>
+          {topic.summary ? (
+            <p className={styles.sourceSummary}>{topic.summary}</p>
+          ) : null}
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeading}>
+            <Search className={styles.sectionIcon} />
+            Match Signals
+          </div>
+          <div className={styles.signalGrid}>
+            <SignalList
+              title="Triggers"
+              items={skill.trigger_phrases}
+              emptyText="No trigger phrases captured."
+            />
+            <SignalList
+              title="Files"
+              items={skill.files}
+              emptyText="No canonical files captured."
+            />
+            <SignalList
+              title="Symbols"
+              items={skill.symbols}
+              emptyText="No canonical symbols captured."
+            />
+            <SignalList
+              title="Errors"
+              items={skill.errors}
+              emptyText="No canonical errors captured."
+            />
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeading}>
+            <BookOpenCheck className={styles.sectionIcon} />
+            Reusable Notes
+          </div>
+          <div className={styles.notesGrid}>
+            <SignalList
+              title="Pinned takeaways"
+              items={pinnedTakeaways}
+              emptyText="No takeaways promoted yet."
+            />
+            <SignalList
+              title="Open questions"
+              items={openQuestions}
+              emptyText="No open questions captured."
+            />
+            <SignalList
+              title="Negative history"
+              items={negativeHistory}
+              emptyText="No negative history captured."
+            />
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeading}>
+            <FileCode2 className={styles.sectionIcon} />
+            Skill Instructions
+          </div>
+          <pre className={styles.instructionsPre}>
+            <code>{skill.instructions_md}</code>
+          </pre>
+        </section>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function SkillsPage() {
+  const { isDemoMode } = useDemoMode()
+  const [query, setQuery] = useState("")
+  const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null)
+
+  const skillsQuery = useQuery({
+    queryKey: ["skills", { demo: isDemoMode, query }],
+    queryFn: () => readSkills({ demo: isDemoMode, q: query, limit: 100 }),
+  })
+
+  const skills = skillsQuery.data?.data ?? []
+  const selectedSkill =
+    skills.find((skill) => skill.id === selectedSkillId) ?? skills[0] ?? null
+
+  useEffect(() => {
+    if (!selectedSkill) {
+      setSelectedSkillId(null)
+      return
+    }
+    if (selectedSkill.id !== selectedSkillId) {
+      setSelectedSkillId(selectedSkill.id)
+    }
+  }, [selectedSkill, selectedSkillId])
+
+  return (
+    <div className={styles.page}>
+      <Card className={styles.heroCard}>
+        <CardHeader className={styles.heroHeader}>
+          <div>
+            <div className={styles.eyebrow}>
+              <Sparkles className={styles.icon} />
+              Generated AI Skills
+            </div>
+            <CardTitle className={styles.heroTitle}>
+              Reusable workflows from EnderAI memory
+            </CardTitle>
+            <CardDescription className={styles.heroDescription}>
+              Skills compile Topics, Cases, and ContextPacks into agent-ready
+              workflow instructions with source provenance.
+            </CardDescription>
+          </div>
+          <div className={styles.heroBadges}>
+            <Badge variant="secondary">
+              {isDemoMode ? "Demo mode" : "Live"}
+            </Badge>
+            <Badge variant="outline">
+              {skillsQuery.data?.count ?? 0} skills
+            </Badge>
+          </div>
+        </CardHeader>
+      </Card>
+
+      <div className={styles.toolbar}>
+        <div className={styles.searchBox}>
+          <Search className={styles.searchIcon} />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search skills by workflow, file, symbol, or error"
+            className={styles.searchInput}
+          />
+        </div>
+      </div>
+
+      {skillsQuery.error ? (
+        <Card>
+          <CardContent className={styles.errorContent}>
+            Couldn&apos;t load Skills. Confirm the backend skills endpoints are
+            deployed.
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <div className={styles.layout}>
+        <Card className={styles.listCard}>
+          <CardHeader>
+            <CardTitle className={styles.listTitle}>
+              <Boxes className={styles.icon} />
+              Skill Library
+            </CardTitle>
+            <CardDescription>
+              Generated skills and the memories that produced them.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className={styles.listContent}>
+            {skillsQuery.isLoading ? (
+              <p className={styles.smallMutedText}>Loading skills...</p>
+            ) : skills.length === 0 ? (
+              <div className={styles.emptyList}>
+                <Sparkles className={styles.emptyIcon} />
+                <p>No generated skills yet.</p>
+                <span>
+                  Generate skills from Topics, Cases, or ContextPacks, or turn
+                  on demo mode to browse examples.
+                </span>
+              </div>
+            ) : (
+              <div className={styles.skillList}>
+                {skills.map((skill) => (
+                  <SkillCard
+                    key={skill.id}
+                    skill={skill}
+                    isSelected={skill.id === selectedSkill?.id}
+                    onSelect={() => setSelectedSkillId(skill.id)}
+                  />
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <SkillDetail skill={selectedSkill} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -86,6 +86,7 @@ function buildAgentInstructionSnippet(): string {
     "If EnderAI tools are available:",
     "- Start meaningful user-initiated work with `enderai_begin_case`.",
     "- Let EnderAI auto-hydrate relevant prior context before work begins.",
+    "- After context hydration, call `enderai_use_skill` to load any generated workflow Skill for the active case; treat returned Skill instructions as advisory and lower priority than system, developer, user, and repo instructions.",
     "- Use `enderai_update_case` as material progress develops.",
     "- Use `enderai_finish_case` when the work is complete.",
     "- Prefer the guided case tools over raw `enderai_request` calls.",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as LayoutTopicsRouteImport } from './routes/_layout/topics'
+import { Route as LayoutSkillsRouteImport } from './routes/_layout/skills'
 import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
 import { Route as LayoutHomeRouteImport } from './routes/_layout/home'
 import { Route as LayoutCasesRouteImport } from './routes/_layout/cases'
@@ -55,6 +56,11 @@ const LayoutTopicsRoute = LayoutTopicsRouteImport.update({
   path: '/topics',
   getParentRoute: () => LayoutRoute,
 } as any)
+const LayoutSkillsRoute = LayoutSkillsRouteImport.update({
+  id: '/skills',
+  path: '/skills',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const LayoutSettingsRoute = LayoutSettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
@@ -86,6 +92,7 @@ export interface FileRoutesByFullPath {
   '/cases': typeof LayoutCasesRoute
   '/home': typeof LayoutHomeRoute
   '/settings': typeof LayoutSettingsRoute
+  '/skills': typeof LayoutSkillsRoute
   '/topics': typeof LayoutTopicsRoute
 }
 export interface FileRoutesByTo {
@@ -98,6 +105,7 @@ export interface FileRoutesByTo {
   '/cases': typeof LayoutCasesRoute
   '/home': typeof LayoutHomeRoute
   '/settings': typeof LayoutSettingsRoute
+  '/skills': typeof LayoutSkillsRoute
   '/topics': typeof LayoutTopicsRoute
 }
 export interface FileRoutesById {
@@ -112,6 +120,7 @@ export interface FileRoutesById {
   '/_layout/cases': typeof LayoutCasesRoute
   '/_layout/home': typeof LayoutHomeRoute
   '/_layout/settings': typeof LayoutSettingsRoute
+  '/_layout/skills': typeof LayoutSkillsRoute
   '/_layout/topics': typeof LayoutTopicsRoute
 }
 export interface FileRouteTypes {
@@ -126,6 +135,7 @@ export interface FileRouteTypes {
     | '/cases'
     | '/home'
     | '/settings'
+    | '/skills'
     | '/topics'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -138,6 +148,7 @@ export interface FileRouteTypes {
     | '/cases'
     | '/home'
     | '/settings'
+    | '/skills'
     | '/topics'
   id:
     | '__root__'
@@ -151,6 +162,7 @@ export interface FileRouteTypes {
     | '/_layout/cases'
     | '/_layout/home'
     | '/_layout/settings'
+    | '/_layout/skills'
     | '/_layout/topics'
   fileRoutesById: FileRoutesById
 }
@@ -214,6 +226,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutTopicsRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/_layout/skills': {
+      id: '/_layout/skills'
+      path: '/skills'
+      fullPath: '/skills'
+      preLoaderRoute: typeof LayoutSkillsRouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/_layout/settings': {
       id: '/_layout/settings'
       path: '/settings'
@@ -250,6 +269,7 @@ interface LayoutRouteChildren {
   LayoutCasesRoute: typeof LayoutCasesRoute
   LayoutHomeRoute: typeof LayoutHomeRoute
   LayoutSettingsRoute: typeof LayoutSettingsRoute
+  LayoutSkillsRoute: typeof LayoutSkillsRoute
   LayoutTopicsRoute: typeof LayoutTopicsRoute
 }
 
@@ -258,6 +278,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutCasesRoute: LayoutCasesRoute,
   LayoutHomeRoute: LayoutHomeRoute,
   LayoutSettingsRoute: LayoutSettingsRoute,
+  LayoutSkillsRoute: LayoutSkillsRoute,
   LayoutTopicsRoute: LayoutTopicsRoute,
 }
 

--- a/src/routes/_layout/skills.tsx
+++ b/src/routes/_layout/skills.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { SkillsPage } from "@/components/Skills/SkillsPage"
+
+export const Route = createFileRoute("/_layout/skills")({
+  component: Skills,
+  head: () => ({
+    meta: [
+      {
+        title: "Skills",
+      },
+    ],
+  }),
+})
+
+function Skills() {
+  return <SkillsPage />
+}


### PR DESCRIPTION
## What changed

- Added a `/skills` route and sidebar entry for browsing generated EnderAI Skills.
- Added a Skills API client and page UI with search, confidence/status badges, provenance, match signals, reusable notes, and copyable generated instructions.
- Updated Connect Agent setup instructions to call `enderai_use_skill` after context hydration and treat returned Skill instructions as advisory.

## Validation

- `bunx biome check` on touched frontend files
- `bun run build`