### PR TITLE
Add Google sign-in button

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,8 +2,10 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import {
   createUserWithEmailAndPassword,
+  GoogleAuthProvider,
   sendEmailVerification,
   signInWithEmailAndPassword,
+  signInWithPopup,
   signOut,
   updateProfile,
 } from "firebase/auth"
@@ -21,6 +23,9 @@ import useCustomToast from "./useCustomToast"
 const isLoggedIn = () => {
   return localStorage.getItem("access_token") !== null
 }
+
+const googleProvider = new GoogleAuthProvider()
+googleProvider.setCustomParameters({ prompt: "select_account" })
 
 const useAuth = () => {
   const navigate = useNavigate()
@@ -91,6 +96,27 @@ const useAuth = () => {
     },
   })
 
+  const googleSignInMutation = useMutation({
+    mutationFn: async () => {
+      const credential = await signInWithPopup(firebaseAuth, googleProvider)
+      const idToken = await credential.user.getIdToken()
+      const response = await exchangeFirebaseToken({
+        id_token: idToken,
+        full_name: credential.user.displayName,
+      })
+      localStorage.setItem("access_token", response.access_token)
+    },
+    onSuccess: () => {
+      navigate({ to: "/home" })
+    },
+    onError: (error) => {
+      showErrorToast(getAuthErrorMessage(error))
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["users"] })
+    },
+  })
+
   const logout = () => {
     void signOut(firebaseAuth)
     localStorage.removeItem("access_token")
@@ -100,6 +126,7 @@ const useAuth = () => {
   return {
     signUpMutation,
     loginMutation,
+    googleSignInMutation,
     logout,
     user,
   }

--- a/src/lib/firebase-errors.ts
+++ b/src/lib/firebase-errors.ts
@@ -4,6 +4,8 @@ import { ApiError } from "@/client"
 const firebaseAuthMessages: Record<string, string> = {
   "auth/email-already-in-use": "An account already exists for this email.",
   "auth/invalid-credential": "Incorrect email or password",
+  "auth/popup-blocked": "Allow popups for this site, then try again.",
+  "auth/popup-closed-by-user": "Google sign-in was cancelled.",
   "auth/requires-recent-login": "Log in again before changing your password.",
   "auth/too-many-requests": "Too many attempts. Try again later.",
   "auth/user-disabled": "This account is disabled.",

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -5,6 +5,7 @@ import {
   redirect,
 } from "@tanstack/react-router"
 import { useForm } from "react-hook-form"
+import { FcGoogle } from "react-icons/fc"
 import { z } from "zod"
 
 import type { Body_login_login_access_token as AccessToken } from "@/client"
@@ -51,7 +52,7 @@ export const Route = createFileRoute("/login")({
 })
 
 function Login() {
-  const { loginMutation } = useAuth()
+  const { googleSignInMutation, loginMutation } = useAuth()
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     mode: "onBlur",
@@ -66,6 +67,8 @@ function Login() {
     if (loginMutation.isPending) return
     loginMutation.mutate(data)
   }
+
+  const authPending = loginMutation.isPending || googleSignInMutation.isPending
 
   return (
     <AuthLayout>
@@ -126,6 +129,23 @@ function Login() {
 
             <LoadingButton type="submit" loading={loginMutation.isPending}>
               Log In
+            </LoadingButton>
+
+            <div className="relative flex items-center py-1">
+              <div className="flex-grow border-t border-border" />
+              <span className="mx-3 text-xs text-muted-foreground">or</span>
+              <div className="flex-grow border-t border-border" />
+            </div>
+
+            <LoadingButton
+              type="button"
+              variant="outline"
+              loading={googleSignInMutation.isPending}
+              disabled={authPending}
+              onClick={() => googleSignInMutation.mutate()}
+            >
+              <FcGoogle />
+              Continue with Google
             </LoadingButton>
           </div>
 

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -5,6 +5,7 @@ import {
   redirect,
 } from "@tanstack/react-router"
 import { useForm } from "react-hook-form"
+import { FcGoogle } from "react-icons/fc"
 import { z } from "zod"
 import { AuthLayout } from "@/components/Common/AuthLayout"
 import {
@@ -58,7 +59,7 @@ export const Route = createFileRoute("/signup")({
 })
 
 function SignUp() {
-  const { signUpMutation } = useAuth()
+  const { googleSignInMutation, signUpMutation } = useAuth()
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     mode: "onBlur",
@@ -78,6 +79,8 @@ function SignUp() {
     const { confirm_password: _confirm_password, ...submitData } = data
     signUpMutation.mutate(submitData)
   }
+
+  const authPending = signUpMutation.isPending || googleSignInMutation.isPending
 
   return (
     <AuthLayout>
@@ -169,8 +172,27 @@ function SignUp() {
               type="submit"
               className="w-full"
               loading={signUpMutation.isPending}
+              disabled={authPending}
             >
               Sign Up
+            </LoadingButton>
+
+            <div className="relative flex items-center py-1">
+              <div className="flex-grow border-t border-border" />
+              <span className="mx-3 text-xs text-muted-foreground">or</span>
+              <div className="flex-grow border-t border-border" />
+            </div>
+
+            <LoadingButton
+              type="button"
+              variant="outline"
+              className="w-full"
+              loading={googleSignInMutation.isPending}
+              disabled={authPending}
+              onClick={() => googleSignInMutation.mutate()}
+            >
+              <FcGoogle />
+              Continue with Google
             </LoadingButton>
           </div>
 


### PR DESCRIPTION
## Summary
- Add a shared Google sign-in mutation using Firebase `GoogleAuthProvider` and popup auth.
- Add `Continue with Google` buttons to login and signup.
- Reuse the existing Firebase ID token -> backend JWT exchange endpoint.
- Add friendly messages for blocked/cancelled popup errors.

## Firebase setup needed
- Enable the Google provider in Firebase Authentication.
- Set the public-facing project name and support email in Firebase as prompted.
- No Android SHA-1 fingerprint is needed for this web app unless an Android app is added later.

## Validation
- `npx biome check --write src/hooks/useAuth.ts src/lib/firebase-errors.ts src/routes/login.tsx src/routes/signup.tsx`
- `npm run build`

## Notes
- Local build completed, with the existing Node 18 vs Vite Node 20 warning.