### PR TITLE
[codex] Remove Skills page header bar

### DIFF
--- a/src/components/Skills/SkillsPage.module.css
+++ b/src/components/Skills/SkillsPage.module.css
@@ -4,30 +4,6 @@
   @apply flex min-h-0 flex-1 flex-col gap-5 overflow-hidden;
 }
 
-.heroCard {
-  @apply shrink-0 overflow-hidden border-0 bg-[linear-gradient(135deg,hsl(var(--card))_0%,hsl(var(--muted))_52%,rgba(16,185,129,0.12)_100%)] shadow-sm;
-}
-
-.heroHeader {
-  @apply flex flex-wrap items-start justify-between gap-4;
-}
-
-.eyebrow {
-  @apply mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.22em] text-emerald-700 dark:text-emerald-300;
-}
-
-.heroTitle {
-  @apply text-2xl;
-}
-
-.heroDescription {
-  @apply max-w-3xl;
-}
-
-.heroBadges {
-  @apply flex flex-wrap gap-2;
-}
-
 .layout {
   @apply grid min-h-0 flex-1 gap-5 overflow-hidden;
 }

--- a/src/components/Skills/SkillsPage.tsx
+++ b/src/components/Skills/SkillsPage.tsx
@@ -332,25 +332,6 @@ export function SkillsPage({
 
   return (
     <div className={styles.page}>
-      <Card className={styles.heroCard}>
-        <CardHeader className={styles.heroHeader}>
-          <div>
-            <div className={styles.eyebrow}>
-              <Sparkles className={styles.icon} />
-              Skills
-            </div>
-          </div>
-          <div className={styles.heroBadges}>
-            <Badge variant="secondary">
-              {isDemoMode ? "Demo mode" : "Live"}
-            </Badge>
-            <Badge variant="outline">
-              {skillsQuery.data?.count ?? 0} skills
-            </Badge>
-          </div>
-        </CardHeader>
-      </Card>
-
       {skillsQuery.error ? (
         <Card>
           <CardContent className={styles.errorContent}>


### PR DESCRIPTION
## Summary

- Removes the Skills-page hero/header bar that showed `Skills`, `Demo mode`, and the total skill count.
- Deletes the now-unused header styles while keeping the existing Skills list and detail layout intact.

## Validation

- `npm run build`
- `git diff --check`
- `rg -n "Skills\s*$|Demo mode|[0-9]+ skills" src/components/Skills/SkillsPage.tsx` returned no matches

Note: `npm run build` completed successfully while printing the existing Vite warning that Node 18.19.1 is below Vite's recommended Node 20.19+ or 22.12+.