### PR TITLE
[codex] Add user last seen column

### DIFF
--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -62,6 +62,7 @@ export type UserPublic = {
     full_name?: (string | null);
     id: string;
     created_at?: (string | null);
+    last_seen_at?: (string | null);
 };
 
 export type UserRegister = {

--- a/src/components/Admin/columns.tsx
+++ b/src/components/Admin/columns.tsx
@@ -9,6 +9,18 @@ export type UserTableData = UserPublic & {
   isCurrentUser: boolean
 }
 
+function formatLastSeen(value: string | null | undefined): string {
+  if (!value) return "Never"
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return "Unknown"
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date)
+}
+
 export const columns: ColumnDef<UserTableData>[] = [
   {
     accessorKey: "full_name",
@@ -62,6 +74,21 @@ export const columns: ColumnDef<UserTableData>[] = [
           {row.original.is_active ? "Active" : "Inactive"}
         </span>
       </div>
+    ),
+  },
+  {
+    accessorKey: "last_seen_at",
+    header: "Last Seen",
+    cell: ({ row }) => (
+      <span
+        className={cn(
+          "text-sm",
+          !row.original.last_seen_at && "text-muted-foreground",
+        )}
+        title={row.original.last_seen_at ?? undefined}
+      >
+        {formatLastSeen(row.original.last_seen_at)}
+      </span>
     ),
   },
   {

--- a/src/components/Pending/PendingUsers.tsx
+++ b/src/components/Pending/PendingUsers.tsx
@@ -16,6 +16,7 @@ const PendingUsers = () => (
         <TableHead>Email</TableHead>
         <TableHead>Role</TableHead>
         <TableHead>Status</TableHead>
+        <TableHead>Last Seen</TableHead>
         <TableHead>
           <span className="sr-only">Actions</span>
         </TableHead>
@@ -38,6 +39,9 @@ const PendingUsers = () => (
               <Skeleton className="size-2 rounded-full" />
               <Skeleton className="h-4 w-12" />
             </div>
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-28" />
           </TableCell>
           <TableCell>
             <div className="flex justify-end">


### PR DESCRIPTION
## Summary

- Adds `last_seen_at` to the generated `UserPublic` frontend type.
- Adds a `Last Seen` column to the Admin Users table.
- Keeps the loading skeleton aligned with the new table column.

## Validation

- `npx biome check --no-errors-on-unmatched --files-ignore-unknown=true src/client/types.gen.ts src/components/Admin/columns.tsx src/components/Pending/PendingUsers.tsx`
- `npm run build` (passes; Vite warns that local Node 18.19.1 is below the preferred Node 20.19+ range)

## Dependency

- Depends on backend PR al-exe/EnderAI#32 exposing and updating `last_seen_at`.