### PR TITLE
[codex] Show skills in global search

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -4,24 +4,27 @@ import { request } from "@/client/core/request"
 export interface SearchRouteSearch {
   topicId?: string | null
   caseId?: string | null
+  skillId?: string | null
 }
 
 export interface SearchHitPublic {
-  kind: "topic" | "case"
+  kind: "topic" | "case" | "skill"
   id: string
   title: string
   subtitle: string | null
   excerpt: string | null
   updated_at: string | null
-  route: "/topics" | "/cases"
+  route: "/topics" | "/cases" | "/skills"
   route_search: SearchRouteSearch
 }
 
 export interface SearchResultsPublic {
   topics: SearchHitPublic[]
   cases: SearchHitPublic[]
+  skills: SearchHitPublic[]
   topic_count: number
   case_count: number
+  skill_count: number
 }
 
 export function readGlobalSearch(

--- a/src/components/Home/HomePage.module.css
+++ b/src/components/Home/HomePage.module.css
@@ -83,7 +83,7 @@
 }
 
 .heroTitle {
-  @apply max-w-4xl text-4xl font-semibold text-foreground md:text-6xl;
+  @apply max-w-4xl text-[1.8rem] font-semibold text-foreground md:text-5xl;
 }
 
 .heroDescription {

--- a/src/components/Home/HomePage.tsx
+++ b/src/components/Home/HomePage.tsx
@@ -55,8 +55,8 @@ export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
                     : `Welcome back, ${displayName}`}
                 </p>
                 <h1 className={styles.heroTitle}>
-                  EnderAI turns the collective knowledge of the company into a
-                  reusable workflows for humans and AI to leverage.
+                  EnderAI turns the collective knowledge of your company into
+                  reusable workflows for humans and AI.
                 </h1>
                 <p className={styles.heroDescription}>
                   Knowledge that matters is scattered across support tickets,

--- a/src/components/Search/GlobalSearchBar.tsx
+++ b/src/components/Search/GlobalSearchBar.tsx
@@ -15,7 +15,7 @@ const LIMIT_PER_KIND = 5
 const DEBOUNCE_MS = 200
 
 type SearchEntry = {
-  group: "Topics" | "Cases"
+  group: "Topics" | "Cases" | "Skills"
   hit: SearchHitPublic
 }
 
@@ -78,8 +78,12 @@ export function GlobalSearchBar() {
       group: "Cases" as const,
       hit,
     }))
+    const skills = (searchQuery.data?.skills ?? []).map((hit) => ({
+      group: "Skills" as const,
+      hit,
+    }))
 
-    return [...topics, ...cases]
+    return [...topics, ...cases, ...skills]
   }, [searchQuery.data])
 
   useEffect(() => {
@@ -104,6 +108,16 @@ export function GlobalSearchBar() {
         to: "/topics",
         search: {
           topicId: hit.route_search.topicId ?? hit.id,
+        },
+      })
+      return
+    }
+
+    if (hit.kind === "skill") {
+      void navigate({
+        to: "/skills",
+        search: {
+          skillId: hit.route_search.skillId ?? hit.id,
         },
       })
       return
@@ -152,7 +166,7 @@ export function GlobalSearchBar() {
   }
 
   const renderGroup = (
-    title: "Topics" | "Cases",
+    title: "Topics" | "Cases" | "Skills",
     results: SearchHitPublic[],
     startIndex: number,
   ) => {
@@ -201,6 +215,7 @@ export function GlobalSearchBar() {
 
   const topicResults = searchQuery.data?.topics ?? []
   const caseResults = searchQuery.data?.cases ?? []
+  const skillResults = searchQuery.data?.skills ?? []
 
   return (
     <div
@@ -212,7 +227,7 @@ export function GlobalSearchBar() {
         <SearchIcon className={styles.searchIcon} />
         <Input
           value={query}
-          placeholder="Search Topics and Cases"
+          placeholder="Search Topics, Cases, and Skills"
           className={styles.input}
           data-testid="global-search-input"
           onFocus={() => setIsFocused(true)}
@@ -226,13 +241,22 @@ export function GlobalSearchBar() {
         <Card className={styles.resultsCard}>
           <CardContent className={styles.resultsContent}>
             {searchQuery.isFetching ? (
-              <div className={styles.status}>Searching Topics and Cases…</div>
+              <div className={styles.status}>
+                Searching Topics, Cases, and Skills…
+              </div>
             ) : entries.length === 0 ? (
-              <div className={styles.status}>No Topics or Cases matched.</div>
+              <div className={styles.status}>
+                No Topics, Cases, or Skills matched.
+              </div>
             ) : (
               <div>
                 {renderGroup("Topics", topicResults, 0)}
                 {renderGroup("Cases", caseResults, topicResults.length)}
+                {renderGroup(
+                  "Skills",
+                  skillResults,
+                  topicResults.length + caseResults.length,
+                )}
               </div>
             )}
           </CardContent>

--- a/src/components/Skills/SkillsPage.tsx
+++ b/src/components/Skills/SkillsPage.tsx
@@ -288,10 +288,16 @@ function SkillDetail({ skill }: { skill: SkillPublic | null }) {
   )
 }
 
-export function SkillsPage() {
+export function SkillsPage({
+  initialSelectedSkillId = null,
+}: {
+  initialSelectedSkillId?: string | null
+}) {
   const { isDemoMode } = useDemoMode()
   const [query, setQuery] = useState("")
-  const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null)
+  const [selectedSkillId, setSelectedSkillId] = useState<string | null>(
+    initialSelectedSkillId,
+  )
 
   const skillsQuery = useQuery({
     queryKey: ["skills", { demo: isDemoMode, query }],
@@ -300,17 +306,31 @@ export function SkillsPage() {
 
   const skills = skillsQuery.data?.data ?? []
   const selectedSkill =
-    skills.find((skill) => skill.id === selectedSkillId) ?? skills[0] ?? null
+    (selectedSkillId
+      ? skills.find((skill) => skill.id === selectedSkillId)
+      : skills[0]) ?? null
 
   useEffect(() => {
-    if (!selectedSkill) {
+    setSelectedSkillId(initialSelectedSkillId)
+  }, [initialSelectedSkillId])
+
+  useEffect(() => {
+    if (skillsQuery.isLoading) return
+
+    if (skills.length === 0) {
       setSelectedSkillId(null)
       return
     }
-    if (selectedSkill.id !== selectedSkillId) {
-      setSelectedSkillId(selectedSkill.id)
+
+    if (
+      selectedSkillId &&
+      skills.some((skill) => skill.id === selectedSkillId)
+    ) {
+      return
     }
-  }, [selectedSkill, selectedSkillId])
+
+    setSelectedSkillId(skills[0].id)
+  }, [selectedSkillId, skills, skillsQuery.isLoading])
 
   return (
     <div className={styles.page}>
@@ -322,11 +342,8 @@ export function SkillsPage() {
               Skills
             </div>
             <CardTitle className={styles.heroTitle}>
-              Generated instructions
+              🛠️ Generated Skills
             </CardTitle>
-            <CardDescription className={styles.heroDescription}>
-              Draft snippets pulled from Topics, Cases, and Context Packs.
-            </CardDescription>
           </div>
           <div className={styles.heroBadges}>
             <Badge variant="secondary">
@@ -366,9 +383,6 @@ export function SkillsPage() {
               <Boxes className={styles.icon} />
               Skill Library
             </CardTitle>
-            <CardDescription>
-              Generated snippets from captured work.
-            </CardDescription>
           </CardHeader>
           <CardContent className={styles.listContent}>
             {skillsQuery.isLoading ? (

--- a/src/routes/_layout/skills.tsx
+++ b/src/routes/_layout/skills.tsx
@@ -1,9 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
 
 import { SkillsPage } from "@/components/Skills/SkillsPage"
 
+const searchSchema = z.object({
+  skillId: z.string().optional(),
+})
+
 export const Route = createFileRoute("/_layout/skills")({
   component: Skills,
+  validateSearch: searchSchema,
   head: () => ({
     meta: [
       {
@@ -14,5 +20,7 @@ export const Route = createFileRoute("/_layout/skills")({
 })
 
 function Skills() {
-  return <SkillsPage />
+  const { skillId } = Route.useSearch()
+
+  return <SkillsPage initialSelectedSkillId={skillId ?? null} />
 }


### PR DESCRIPTION
## What changed

Wires generated Skills into the global search dropdown and selection flow.

- Updates the global search client type to include Skills
- Adds a Skills group to the header dropdown
- Navigates selected Skill hits to `/skills?skillId=...`
- Lets the Skills page initialize from `skillId` search params
- Includes the requested Skills page label cleanup and homepage hero copy/size update

## Validation

- `npm run build` passed
- Vite emitted the existing local Node warning: this shell uses Node `18.19.1`, while Vite recommends `20.19+` or `22.12+`
