### PR TITLE
Fix v2 document back link width

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,8 @@ For repo-level fix requests, bug lists, or cleanup batches:
 1. create a Jira ticket with relevant context before coding unless the user explicitly says not to
 2. do the work on a branch and open a PR
 3. link the Jira ticket in the PR and add the PR URL back to Jira
-4. merge after validation unless the user explicitly asks to hold the PR open
+4. never commit, merge, or push directly to `master`/`main`; all work that will land there must exist as a PR first
+5. after validation, merge only through the PR when the user has explicitly asked to merge or deploy; otherwise leave the PR open and report it back
 
 ## Default Behavior
 - for V2-enabled users, prefer guided Taskforce V2 document tools over raw `enderai_request`

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -309,7 +309,13 @@ function TaskforceDocumentDetail() {
         )}
       >
         <div className="-ml-3 mb-4 flex items-center justify-between">
-          <Button asChild variant="ghost" size="sm">
+          <Button
+            asChild
+            variant="ghost"
+            size="sm"
+            data-testid="v2-document-back-link"
+            className="w-fit"
+          >
             <Link to="/v2/library">
               <ArrowLeft className="size-4" />
               Library

--- a/tests/fixtures/v2-documents.ts
+++ b/tests/fixtures/v2-documents.ts
@@ -94,8 +94,14 @@ export async function mockV2Documents(page: Page) {
     const url = new URL(route.request().url())
     const pathname = url.pathname
     const method = route.request().method()
+    const isDemoRequest = url.searchParams.get("demo") === "true"
 
     if (pathname === "/api/v1/v2/documents/" && method === "GET") {
+      if (!isDemoRequest) {
+        await route.fulfill({ json: { data: [], count: 0 } })
+        return
+      }
+
       await route.fulfill({
         json: { data: documents, count: documents.length },
       })

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -196,6 +196,10 @@ test("Taskforce v2 library shows document demo data only in demo mode", async ({
   await expect(page).toHaveURL(
     /\/v2\/library\/8c9b0f48-2f3f-4e8d-9f7d-b4f0607d6a32$/,
   )
+  const backLinkWidth = await page
+    .getByTestId("v2-document-back-link")
+    .evaluate((element) => element.getBoundingClientRect().width)
+  expect(backLinkWidth).toBeLessThan(160)
   await expect(page.getByRole("tab", { name: "Summary" })).toHaveAttribute(
     "data-state",
     "active",


### PR DESCRIPTION
## Summary
- constrain the v2 document Library back link to content width instead of stretching across the page
- add regression coverage that checks the back link remains narrow
- update repo agent delivery guidance to require PRs before master/main merges

## Validation
- ./node_modules/.bin/biome check --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true src/routes/v2/library.$documentId.tsx tests/taskforce-shell.spec.ts AGENTS.md
- ./node_modules/.bin/tsc -p tsconfig.build.json --noEmit
- FIRST_SUPERUSER=test@example.com FIRST_SUPERUSER_PASSWORD=password VITE_API_URL=http://localhost:5173 VITE_FIREBASE_API_KEY=fake-api-key VITE_FIREBASE_AUTH_DOMAIN=example.firebaseapp.com VITE_FIREBASE_PROJECT_ID=demo VITE_FIREBASE_MESSAGING_SENDER_ID=1 VITE_FIREBASE_APP_ID=1:1:web:1 ./node_modules/.bin/playwright test tests/taskforce-shell.spec.ts --project=chromium --no-deps --reporter=line
- FIRST_SUPERUSER=test@example.com FIRST_SUPERUSER_PASSWORD=password VITE_API_URL=http://localhost:5173 VITE_FIREBASE_API_KEY=fake-api-key VITE_FIREBASE_AUTH_DOMAIN=example.firebaseapp.com VITE_FIREBASE_PROJECT_ID=demo VITE_FIREBASE_MESSAGING_SENDER_ID=1 VITE_FIREBASE_APP_ID=1:1:web:1 npm run build

Note: local build prints the existing Vite warning because this shell is on Node 18.19.1; the configured GitHub Pages workflow uses Node 20.