### PR TITLE
[codex] Clean up Skills page UI

### DIFF
--- a/src/components/Skills/SkillsPage.module.css
+++ b/src/components/Skills/SkillsPage.module.css
@@ -28,22 +28,6 @@
   @apply flex flex-wrap gap-2;
 }
 
-.toolbar {
-  @apply shrink-0;
-}
-
-.searchBox {
-  @apply relative max-w-2xl;
-}
-
-.searchIcon {
-  @apply pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground;
-}
-
-.searchInput {
-  @apply pl-9;
-}
-
 .layout {
   @apply grid min-h-0 flex-1 gap-5 overflow-hidden;
 }
@@ -69,7 +53,7 @@
 }
 
 .skillCardSelected {
-  @apply border-emerald-500 bg-emerald-50/70 dark:bg-emerald-950/20;
+  @apply border-emerald-500 shadow-[inset_3px_0_0_rgb(16_185_129)];
 }
 
 .skillCardHeader {

--- a/src/components/Skills/SkillsPage.tsx
+++ b/src/components/Skills/SkillsPage.tsx
@@ -20,7 +20,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { cn } from "@/lib/utils"
 import styles from "./SkillsPage.module.css"
@@ -294,14 +293,13 @@ export function SkillsPage({
   initialSelectedSkillId?: string | null
 }) {
   const { isDemoMode } = useDemoMode()
-  const [query, setQuery] = useState("")
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(
     initialSelectedSkillId,
   )
 
   const skillsQuery = useQuery({
-    queryKey: ["skills", { demo: isDemoMode, query }],
-    queryFn: () => readSkills({ demo: isDemoMode, q: query, limit: 100 }),
+    queryKey: ["skills", { demo: isDemoMode }],
+    queryFn: () => readSkills({ demo: isDemoMode, limit: 100 }),
   })
 
   const skills = skillsQuery.data?.data ?? []
@@ -341,9 +339,6 @@ export function SkillsPage({
               <Sparkles className={styles.icon} />
               Skills
             </div>
-            <CardTitle className={styles.heroTitle}>
-              🛠️ Generated Skills
-            </CardTitle>
           </div>
           <div className={styles.heroBadges}>
             <Badge variant="secondary">
@@ -355,18 +350,6 @@ export function SkillsPage({
           </div>
         </CardHeader>
       </Card>
-
-      <div className={styles.toolbar}>
-        <div className={styles.searchBox}>
-          <Search className={styles.searchIcon} />
-          <Input
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search skills"
-            className={styles.searchInput}
-          />
-        </div>
-      </div>
 
       {skillsQuery.error ? (
         <Card>


### PR DESCRIPTION
## Summary

- Removes the `🛠️ Generated Skills` hero title from the Skills page.
- Removes the dedicated Skills-page search bar now that global search covers Skills.
- Replaces the selected Skill card background tint with an inset accent so dark mode remains readable.

## Validation

- `npm run build`
- `git diff --check`
- `rg -n "Generated Skills|🛠️|Search skills|Generated snippets|Draft snippets|Generated instructions" src` returned no matches

Note: `npm run build` completed successfully while printing the existing Vite warning that Node 18.19.1 is below Vite's recommended Node 20.19+ or 22.12+.