### PR TITLE
Add v2 document search and widen single-pane document view

### DIFF
--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -1,13 +1,24 @@
 import {
   Outlet,
   Link as RouterLink,
+  useNavigate,
   useRouterState,
 } from "@tanstack/react-router"
 import { BookOpenText, Component, Home, Search, Shield } from "lucide-react"
+import {
+  Fragment,
+  type KeyboardEvent as ReactKeyboardEvent,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 
 import type { UserPublic } from "@/client"
 import { SidebarAppearance } from "@/components/Common/Appearance"
 import { SidebarCollapseToggle } from "@/components/Common/SidebarCollapseToggle"
+import { useDemoMode } from "@/components/demo-mode-provider"
 import { DemoModeToggle, V2ModeSwitch } from "@/components/Sidebar/ModeSwitches"
 import { User } from "@/components/Sidebar/User"
 import { Button } from "@/components/ui/button"
@@ -25,6 +36,8 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar"
+import { cn } from "@/lib/utils"
+import { type V2DemoDocument, v2DemoDocuments } from "@/lib/v2-demo-documents"
 
 type TaskforceShellProps = {
   currentUser: UserPublic
@@ -92,6 +105,293 @@ function TaskforceNav({ currentUser }: TaskforceShellProps) {
   )
 }
 
+type DocumentSearchMatch = {
+  document: V2DemoDocument
+  snippet: string
+}
+
+const MAX_SEARCH_RESULTS = 8
+
+function collectSearchableFields(document: V2DemoDocument): string[] {
+  const bodyText = document.mainBody
+    .map((paragraph) =>
+      paragraph.segments.map((segment) => segment.text).join(""),
+    )
+    .join("\n")
+  const detailsText = document.detailsMarkdownSections
+    .map((section) => section.markdown)
+    .join("\n")
+  return [
+    document.title,
+    document.description,
+    document.humanSummary,
+    document.aiGeneratedSummary,
+    bodyText,
+    detailsText,
+  ]
+}
+
+function extractSnippet(text: string, matchIndex: number, matchLength: number) {
+  const start = Math.max(0, matchIndex - 30)
+  const end = Math.min(text.length, matchIndex + matchLength + 80)
+  let snippet = text.slice(start, end).replace(/\s+/g, " ").trim()
+  if (start > 0) snippet = `…${snippet}`
+  if (end < text.length) snippet = `${snippet}…`
+  return snippet
+}
+
+function findMatch(
+  document: V2DemoDocument,
+  needle: string,
+): DocumentSearchMatch | null {
+  for (const text of collectSearchableFields(document)) {
+    const index = text.toLowerCase().indexOf(needle)
+    if (index !== -1) {
+      const snippet =
+        text === document.title
+          ? document.description
+          : extractSnippet(text, index, needle.length)
+      return { document, snippet }
+    }
+  }
+  return null
+}
+
+function HighlightedText({ text, query }: { text: string; query: string }) {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return <>{text}</>
+
+  const nodes: React.ReactNode[] = []
+  const lower = text.toLowerCase()
+  let cursor = 0
+  let key = 0
+
+  while (cursor < text.length) {
+    const index = lower.indexOf(needle, cursor)
+    if (index === -1) {
+      nodes.push(<Fragment key={key++}>{text.slice(cursor)}</Fragment>)
+      break
+    }
+    if (index > cursor) {
+      nodes.push(<Fragment key={key++}>{text.slice(cursor, index)}</Fragment>)
+    }
+    nodes.push(
+      <mark
+        key={key++}
+        className="rounded-sm bg-yellow-200/80 px-0.5 text-foreground dark:bg-yellow-500/30 dark:text-yellow-50"
+      >
+        {text.slice(index, index + needle.length)}
+      </mark>,
+    )
+    cursor = index + needle.length
+  }
+
+  return <>{nodes}</>
+}
+
+function DocumentSearch() {
+  const { isDemoMode } = useDemoMode()
+  const navigate = useNavigate()
+  const router = useRouterState()
+  const pathname = router.location.pathname
+  const containerRef = useRef<HTMLDivElement>(null)
+  const blurTimeoutRef = useRef<number | null>(null)
+  const lastQueryRef = useRef("")
+  const lastPathnameRef = useRef(pathname)
+  const listboxId = useId()
+
+  const [query, setQuery] = useState("")
+  const [isOpen, setIsOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  const trimmedQuery = query.trim()
+
+  const results = useMemo<DocumentSearchMatch[]>(() => {
+    if (!isDemoMode || !trimmedQuery) return []
+    const needle = trimmedQuery.toLowerCase()
+    const matches: DocumentSearchMatch[] = []
+    for (const document of v2DemoDocuments) {
+      const match = findMatch(document, needle)
+      if (match) {
+        matches.push(match)
+        if (matches.length >= MAX_SEARCH_RESULTS) break
+      }
+    }
+    return matches
+  }, [isDemoMode, trimmedQuery])
+
+  useEffect(() => {
+    if (lastQueryRef.current === trimmedQuery) return
+    lastQueryRef.current = trimmedQuery
+    setActiveIndex(0)
+  }, [trimmedQuery])
+
+  useEffect(() => {
+    if (lastPathnameRef.current === pathname) return
+    lastPathnameRef.current = pathname
+    setQuery("")
+    setIsOpen(false)
+  }, [pathname])
+
+  useEffect(() => {
+    return () => {
+      if (blurTimeoutRef.current !== null) {
+        window.clearTimeout(blurTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const showHint = isOpen && trimmedQuery.length > 0 && !isDemoMode
+  const showResults = isOpen && isDemoMode && trimmedQuery.length > 0
+  const dropdownOpen = showHint || showResults
+  const activeResult = showResults ? results[activeIndex] : undefined
+
+  const openDocument = (documentId: string) => {
+    setQuery("")
+    setIsOpen(false)
+    navigate({
+      to: "/v2/library/$documentId",
+      params: { documentId },
+    })
+  }
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      if (dropdownOpen) {
+        event.preventDefault()
+        setIsOpen(false)
+      }
+      return
+    }
+
+    if (!showResults || results.length === 0) return
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      setActiveIndex((index) => (index + 1) % results.length)
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault()
+      setActiveIndex((index) => (index - 1 + results.length) % results.length)
+    } else if (event.key === "Enter") {
+      const next = results[activeIndex]
+      if (next) {
+        event.preventDefault()
+        openDocument(next.document.id)
+      }
+    }
+  }
+
+  const handleBlur = () => {
+    if (blurTimeoutRef.current !== null) {
+      window.clearTimeout(blurTimeoutRef.current)
+    }
+    blurTimeoutRef.current = window.setTimeout(() => {
+      if (!containerRef.current?.contains(document.activeElement)) {
+        setIsOpen(false)
+      }
+    }, 80)
+  }
+
+  return (
+    <div ref={containerRef} className="relative w-full max-w-2xl">
+      <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        role="combobox"
+        aria-label="Search documents"
+        aria-autocomplete="list"
+        aria-expanded={dropdownOpen}
+        aria-controls={dropdownOpen ? listboxId : undefined}
+        aria-activedescendant={
+          activeResult ? `${listboxId}-option-${activeIndex}` : undefined
+        }
+        className="pl-9"
+        data-testid="v2-document-lookup-input"
+        placeholder="Search documents"
+        value={query}
+        onChange={(event) => {
+          setQuery(event.target.value)
+          setIsOpen(true)
+        }}
+        onFocus={() => {
+          if (blurTimeoutRef.current !== null) {
+            window.clearTimeout(blurTimeoutRef.current)
+            blurTimeoutRef.current = null
+          }
+          setIsOpen(true)
+        }}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+      />
+      {dropdownOpen && (
+        <div
+          id={listboxId}
+          data-testid="v2-document-lookup-results"
+          className="absolute top-full right-0 left-0 z-50 mt-2 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg"
+        >
+          {showHint && (
+            <p
+              data-testid="v2-document-lookup-hint"
+              className="px-4 py-3 text-sm text-muted-foreground"
+            >
+              Turn on demo mode to search documents.
+            </p>
+          )}
+          {showResults && results.length === 0 && (
+            <p
+              data-testid="v2-document-lookup-empty"
+              className="px-4 py-3 text-sm text-muted-foreground"
+            >
+              No documents match "{trimmedQuery}".
+            </p>
+          )}
+          {showResults && results.length > 0 && (
+            <div
+              role="listbox"
+              aria-label="Document search results"
+              className="max-h-[28rem] overflow-y-auto py-1"
+            >
+              {results.map((result, index) => (
+                <button
+                  key={result.document.id}
+                  type="button"
+                  role="option"
+                  id={`${listboxId}-option-${index}`}
+                  data-testid={`v2-document-lookup-result-${result.document.id}`}
+                  aria-selected={index === activeIndex}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onMouseDown={(event) => {
+                    event.preventDefault()
+                  }}
+                  onClick={() => openDocument(result.document.id)}
+                  className={cn(
+                    "flex w-full flex-col gap-1 px-4 py-2.5 text-left transition-colors",
+                    index === activeIndex
+                      ? "bg-accent text-accent-foreground"
+                      : "hover:bg-accent/60",
+                  )}
+                >
+                  <span className="text-sm font-medium leading-5">
+                    <HighlightedText
+                      text={result.document.title}
+                      query={trimmedQuery}
+                    />
+                  </span>
+                  <span className="line-clamp-2 text-xs leading-5 text-muted-foreground">
+                    <HighlightedText
+                      text={result.snippet}
+                      query={trimmedQuery}
+                    />
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function TaskforceShell({ currentUser }: TaskforceShellProps) {
   return (
     <SidebarProvider className="h-svh overflow-hidden">
@@ -114,16 +414,7 @@ export function TaskforceShell({ currentUser }: TaskforceShellProps) {
         <header className="shrink-0 border-b bg-background px-5 md:px-8">
           <div className="flex h-16 items-center gap-3">
             <SidebarTrigger className="md:hidden" />
-            <div className="relative w-full max-w-2xl">
-              <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                aria-label="Search documents"
-                className="pl-9"
-                data-testid="v2-document-lookup-input"
-                placeholder="Search documents"
-                readOnly
-              />
-            </div>
+            <DocumentSearch />
           </div>
         </header>
         <main className="flex min-h-0 flex-1 flex-col overflow-hidden p-6 md:p-8">

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -5,7 +5,10 @@ import { useState } from "react"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
-import { findV2DemoDocument, type V2DemoDocument } from "@/lib/v2-demo-documents"
+import {
+  findV2DemoDocument,
+  type V2DemoDocument,
+} from "@/lib/v2-demo-documents"
 
 export const Route = createFileRoute("/v2/library/$documentId")({
   component: TaskforceDocumentDetail,
@@ -90,7 +93,7 @@ function TaskforceDocumentDetail() {
           "mx-auto flex w-full flex-col transition-[max-width]",
           isSplit
             ? "max-w-6xl md:min-h-0 md:flex-1 md:overflow-hidden"
-            : "max-w-3xl pb-16",
+            : "max-w-none pb-16",
         )}
       >
         <div className={cn(isSplit && "md:shrink-0")}>
@@ -112,9 +115,7 @@ function TaskforceDocumentDetail() {
           <p
             className={cn(
               "text-muted-foreground",
-              isSplit
-                ? "mt-1 text-sm leading-6"
-                : "mt-4 text-base leading-7",
+              isSplit ? "mt-1 text-sm leading-6" : "mt-4 text-base leading-7",
             )}
           >
             {demoDocument.description}

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -89,6 +89,76 @@ test("Taskforce v2 wordmark links to v2 home", async ({ page }) => {
   await expect(page).toHaveURL(/\/v2\/home$/)
 })
 
+test("Taskforce v2 document search filters demo documents and opens results", async ({
+  page,
+}) => {
+  await mockTaskforceAuth(page)
+
+  await page.goto("/v2/home")
+
+  const search = page.getByTestId("v2-document-lookup-input")
+  await expect(search).toBeVisible()
+
+  // Without demo mode, typing prompts the user to enable it.
+  await search.fill("bridge")
+  await expect(page.getByTestId("v2-document-lookup-hint")).toBeVisible()
+  await expect(page.getByTestId("v2-document-lookup-results")).toContainText(
+    "demo mode",
+  )
+
+  // Enabling demo mode replaces the hint with matching documents.
+  await search.fill("")
+  await page.getByTestId("demo-mode-toggle").click()
+  await search.fill("bridge")
+  await expect(
+    page
+      .getByText("Latest Stale Network Bridge Issue", { exact: true })
+      .first(),
+  ).toBeVisible()
+  await expect(
+    page.getByText("Hosted MCP Credential Setup Refresh"),
+  ).toHaveCount(0)
+
+  // Unrelated query produces an empty-state message.
+  await search.fill("zzzzznomatch")
+  await expect(page.getByTestId("v2-document-lookup-empty")).toBeVisible()
+
+  // Enter on the first result navigates to that document.
+  await search.fill("evidence contract")
+  await expect(
+    page.getByTestId(
+      "v2-document-lookup-result-5b7462e9-6b0e-4d48-81a2-07f052534a12",
+    ),
+  ).toBeVisible()
+  await search.press("Enter")
+  await expect(page).toHaveURL(
+    /\/v2\/library\/5b7462e9-6b0e-4d48-81a2-07f052534a12$/,
+  )
+  await expect(
+    page.getByRole("heading", { name: "V2 Document Evidence Contract" }),
+  ).toBeVisible()
+
+  // After navigation, the search input is reset.
+  await expect(search).toHaveValue("")
+
+  // Clicking a result navigates to a different document.
+  await search.fill("hosted mcp")
+  await page
+    .getByTestId(
+      "v2-document-lookup-result-0fd8a545-a3b7-4a9f-bb65-1ecf76bd8b6d",
+    )
+    .click()
+  await expect(page).toHaveURL(
+    /\/v2\/library\/0fd8a545-a3b7-4a9f-bb65-1ecf76bd8b6d$/,
+  )
+
+  // Escape closes the dropdown without navigating.
+  await search.fill("bridge")
+  await expect(page.getByTestId("v2-document-lookup-results")).toBeVisible()
+  await search.press("Escape")
+  await expect(page.getByTestId("v2-document-lookup-results")).toHaveCount(0)
+})
+
 test("Taskforce v2 library shows document demo data only in demo mode", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- Wire the v2 header search input to filter demo documents (title, description, summaries, body, details) and navigate to results
- Dropdown supports keyboard nav (↑/↓ + Enter, Esc), hover, highlighted matches, and a hint state telling users to enable demo mode when no documents are loaded
- Remove the `max-w-3xl` cap on the single-pane Summary / Details view so the article fills the available width (parent `main` already provides side padding); split view still capped at `max-w-6xl`

## Test plan
- [ ] CI Playwright suite (existing taskforce-shell tests + new `Taskforce v2 document search …` test)
- [ ] Manual: demo mode off → typing shows hint
- [ ] Manual: demo mode on → typing filters; ↑/↓ + Enter opens a document; Esc closes
- [ ] Manual: Summary-only or Details-only view fills horizontal space minus sidebar/padding; split view still capped

🤖 Generated with [Claude Code](https://claude.com/claude-code)