### PR TITLE
Stretch v2 document split view to full available width

### DIFF
--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -90,10 +90,8 @@ function TaskforceDocumentDetail() {
     >
       <article
         className={cn(
-          "mx-auto flex w-full flex-col transition-[max-width]",
-          isSplit
-            ? "max-w-6xl md:min-h-0 md:flex-1 md:overflow-hidden"
-            : "max-w-none pb-16",
+          "mx-auto flex w-full max-w-none flex-col",
+          isSplit ? "md:min-h-0 md:flex-1 md:overflow-hidden" : "pb-16",
         )}
       >
         <div className={cn(isSplit && "md:shrink-0")}>


### PR DESCRIPTION
## Summary
- Drop the `max-w-6xl` cap on the split-view article so Summary and Details side-by-side use the same horizontal space as the single-pane view

## Test plan
- [ ] Open a demo document, click an evidence anchor to enter split view → both panes fill the available width (minus sidebar / parent padding) rather than centering inside a 6xl box

🤖 Generated with [Claude Code](https://claude.com/claude-code)