### PR TITLE
Fix v2 document overflow and save scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ For repo-level fix requests, bug lists, or cleanup batches:
 3. link the Jira ticket in the PR and add the PR URL back to Jira
 4. never commit, merge, or push directly to `master`/`main`; all work that will land there must exist as a PR first
 5. after validation, merge only through the PR when the user has explicitly asked to merge or deploy; otherwise leave the PR open and report it back
+6. when a merge triggers deployment automatically, do not run deploy watchers or repeatedly poll CI/deploy status unless the user explicitly asks; report the PR/merge SHA and that deployment was triggered
 
 ## Default Behavior
 - for V2-enabled users, prefer guided Taskforce V2 document tools over raw `enderai_request`

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -143,7 +143,7 @@ function TaskforceDocumentDetail() {
 
   const updateMutation = useMutation({
     mutationFn: (body: V2DocumentUpdate) =>
-      updateV2Document(documentId, body, { demo: isDemoMode }),
+      updateV2Document(documentId, body, { demo: document?.is_demo }),
     onSuccess: (data) => {
       queryClient.setQueryData(
         ["v2-document", documentId, { demo: isDemoMode }],
@@ -304,7 +304,7 @@ function TaskforceDocumentDetail() {
     >
       <article
         className={cn(
-          "mx-auto flex w-full max-w-none flex-col",
+          "mx-auto flex w-full max-w-none flex-col px-4 md:px-6 lg:px-8",
           isSplit ? "md:min-h-0 md:flex-1 md:overflow-hidden" : "pb-16",
         )}
       >
@@ -363,7 +363,7 @@ function TaskforceDocumentDetail() {
         <div
           data-testid="v2-document-sticky-header"
           className={cn(
-            "sticky top-0 z-20 -mx-6 border-b bg-background/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:-mx-8 md:px-8",
+            "sticky top-0 z-20 border-b bg-background/95 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80",
             isSplit && "md:shrink-0",
           )}
         >

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -219,6 +219,15 @@ test("Taskforce v2 library shows document demo data only in demo mode", async ({
 
   const documentScroll = page.getByTestId("v2-document-scroll")
   const stickyHeader = page.getByTestId("v2-document-sticky-header")
+  await expect
+    .poll(
+      async () =>
+        documentScroll.evaluate(
+          (element) => element.scrollWidth <= element.clientWidth,
+        ),
+      { message: "document page should not have horizontal overflow" },
+    )
+    .toBe(true)
   await documentScroll.evaluate((element) => {
     element.scrollTop = 500
   })
@@ -300,4 +309,63 @@ test("Taskforce v2 library shows document demo data only in demo mode", async ({
   await expect(
     page.getByText("latest-stale-network-bridge-issue.details.md"),
   ).not.toBeVisible()
+})
+
+test("Taskforce v2 document save uses document scope instead of sidebar demo mode", async ({
+  page,
+}) => {
+  await mockTaskforceAuth(page)
+
+  const liveDocument = {
+    id: "e7531338-c788-4d30-a4d4-7e3c2053e803",
+    title: "Live Editable Document",
+    description: "Document that should save outside demo mode.",
+    human_summary: "Live summary.",
+    ai_generated_summary: "AI summary.",
+    collaborators: ["Alex Lee"],
+    main_body: [{ segments: [{ text: "Live report body." }] }],
+    details_file_name: "live-editable-document.details.md",
+    details_markdown_sections: [
+      {
+        anchor_id: "live-details",
+        markdown: "## Live Details\nEvidence stays editable.",
+      },
+    ],
+    is_demo: false,
+    created_at: "2026-05-18T00:00:00Z",
+    updated_at: "2026-05-18T00:00:00Z",
+  }
+  const patchUrls: string[] = []
+
+  await page.route("**/api/v1/v2/documents/**", async (route) => {
+    const url = new URL(route.request().url())
+    const method = route.request().method()
+
+    if (url.pathname === `/api/v1/v2/documents/${liveDocument.id}`) {
+      if (method === "GET") {
+        await route.fulfill({ json: liveDocument })
+        return
+      }
+      if (method === "PATCH") {
+        patchUrls.push(route.request().url())
+        const body = JSON.parse(route.request().postData() ?? "{}")
+        await route.fulfill({ json: { ...liveDocument, ...body } })
+        return
+      }
+    }
+
+    await route.fulfill({ json: { data: [], count: 0 } })
+  })
+
+  await page.goto("/v2/home")
+  await page.getByTestId("demo-mode-toggle").click()
+  await page.goto(`/v2/library/${liveDocument.id}`)
+
+  await page.getByTestId("document-edit").click()
+  await page.getByTestId("edit-title").fill("Updated Live Editable Document")
+  await page.getByTestId("document-save").click()
+
+  await expect(page.getByText("Document saved.")).toBeVisible()
+  expect(patchUrls).toHaveLength(1)
+  expect(new URL(patchUrls[0]).searchParams.get("demo")).toBeNull()
 })


### PR DESCRIPTION
## Summary
- remove the negative-margin sticky document header that made the document scroll container slightly wider than its viewport
- add horizontal document padding so Summary, Details, and Split read with more comfortable left/right margins
- save documents using the loaded document scope instead of the sidebar demo toggle, preventing live document PATCH requests from accidentally sending demo=true
- record the no-deploy-watcher preference in repo agent guidance

## Validation
- ./node_modules/.bin/biome check --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true AGENTS.md src/routes/v2/library.$documentId.tsx tests/taskforce-shell.spec.ts
- ./node_modules/.bin/tsc -p tsconfig.build.json --noEmit
- FIRST_SUPERUSER=test@example.com FIRST_SUPERUSER_PASSWORD=password VITE_API_URL=http://localhost:5173 VITE_FIREBASE_API_KEY=fake-api-key VITE_FIREBASE_AUTH_DOMAIN=example.firebaseapp.com VITE_FIREBASE_PROJECT_ID=demo VITE_FIREBASE_MESSAGING_SENDER_ID=1 VITE_FIREBASE_APP_ID=1:1:web:1 ./node_modules/.bin/playwright test tests/taskforce-shell.spec.ts --project=chromium --no-deps --reporter=line
- FIRST_SUPERUSER=test@example.com FIRST_SUPERUSER_PASSWORD=password VITE_API_URL=http://localhost:5173 VITE_FIREBASE_API_KEY=fake-api-key VITE_FIREBASE_AUTH_DOMAIN=example.firebaseapp.com VITE_FIREBASE_PROJECT_ID=demo VITE_FIREBASE_MESSAGING_SENDER_ID=1 VITE_FIREBASE_APP_ID=1:1:web:1 npm run build

Note: local build still prints the existing Node 18/Vite warning; GitHub Pages workflow uses Node 20.