### PR TITLE
[codex] Revise product copy

### DIFF
--- a/src/components/Cases/CasesPage.tsx
+++ b/src/components/Cases/CasesPage.tsx
@@ -333,7 +333,7 @@ function ContextPackSection({
         <div>
           <div className={styles.sectionTitle}>Context Pack</div>
           <p className={styles.sectionIntro}>
-            Agent briefing captured when this Case started.
+            Briefing captured when this Case started.
           </p>
         </div>
         <div className={styles.contextMeta}>
@@ -355,13 +355,13 @@ function ContextPackSection({
 
       {!hasBriefing ? (
         <p className={styles.smallMutedText}>
-          No Context Pack briefing was captured for this Case.
+          No briefing was captured for this Case.
         </p>
       ) : (
         <div className={styles.contextPackStack}>
           {snapshot.topic_summary ? (
             <div className={styles.contextPanel}>
-              <div className={styles.signalTitle}>Topic briefing</div>
+              <div className={styles.signalTitle}>Topic note</div>
               <p className={styles.mutedText}>{snapshot.topic_summary}</p>
             </div>
           ) : null}
@@ -398,7 +398,7 @@ function ContextPackSection({
           </div>
 
           <div className={styles.contextPanel}>
-            <div className={styles.signalTitle}>Likely relevant code</div>
+            <div className={styles.signalTitle}>Likely code</div>
             <div className={styles.signalGroups}>
               <div>
                 <div className={styles.subsectionTitle}>Files</div>
@@ -819,7 +819,7 @@ export function CasesPage({
               <div className={styles.detailHeaderMain}>
                 <CardTitle>Loading Case…</CardTitle>
                 <CardDescription>
-                  Fetching the selected case detail from the canonical API.
+                  Fetching the selected case detail.
                 </CardDescription>
               </div>
               <Button
@@ -843,7 +843,7 @@ export function CasesPage({
               focused ? styles.detailContentFocused : styles.detailContentSplit,
             )}
           >
-            Case details will appear here once loading completes.
+            Case details will appear here when loading finishes.
           </CardContent>
         </Card>
       )

--- a/src/components/Home/HomePage.tsx
+++ b/src/components/Home/HomePage.tsx
@@ -51,19 +51,19 @@ export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
               <div className={styles.heroText}>
                 <p className={styles.greeting}>
                   {isPublic
-                    ? "Operational memory for AI automation"
+                    ? "Working memory for AI-assisted teams"
                     : `Welcome back, ${displayName}`}
                 </p>
                 <h1 className={styles.heroTitle}>
-                  EnderAI turns scattered company knowledge into executable
-                  context.
+                  EnderAI turns messy team history into context agents can
+                  actually use.
                 </h1>
                 <p className={styles.heroDescription}>
-                  Every company runs on domain knowledge spread across people,
-                  tickets, code, docs, Slack, support history, databases, and
-                  past decisions. EnderAI captures that raw context, organizes
-                  it into a living map of how the business works, and turns it
-                  into workflows humans and AI agents can use safely.
+                  Work leaves useful traces in tickets, pull requests, docs,
+                  Slack threads, incidents, support notes, commands, and one-off
+                  decisions. EnderAI captures those traces while work is
+                  happening, ties them to durable topics, and turns the useful
+                  parts into briefings and skills for the next person or agent.
                 </p>
               </div>
               <div className={styles.heroActions}>
@@ -72,7 +72,7 @@ export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
                     <Button asChild size="lg" className={styles.primaryCta}>
                       <RouterLink to={signedIn ? "/home" : "/signup"}>
                         <Sparkles className={styles.icon} />
-                        Build operational memory
+                        Try the demo
                       </RouterLink>
                     </Button>
                     <Button asChild variant="outline" size="lg">
@@ -120,14 +120,13 @@ export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
             <div>
               <p className={styles.sectionEyebrow}>Why it matters</p>
               <h2 className={styles.sectionTitle}>
-                The bottleneck is company context
+                The missing part is the local story
               </h2>
             </div>
             <p className={styles.sectionDescription}>
-              AI models can do real work, but agents still need the
-              company-specific context required to act correctly. EnderAI fills
-              the missing layer between raw company data and reliable
-              automation.
+              Most agent failures are not model failures. They come from missing
+              background: weird edge cases, prior fixes, approval paths, team
+              conventions, and what already got tried.
             </p>
           </div>
 
@@ -143,13 +142,13 @@ export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
             <div>
               <p className={styles.sectionEyebrow}>How it works</p>
               <h2 className={styles.sectionTitle}>
-                Company knowledge becomes structured and actionable
+                Keep the useful parts of past work
               </h2>
             </div>
             <p className={styles.sectionDescription}>
-              EnderAI is not search and not a chatbot over docs. It is the
-              operational memory layer that makes domain knowledge current,
-              structured, and executable.
+              EnderAI is closer to a work log that cleans itself up than a docs
+              chatbot. It keeps the requests, evidence, decisions, commands, and
+              outcomes that should shape the next pass.
             </p>
           </div>
 
@@ -230,8 +229,8 @@ export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
                     "I found the customer record, source-of-truth policy,
                     approval path, replica systems, validation checklist, and
                     prior correction cases. I will draft the correction steps,
-                    preserve an audit trail, and produce the reusable workflow
-                    for the next similar request."
+                    preserve an audit trail, and save the steps that should be
+                    reused next time."
                   </p>
                 </div>
               </div>
@@ -257,7 +256,7 @@ function PublicNav({ signedIn }: { signedIn: boolean }) {
         </Button>
         <Button asChild>
           <RouterLink to={signedIn ? "/home" : "/signup"}>
-            {signedIn ? "Use now" : "Sign up"}
+            {signedIn ? "Open app" : "Sign up"}
           </RouterLink>
         </Button>
       </nav>
@@ -271,7 +270,7 @@ function HeroGraphic() {
       <div className={styles.graphicHeader}>
         <Badge variant="outline" className={styles.connectBadge}>
           <Zap className={styles.badgeIcon} />
-          Live context
+          Demo context
         </Badge>
         <span className={styles.graphicStatus}>Ready for the next task</span>
       </div>
@@ -391,27 +390,27 @@ const getModelAction = (
 const workflowSteps = [
   {
     step: "01",
-    title: "Capture raw context",
+    title: "Capture the work",
     description:
       "Tickets, docs, code, commands, conversations, approvals, and outcomes are preserved.",
   },
   {
     step: "02",
-    title: "Structure the domain",
+    title: "Sort it into topics",
     description:
-      "EnderAI organizes the work into entities, systems, policies, risks, and workflows.",
+      "Related requests, files, decisions, policies, and edge cases land in the same bucket.",
   },
   {
     step: "03",
-    title: "Hydrate the next task",
+    title: "Brief the next run",
     description:
-      "Relevant prior context is packaged before a human or AI agent starts work.",
+      "The next person or agent starts with the notes that were worth keeping.",
   },
   {
     step: "04",
-    title: "Make it executable",
+    title: "Extract reusable steps",
     description:
-      "The result becomes checklists, audit trails, handoffs, tests, and agent instructions.",
+      "Repeated patterns become checklists, handoffs, tests, and agent instructions.",
   },
 ]
 
@@ -427,21 +426,21 @@ const signalPills = [
 const marketingTiles: MarketingTileProps[] = [
   {
     icon: Database,
-    title: "Capture raw context",
+    title: "Capture the work",
     description:
-      "Pull in the tickets, docs, code changes, commands, conversations, approvals, customer history, incidents, and decisions behind how work happens.",
+      "Keep the tickets, docs, code changes, commands, conversations, incidents, and decisions behind a real request.",
   },
   {
     icon: GitBranch,
-    title: "Structure the domain",
+    title: "Connect the pieces",
     description:
-      "Organize company knowledge into Topics, Cases, entities, systems, policies, risks, and edge cases so it becomes a living map.",
+      "Group related history around Topics so the next run can find the relevant systems, policies, risks, and edge cases.",
   },
   {
     icon: RefreshCcw,
-    title: "Make it executable",
+    title: "Reuse what worked",
     description:
-      "Turn that map into checklists, audit trails, handoffs, agent briefings, tests, and reusable workflow instructions.",
+      "Turn repeated fixes into small briefings, checklists, tests, and draft instructions for agents.",
   },
 ]
 
@@ -451,11 +450,11 @@ const modelCards: ModelCardProps[] = [
     label: "User-facing",
     title: "Topics",
     description:
-      "Topics are durable areas of company knowledge that should be reused across related work.",
+      "Topics are the buckets where related work history accumulates.",
     details: [
-      "Useful for products, systems, policies, customers, incidents, and operational areas.",
-      "Holds aliases, status, summaries, files, symbols, risks, and decisions.",
-      "Gives future Cases a stable place to inherit domain context.",
+      "Useful for products, systems, policies, customers, incidents, and messy operational areas.",
+      "Holds summaries, files, symbols, risks, decisions, and odd vocabulary.",
+      "Gives future Cases a starting point instead of a blank page.",
     ],
     action: {
       label: "Browse Topics",
@@ -466,12 +465,11 @@ const modelCards: ModelCardProps[] = [
     icon: Boxes,
     label: "User-facing",
     title: "Cases",
-    description:
-      "Cases are individual executions of work under a Topic, usually one request or task.",
+    description: "Cases are single runs of work under a Topic.",
     details: [
-      "Tracks input, raw context, commands, hypotheses, changes, approvals, and outcome.",
-      "Keeps validation evidence and next steps visible when work pauses or continues later.",
-      "Provides the concrete history future humans and agents can reuse.",
+      "Tracks the request, notes, commands, hypotheses, changes, and outcome.",
+      "Keeps validation evidence and next steps visible when work pauses.",
+      "Leaves concrete history future humans and agents can reuse.",
     ],
     action: {
       label: "Review Cases",
@@ -483,11 +481,11 @@ const modelCards: ModelCardProps[] = [
     label: "System-powered",
     title: "Context Packs",
     description:
-      "Context Packs are the synthesized briefings EnderAI builds before a human or agent starts work.",
+      "Context Packs are the briefings EnderAI assembles before work starts.",
     details: [
-      "Select relevant prior Topics, Cases, policies, systems, and decisions.",
-      "Include matched signals, pinned takeaways, ambiguity notes, risks, and confidence.",
-      "Give agents the domain context needed to act safely and consistently.",
+      "Pull in relevant prior Topics, Cases, policies, systems, and decisions.",
+      "Include matched signals, pinned takeaways, open questions, and avoid-lists.",
+      "Give agents enough background to stop guessing from scratch.",
     ],
   },
 ]

--- a/src/components/Skills/SkillsPage.module.css
+++ b/src/components/Skills/SkillsPage.module.css
@@ -124,11 +124,11 @@
   @apply size-4 text-emerald-600;
 }
 
-.provenanceGrid {
+.sourceGrid {
   @apply grid gap-3 rounded-xl border bg-muted/30 p-4 text-sm;
 }
 
-.provenanceLabel {
+.sourceLabel {
   @apply text-xs uppercase tracking-[0.14em] text-muted-foreground;
 }
 
@@ -209,7 +209,7 @@
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .provenanceGrid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+  .sourceGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/src/components/Skills/SkillsPage.tsx
+++ b/src/components/Skills/SkillsPage.tsx
@@ -4,7 +4,6 @@ import {
   Boxes,
   Copy,
   FileCode2,
-  Fingerprint,
   Search,
   Sparkles,
 } from "lucide-react"
@@ -60,13 +59,11 @@ function stringList(value: unknown): string[] {
 
 function getSourceTopic(skill: SkillPublic): {
   title: string | null
-  workflowKey: string | null
   summary: string | null
 } {
   const topic = asRecord(skill.source_snapshot.topic)
   return {
     title: stringValue(topic.title),
-    workflowKey: stringValue(topic.workflow_key),
     summary: stringValue(topic.summary),
   }
 }
@@ -162,8 +159,7 @@ function SkillDetail({ skill }: { skill: SkillPublic | null }) {
           <div>
             <h3 className={styles.emptyTitle}>Select a generated skill</h3>
             <p className={styles.smallMutedText}>
-              Skills turn Topic and Case history into reusable agent workflow
-              instructions.
+              Draft instructions generated from captured work.
             </p>
           </div>
         </CardContent>
@@ -205,25 +201,18 @@ function SkillDetail({ skill }: { skill: SkillPublic | null }) {
       </CardHeader>
       <CardContent className={styles.detailContent}>
         <section className={styles.section}>
-          <div className={styles.sectionHeading}>
-            <Fingerprint className={styles.sectionIcon} />
-            Provenance
-          </div>
-          <div className={styles.provenanceGrid}>
+          <div className={styles.sectionHeading}>Source</div>
+          <div className={styles.sourceGrid}>
             <div>
-              <span className={styles.provenanceLabel}>Source</span>
+              <span className={styles.sourceLabel}>Type</span>
               <p>{sourceTypeLabel(skill.source_type)}</p>
             </div>
             <div>
-              <span className={styles.provenanceLabel}>Topic</span>
+              <span className={styles.sourceLabel}>Topic</span>
               <p>{topic.title ?? skill.source_topic_id ?? "Unknown"}</p>
             </div>
             <div>
-              <span className={styles.provenanceLabel}>Workflow key</span>
-              <p>{topic.workflowKey ?? "Not captured"}</p>
-            </div>
-            <div>
-              <span className={styles.provenanceLabel}>Updated</span>
+              <span className={styles.sourceLabel}>Last updated</span>
               <p>{formatTimestamp(skill.updated_at)}</p>
             </div>
           </div>
@@ -330,14 +319,13 @@ export function SkillsPage() {
           <div>
             <div className={styles.eyebrow}>
               <Sparkles className={styles.icon} />
-              Generated AI Skills
+              Skills
             </div>
             <CardTitle className={styles.heroTitle}>
-              Reusable workflows from EnderAI memory
+              Generated instructions
             </CardTitle>
             <CardDescription className={styles.heroDescription}>
-              Skills compile Topics, Cases, and ContextPacks into agent-ready
-              workflow instructions with source provenance.
+              Draft snippets pulled from Topics, Cases, and Context Packs.
             </CardDescription>
           </div>
           <div className={styles.heroBadges}>
@@ -357,7 +345,7 @@ export function SkillsPage() {
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search skills by workflow, file, symbol, or error"
+            placeholder="Search skills"
             className={styles.searchInput}
           />
         </div>
@@ -366,8 +354,7 @@ export function SkillsPage() {
       {skillsQuery.error ? (
         <Card>
           <CardContent className={styles.errorContent}>
-            Couldn&apos;t load Skills. Confirm the backend skills endpoints are
-            deployed.
+            Couldn&apos;t load skills. Check the backend endpoint.
           </CardContent>
         </Card>
       ) : null}
@@ -380,7 +367,7 @@ export function SkillsPage() {
               Skill Library
             </CardTitle>
             <CardDescription>
-              Generated skills and the memories that produced them.
+              Generated snippets from captured work.
             </CardDescription>
           </CardHeader>
           <CardContent className={styles.listContent}>
@@ -391,8 +378,7 @@ export function SkillsPage() {
                 <Sparkles className={styles.emptyIcon} />
                 <p>No generated skills yet.</p>
                 <span>
-                  Generate skills from Topics, Cases, or ContextPacks, or turn
-                  on demo mode to browse examples.
+                  Turn on demo mode or generate one from a Topic or Case.
                 </span>
               </div>
             ) : (

--- a/src/components/Topics/TopicsPage.tsx
+++ b/src/components/Topics/TopicsPage.tsx
@@ -237,9 +237,9 @@ function TopicContextIntelligence({
     <div className={styles.section} data-testid="topic-context-intelligence">
       <div className={styles.sectionHeader}>
         <div>
-          <div className={styles.sectionTitle}>Context intelligence</div>
+          <div className={styles.sectionTitle}>Topic notes</div>
           <p className={styles.sectionIntro}>
-            Durable Topic memory used to shape future Context Packs.
+            Promoted notes and signals for future briefings.
           </p>
         </div>
         <div className={styles.contextMeta}>
@@ -258,7 +258,7 @@ function TopicContextIntelligence({
       ) : (
         <div className={styles.contextPackStack}>
           <div className={styles.contextPanel}>
-            <div className={styles.signalTitle}>Briefing seed</div>
+            <div className={styles.signalTitle}>Briefing note</div>
             <p className={styles.mutedText}>
               {topic.rollup_summary || "No rollup summary yet."}
             </p>
@@ -296,7 +296,7 @@ function TopicContextIntelligence({
           </div>
 
           <div className={styles.contextPanel}>
-            <div className={styles.signalTitle}>Canonical signals</div>
+            <div className={styles.signalTitle}>Saved signals</div>
             <div className={styles.signalGroups}>
               <div>
                 <div className={styles.signalTitle}>Files</div>
@@ -856,7 +856,7 @@ export function TopicsPage({
 
         <div className={styles.summaryMeta}>
           <div>
-            <div className={styles.sectionTitle}>Rollup summary</div>
+            <div className={styles.sectionTitle}>Summary</div>
             <p className={styles.mutedText}>
               {selectedTopic?.rollup_summary || "No rollup summary yet."}
             </p>

--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -390,7 +390,7 @@ const ConnectAgent = () => {
             Connect agent
           </CardTitle>
           <p className={styles.mutedText}>
-            Generate an MCP token to get your agent connected to EnderAI.
+            Token and config snippets for local MCP testing.
           </p>
         </CardHeader>
         <CardContent className={styles.cardContent}>
@@ -431,7 +431,7 @@ const ConnectAgent = () => {
             </div>
 
             <div className={styles.benefitCard}>
-              <h3 className={styles.sectionTitle}>What this page gives you</h3>
+              <h3 className={styles.sectionTitle}>Setup bits</h3>
               <ul className={styles.benefitList}>
                 <li className={styles.benefitItem}>
                   <CheckCircle2
@@ -440,7 +440,7 @@ const ConnectAgent = () => {
                       styles.benefitIconSuccess,
                     )}
                   />
-                  MCP token for EnderAI.
+                  MCP token.
                 </li>
                 <li className={styles.benefitItem}>
                   <Shield
@@ -467,7 +467,7 @@ const ConnectAgent = () => {
                       styles.benefitIconPrimary,
                     )}
                   />
-                  Agent workflow reminder.
+                  Agent instruction snippet.
                 </li>
               </ul>
             </div>
@@ -502,8 +502,8 @@ const ConnectAgent = () => {
 
                 <TabsContent value="ai-assisted" className={styles.setupTab}>
                   <SnippetBlock
-                    title="Leverage AI to complete setup"
-                    description="Pass the following instructions to your AI of choice to help you complete setup."
+                    title="Ask an agent to wire it up"
+                    description="Paste this into the agent doing setup."
                     snippet={aiAssistedSetupSnippet ?? ""}
                     copiedText={copiedText}
                     onCopy={(value) => {
@@ -515,8 +515,8 @@ const ConnectAgent = () => {
 
                 <TabsContent value="manual" className={styles.setupTab}>
                   <SnippetBlock
-                    title="Persist the token across new terminals"
-                    description="Stores the token locally so AI clients can launch with EnderAI connected."
+                    title="Persist token"
+                    description="Writes the token to a local shell file."
                     snippet={persistentShellSnippet}
                     copiedText={copiedText}
                     onCopy={(value) => {
@@ -527,7 +527,7 @@ const ConnectAgent = () => {
 
                   <SnippetBlock
                     title="MCP client config"
-                    description="Add this block to your AI client's MCP config file."
+                    description="Add this block to your AI client's MCP config."
                     snippet={clientSnippet}
                     copiedText={copiedText}
                     onCopy={(value) => {
@@ -538,7 +538,7 @@ const ConnectAgent = () => {
 
                   <SnippetBlock
                     title="Minimal agent instruction"
-                    description="Add this to your AI workflow's instruction file to start using EnderAI."
+                    description="Smallest instruction block for testing EnderAI."
                     snippet={agentInstructionSnippet}
                     copiedText={copiedText}
                     onCopy={(value) => {
@@ -565,8 +565,8 @@ const ConnectAgent = () => {
               <KeyRound className={styles.icon} />
               <AlertTitle>Create your first agent credential</AlertTitle>
               <AlertDescription>
-                Once you create a credential, this page will generate the token,
-                MCP config, and workflow snippet you need.
+                Create a credential to generate the token, MCP config, and
+                instruction snippet.
               </AlertDescription>
             </Alert>
           )}

--- a/src/routes/_layout/settings.tsx
+++ b/src/routes/_layout/settings.tsx
@@ -59,10 +59,8 @@ function UserSettings() {
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden">
       <div className="shrink-0">
-        <h1 className="text-2xl font-bold tracking-tight">User Settings</h1>
-        <p className="text-muted-foreground">
-          Manage your account settings and preferences
-        </p>
+        <h1 className="text-2xl font-bold tracking-tight">Settings</h1>
+        <p className="text-muted-foreground">Account and local setup.</p>
       </div>
 
       <Tabs

--- a/tests/home-docs.spec.ts
+++ b/tests/home-docs.spec.ts
@@ -38,20 +38,20 @@ test("Home page explains EnderAI and the domain memory model", async ({
 
   await expect(
     page.getByText(
-      "EnderAI turns scattered company knowledge into executable context.",
+      "EnderAI turns messy team history into context agents can actually use.",
     ),
   ).toBeVisible()
   await expect(page.getByText("Welcome back, Alex")).toBeVisible()
   await expect(
     page.getByText(
-      "Every company runs on domain knowledge spread across people, tickets, code, docs, Slack, support history, databases, and past decisions.",
+      "Work leaves useful traces in tickets, pull requests, docs, Slack threads, incidents, support notes, commands, and one-off decisions.",
     ),
   ).toBeVisible()
   await expect(
-    page.getByText("The bottleneck is company context"),
+    page.getByText("The missing part is the local story"),
   ).toBeVisible()
   await expect(
-    page.getByText("Company knowledge becomes structured and actionable"),
+    page.getByText("Keep the useful parts of past work"),
   ).toBeVisible()
   await expect(
     page.getByText(
@@ -70,12 +70,12 @@ test("Home page explains EnderAI and the domain memory model", async ({
   await expect(page.getByText("ContextPacks")).toHaveCount(0)
   await expect(
     page.getByText(
-      "Context Packs are the synthesized briefings EnderAI builds before a human or agent starts work.",
+      "Context Packs are the briefings EnderAI assembles before work starts.",
     ),
   ).toBeVisible()
   await expect(
     page.getByText(
-      "Give agents the domain context needed to act safely and consistently.",
+      "Give agents enough background to stop guessing from scratch.",
     ),
   ).toBeVisible()
   await expect(page.getByText("Search and demo mode")).toHaveCount(0)
@@ -98,10 +98,10 @@ test("Landing page is public and points inaccessible actions to auth", async ({
 
   await expect(
     page.getByText(
-      "EnderAI turns scattered company knowledge into executable context.",
+      "EnderAI turns messy team history into context agents can actually use.",
     ),
   ).toBeVisible()
-  await expect(page.getByText("Build operational memory").first()).toBeVisible()
+  await expect(page.getByText("Try the demo").first()).toBeVisible()
   await expect(page.getByText("See how it works")).toBeVisible()
   await expect(
     page.getByRole("link", { name: "Log in", exact: true }),
@@ -125,8 +125,6 @@ test("Connect agent CTA opens the settings tab directly", async ({ page }) => {
     page.getByRole("tab", { name: "Connect agent" }),
   ).toHaveAttribute("aria-selected", "true")
   await expect(
-    page.getByText(
-      "Generate an MCP token to get your agent connected to EnderAI.",
-    ),
+    page.getByText("Token and config snippets for local MCP testing."),
   ).toBeVisible()
 })

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -47,7 +47,7 @@ test("Log in with valid email and password ", async ({ page }) => {
 
   await expect(
     page.getByText(
-      "EnderAI turns scattered company knowledge into executable context.",
+      "EnderAI turns messy team history into context agents can actually use.",
     ),
   ).toBeVisible()
 })
@@ -98,7 +98,7 @@ test("Successful log out", async ({ page }) => {
 
   await expect(
     page.getByText(
-      "EnderAI turns scattered company knowledge into executable context.",
+      "EnderAI turns messy team history into context agents can actually use.",
     ),
   ).toBeVisible()
 
@@ -117,7 +117,7 @@ test("Logged-out user cannot access protected routes", async ({ page }) => {
 
   await expect(
     page.getByText(
-      "EnderAI turns scattered company knowledge into executable context.",
+      "EnderAI turns messy team history into context agents can actually use.",
     ),
   ).toBeVisible()
 

--- a/tests/topics-cases-ui.spec.ts
+++ b/tests/topics-cases-ui.spec.ts
@@ -405,10 +405,10 @@ test("Topics page matches the primary pane width and truncates long left-table t
   await expect(topicStatusTrigger).toContainText("Closed")
 
   await expect(page.getByTestId("topic-context-intelligence")).toContainText(
-    "Context intelligence",
+    "Topic notes",
   )
   await expect(page.getByTestId("topic-context-intelligence")).toContainText(
-    "Durable Topic memory used to shape future Context Packs.",
+    "Promoted notes and signals for future briefings.",
   )
   await expect(
     page.getByText("Prefer server precedence for tombstones."),
@@ -606,7 +606,7 @@ test("Cases page truncates long table text and normalizes file chips", async ({
   const contextPack = page.getByTestId("case-context-pack")
   await expect(contextPack).toContainText("Context Pack")
   await expect(contextPack).toContainText(
-    "Agent briefing captured when this Case started.",
+    "Briefing captured when this Case started.",
   )
   await expect(contextPack).toContainText("high confidence")
   await expect(contextPack).toContainText("v1")

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -383,9 +383,7 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   await expect(page.getByLabel("Credential label")).toHaveValue("EnderAI token")
   await expect(page.getByText("Revoked install")).toHaveCount(0)
   await expect(
-    page.getByText(
-      "Generate an MCP token to get your agent connected to EnderAI.",
-    ),
+    page.getByText("Token and config snippets for local MCP testing."),
   ).toBeVisible()
   await expect(page.getByText("Hosted MCP URL")).toHaveCount(0)
   await expect(
@@ -408,11 +406,9 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
     page.getByRole("tab", { name: "AI assisted setup" }),
   ).toHaveAttribute("aria-selected", "true")
   await expect(page.getByRole("tab", { name: "Manual setup" })).toBeVisible()
-  await expect(page.getByText("Leverage AI to complete setup")).toBeVisible()
+  await expect(page.getByText("Ask an agent to wire it up")).toBeVisible()
   await expect(
-    page.getByText(
-      "Pass the following instructions to your AI of choice to help you complete setup.",
-    ),
+    page.getByText("Paste this into the agent doing setup."),
   ).toBeVisible()
   await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
     "# Persist the token",
@@ -443,9 +439,7 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   )
 
   await page.getByRole("tab", { name: "Manual setup" }).click()
-  await expect(
-    page.getByText("Persist the token across new terminals"),
-  ).toBeVisible()
+  await expect(page.getByText("Persist token")).toBeVisible()
   await expect(
     page.getByTestId("connect-agent-persistent-shell"),
   ).toContainText("mcp-token-abc")
@@ -471,14 +465,12 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
     'bearer_token_env_var = "ENDERAI_MCP_TOKEN"',
   )
   await expect(
-    page.getByText("Add this block to your AI client's MCP config file."),
+    page.getByText("Add this block to your AI client's MCP config."),
   ).toBeVisible()
   await expect(page.getByTestId("connect-agent-config")).not.toContainText(
     "X-EnderAI-Backend-Token",
   )
-  const persistStepTop = await page
-    .getByText("Persist the token across new terminals")
-    .boundingBox()
+  const persistStepTop = await page.getByText("Persist token").boundingBox()
   const configStepTop = await page.getByText("MCP client config").boundingBox()
   expect(persistStepTop?.y).toBeLessThan(configStepTop?.y ?? 0)
   await expect(page.getByText("Reconnect AI client")).toBeVisible()
@@ -520,9 +512,7 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   await page.reload()
   await page.getByRole("tab", { name: "Connect agent" }).click()
 
-  await expect(
-    page.getByText("Persist the token across new terminals"),
-  ).toHaveCount(0)
+  await expect(page.getByText("Persist token")).toHaveCount(0)
   await expect(
     page.getByText('export ENDERAI_MCP_TOKEN="PASTE_MCP_TOKEN_HERE"'),
   ).toHaveCount(0)
@@ -541,7 +531,7 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   )
   await expect(page.getByTestId("connect-agent-instructions")).toHaveCount(0)
   await expect(page.getByText("Minimal agent instruction")).toHaveCount(0)
-  await expect(page.getByText("Leverage AI to complete setup")).toHaveCount(0)
+  await expect(page.getByText("Ask an agent to wire it up")).toHaveCount(0)
   await expect(page.getByText("enderai_finish_case")).toHaveCount(0)
   await expect(page.getByText("enderai_begin_case")).toHaveCount(0)
   await expect(page.getByText("# Add agent instruction")).toHaveCount(0)

--- a/tests/utils/user.ts
+++ b/tests/utils/user.ts
@@ -25,7 +25,7 @@ export async function logInUser(page: Page, email: string, password: string) {
   await page.waitForURL("/home")
   await expect(
     page.getByText(
-      "EnderAI turns scattered company knowledge into executable context.",
+      "EnderAI turns messy team history into context agents can actually use.",
     ),
   ).toBeVisible()
 }


### PR DESCRIPTION
## Summary

- Rewrites the home/landing positioning to be more original and less close to the YC Company Brain prompt.
- Tightens app-page copy across Topics, Cases, Skills, and Settings so usage screens feel more like a compact demo workspace than a polished marketing surface.
- Removes user-facing provenance/workflow-key wording from the Skills details panel and updates affected Playwright expectations.

## Validation

- `npm run lint`
- `npm run build` (passes; Vite warns that local Node 18.19.1 is below the preferred Node 20.19+ range)
- `FIRST_SUPERUSER=frontend-test@example.com FIRST_SUPERUSER_PASSWORD=frontend-test-password npx playwright test home-docs.spec.ts topics-cases-ui.spec.ts user-settings.spec.ts --project=chromium --no-deps --grep "Home page|Landing page|Connect agent CTA|Topics page|Cases page|Connect agent generates"` (5 passed, 1 blocked by missing storage state)
- Created temporary empty `playwright/.auth/user.json`, then `FIRST_SUPERUSER=frontend-test@example.com FIRST_SUPERUSER_PASSWORD=frontend-test-password npx playwright test user-settings.spec.ts --project=chromium --no-deps --grep "Connect agent generates"` (1 passed)