### PR TITLE
[codex] Surface organization settings and library sharing

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -1,0 +1,95 @@
+import { type CancelablePromise, OpenAPI } from "@/client"
+import { request } from "@/client/core/request"
+
+export interface OrganizationMemberPublic {
+  id: string
+  email: string
+  full_name?: string | null
+  organization_role: OrganizationRole
+}
+
+export interface OrganizationInvitationPublic {
+  id: string
+  organization_id: string
+  organization_name?: string | null
+  invited_email: string
+  invited_by_user_id: string
+  created_at: string | null
+  accepted_at: string | null
+  revoked_at: string | null
+}
+
+export interface OrganizationMePublic {
+  id: string
+  name: string
+  created_at: string | null
+  updated_at: string | null
+  organization_role: OrganizationRole
+  members: OrganizationMemberPublic[]
+  invitations: OrganizationInvitationPublic[]
+}
+
+export type OrganizationRole = "admin" | "member"
+
+export interface OrganizationInvitationsPublic {
+  data: OrganizationInvitationPublic[]
+  count: number
+}
+
+export interface OrganizationInvitationCreate {
+  email: string
+}
+
+export interface OrganizationMemberUpdate {
+  organization_role: OrganizationRole
+}
+
+export function readMyOrganization(): CancelablePromise<OrganizationMePublic> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/organizations/me",
+  })
+}
+
+export function readMyOrganizationInvitations(): CancelablePromise<OrganizationInvitationsPublic> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/organizations/invitations",
+  })
+}
+
+export function createOrganizationInvitation(
+  body: OrganizationInvitationCreate,
+): CancelablePromise<OrganizationInvitationPublic> {
+  return request(OpenAPI, {
+    method: "POST",
+    url: "/api/v1/organizations/invitations",
+    body,
+  })
+}
+
+export function acceptOrganizationInvitation(
+  invitationId: string,
+): CancelablePromise<OrganizationMePublic> {
+  return request(OpenAPI, {
+    method: "POST",
+    url: "/api/v1/organizations/invitations/{invitation_id}/accept",
+    path: {
+      invitation_id: invitationId,
+    },
+  })
+}
+
+export function updateOrganizationMember(
+  userId: string,
+  body: OrganizationMemberUpdate,
+): CancelablePromise<OrganizationMemberPublic> {
+  return request(OpenAPI, {
+    method: "PATCH",
+    url: "/api/v1/organizations/members/{user_id}",
+    path: {
+      user_id: userId,
+    },
+    body,
+  })
+}

--- a/src/api/v2Documents.ts
+++ b/src/api/v2Documents.ts
@@ -15,13 +15,35 @@ export interface V2DocumentDetailsSection {
   markdown: string
 }
 
+export type V2DocumentVisibility = "private" | "organization"
+export type V2DocumentAccess = "owner" | "editor" | "viewer"
+export type V2DocumentSharePermission = "viewer" | "editor"
+
+export interface V2DocumentSharePublic {
+  id: string
+  document_id: string
+  user_id: string
+  email: string
+  full_name?: string | null
+  permission: V2DocumentSharePermission
+  created_at: string | null
+  updated_at: string | null
+}
+
 export interface V2DocumentPublic {
   id: string
+  owner_id: string
+  organization_id?: string | null
+  folder_id?: string | null
+  folder_name?: string | null
+  visibility: V2DocumentVisibility
+  user_access: V2DocumentAccess
   title: string
   description: string
   human_summary: string
   ai_generated_summary: string
   collaborators: string[]
+  shared_with: V2DocumentSharePublic[]
   main_body: V2DocumentParagraph[]
   details_file_name: string
   details_markdown_sections: V2DocumentDetailsSection[]
@@ -41,9 +63,48 @@ export interface V2DocumentUpdate {
   human_summary?: string
   ai_generated_summary?: string
   collaborators?: string[]
+  folder_id?: string | null
+  visibility?: V2DocumentVisibility
   main_body?: V2DocumentParagraph[]
   details_file_name?: string
   details_markdown_sections?: V2DocumentDetailsSection[]
+}
+
+export interface V2DocumentFolderPublic {
+  id: string
+  owner_id: string
+  organization_id?: string | null
+  name: string
+  visibility: V2DocumentVisibility
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface V2DocumentFoldersPublic {
+  data: V2DocumentFolderPublic[]
+  count: number
+}
+
+export interface V2DocumentFolderCreate {
+  name: string
+  visibility?: V2DocumentVisibility
+}
+
+export interface V2DocumentFolderUpdate {
+  name?: string
+  visibility?: V2DocumentVisibility
+}
+
+export interface V2DocumentSharesPublic {
+  data: V2DocumentSharePublic[]
+  count: number
+}
+
+export interface V2DocumentSharesUpdate {
+  shares: Array<{
+    user_id: string
+    permission: V2DocumentSharePermission
+  }>
 }
 
 export function readV2Documents(
@@ -54,6 +115,54 @@ export function readV2Documents(
     url: "/api/v1/v2/documents/",
     query: {
       demo: options.demo || undefined,
+    },
+  })
+}
+
+export function readV2DocumentFolders(
+  options: { demo?: boolean } = {},
+): CancelablePromise<V2DocumentFoldersPublic> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/documents/folders/",
+    query: {
+      demo: options.demo || undefined,
+    },
+  })
+}
+
+export function createV2DocumentFolder(
+  body: V2DocumentFolderCreate,
+): CancelablePromise<V2DocumentFolderPublic> {
+  return request(OpenAPI, {
+    method: "POST",
+    url: "/api/v1/v2/documents/folders/",
+    body,
+  })
+}
+
+export function updateV2DocumentFolder(
+  folderId: string,
+  body: V2DocumentFolderUpdate,
+): CancelablePromise<V2DocumentFolderPublic> {
+  return request(OpenAPI, {
+    method: "PATCH",
+    url: "/api/v1/v2/documents/folders/{folder_id}",
+    path: {
+      folder_id: folderId,
+    },
+    body,
+  })
+}
+
+export function deleteV2DocumentFolder(
+  folderId: string,
+): CancelablePromise<void> {
+  return request(OpenAPI, {
+    method: "DELETE",
+    url: "/api/v1/v2/documents/folders/{folder_id}",
+    path: {
+      folder_id: folderId,
     },
   })
 }
@@ -71,6 +180,32 @@ export function readV2Document(
     query: {
       demo: options.demo || undefined,
     },
+  })
+}
+
+export function readV2DocumentShares(
+  documentId: string,
+): CancelablePromise<V2DocumentSharesPublic> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/documents/{document_id}/shares/",
+    path: {
+      document_id: documentId,
+    },
+  })
+}
+
+export function replaceV2DocumentShares(
+  documentId: string,
+  body: V2DocumentSharesUpdate,
+): CancelablePromise<V2DocumentSharesPublic> {
+  return request(OpenAPI, {
+    method: "PUT",
+    url: "/api/v1/v2/documents/{document_id}/shares/",
+    path: {
+      document_id: documentId,
+    },
+    body,
   })
 }
 

--- a/src/components/UserSettings/Organization.tsx
+++ b/src/components/UserSettings/Organization.tsx
@@ -1,0 +1,453 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  Building2,
+  Check,
+  MailPlus,
+  RefreshCw,
+  Shield,
+  Users,
+} from "lucide-react"
+import { type FormEvent, useState } from "react"
+
+import {
+  acceptOrganizationInvitation,
+  createOrganizationInvitation,
+  type OrganizationInvitationPublic,
+  type OrganizationMemberPublic,
+  type OrganizationRole,
+  readMyOrganization,
+  readMyOrganizationInvitations,
+  updateOrganizationMember,
+} from "@/api/organizations"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { LoadingButton } from "@/components/ui/loading-button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import useAuth from "@/hooks/useAuth"
+import useCustomToast from "@/hooks/useCustomToast"
+import { handleError } from "@/utils"
+
+const organizationQueryKey = ["my-organization"]
+const incomingInvitationsQueryKey = ["my-organization-invitations"]
+
+function formatDate(value: string | null): string {
+  if (!value) return "Not available"
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value))
+}
+
+function roleLabel(role: OrganizationRole): string {
+  return role === "admin" ? "Admin" : "Member"
+}
+
+function RoleBadge({ role }: { role: OrganizationRole }) {
+  return (
+    <Badge variant={role === "admin" ? "default" : "secondary"}>
+      {role === "admin" && <Shield className="size-3" />}
+      {roleLabel(role)}
+    </Badge>
+  )
+}
+
+function EmptyRow({
+  colSpan,
+  children,
+}: {
+  colSpan: number
+  children: string
+}) {
+  return (
+    <TableRow>
+      <TableCell colSpan={colSpan} className="text-muted-foreground">
+        {children}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function OrganizationSettings() {
+  const queryClient = useQueryClient()
+  const { user: currentUser } = useAuth()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const [inviteEmail, setInviteEmail] = useState("")
+
+  const organizationQuery = useQuery({
+    queryKey: organizationQueryKey,
+    queryFn: readMyOrganization,
+  })
+
+  const incomingInvitationsQuery = useQuery({
+    queryKey: incomingInvitationsQueryKey,
+    queryFn: readMyOrganizationInvitations,
+  })
+
+  const inviteMutation = useMutation({
+    mutationFn: (email: string) => createOrganizationInvitation({ email }),
+    onSuccess: () => {
+      setInviteEmail("")
+      showSuccessToast("Invitation sent")
+      void queryClient.invalidateQueries({ queryKey: organizationQueryKey })
+    },
+    onError: handleError.bind(showErrorToast),
+  })
+
+  const acceptMutation = useMutation({
+    mutationFn: acceptOrganizationInvitation,
+    onSuccess: () => {
+      showSuccessToast("Invitation accepted")
+      void queryClient.invalidateQueries({ queryKey: organizationQueryKey })
+      void queryClient.invalidateQueries({
+        queryKey: incomingInvitationsQueryKey,
+      })
+      void queryClient.invalidateQueries({ queryKey: ["currentUser"] })
+    },
+    onError: handleError.bind(showErrorToast),
+  })
+
+  const roleMutation = useMutation({
+    mutationFn: ({
+      userId,
+      role,
+    }: {
+      userId: string
+      role: OrganizationRole
+    }) => updateOrganizationMember(userId, { organization_role: role }),
+    onSuccess: () => {
+      showSuccessToast("Member role updated")
+      void queryClient.invalidateQueries({ queryKey: organizationQueryKey })
+    },
+    onError: handleError.bind(showErrorToast),
+  })
+
+  const organization = organizationQuery.data
+  const incomingInvitations = incomingInvitationsQuery.data?.data ?? []
+  const isAdmin = organization?.organization_role === "admin"
+
+  const submitInvitation = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const email = inviteEmail.trim()
+    if (!email) return
+    inviteMutation.mutate(email)
+  }
+
+  const refresh = () => {
+    void queryClient.invalidateQueries({ queryKey: organizationQueryKey })
+    void queryClient.invalidateQueries({
+      queryKey: incomingInvitationsQueryKey,
+    })
+  }
+
+  if (organizationQuery.isLoading) {
+    return (
+      <div className="max-w-4xl space-y-4">
+        <Card>
+          <CardContent className="text-sm text-muted-foreground">
+            Loading organization...
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (organizationQuery.error || !organization) {
+    return (
+      <div className="max-w-4xl space-y-4">
+        <Alert variant="destructive">
+          <AlertTitle>Organization unavailable</AlertTitle>
+          <AlertDescription>
+            Could not load your organization details.
+          </AlertDescription>
+        </Alert>
+        <Button type="button" variant="outline" onClick={refresh}>
+          <RefreshCw className="size-4" />
+          Refresh
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-4xl space-y-4">
+      <IncomingInvitations
+        invitations={incomingInvitations}
+        loading={incomingInvitationsQuery.isLoading}
+        acceptingInvitationId={
+          acceptMutation.isPending
+            ? (acceptMutation.variables as string | undefined)
+            : undefined
+        }
+        onAccept={(invitationId) => acceptMutation.mutate(invitationId)}
+      />
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Building2 className="size-5 text-muted-foreground" />
+            <CardTitle>Organization</CardTitle>
+          </div>
+          <CardDescription>{organization.name}</CardDescription>
+          <CardAction>
+            <RoleBadge role={organization.organization_role} />
+          </CardAction>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <dl className="grid gap-3 text-sm sm:grid-cols-3">
+            <div className="rounded-md border p-3">
+              <dt className="text-muted-foreground">Members</dt>
+              <dd className="mt-1 text-lg font-semibold">
+                {organization.members.length}
+              </dd>
+            </div>
+            <div className="rounded-md border p-3">
+              <dt className="text-muted-foreground">Pending invites</dt>
+              <dd className="mt-1 text-lg font-semibold">
+                {organization.invitations.length}
+              </dd>
+            </div>
+            <div className="rounded-md border p-3">
+              <dt className="text-muted-foreground">Created</dt>
+              <dd className="mt-1 font-medium">
+                {formatDate(organization.created_at)}
+              </dd>
+            </div>
+          </dl>
+
+          {isAdmin && (
+            <form
+              className="flex flex-col gap-2 sm:flex-row"
+              onSubmit={submitInvitation}
+            >
+              <Input
+                type="email"
+                value={inviteEmail}
+                onChange={(event) => setInviteEmail(event.target.value)}
+                placeholder="teammate@example.com"
+                aria-label="Invitation email"
+              />
+              <LoadingButton
+                type="submit"
+                loading={inviteMutation.isPending}
+                disabled={!inviteEmail.trim()}
+              >
+                <MailPlus className="size-4" />
+                Invite
+              </LoadingButton>
+            </form>
+          )}
+
+          <MembersTable
+            members={organization.members}
+            currentUserId={currentUser?.id}
+            isAdmin={isAdmin}
+            pendingMemberId={
+              roleMutation.isPending
+                ? roleMutation.variables?.userId
+                : undefined
+            }
+            onRoleChange={(member, role) => {
+              if (member.organization_role === role) return
+              roleMutation.mutate({ userId: member.id, role })
+            }}
+          />
+
+          <PendingInvitations invitations={organization.invitations} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function IncomingInvitations({
+  invitations,
+  loading,
+  acceptingInvitationId,
+  onAccept,
+}: {
+  invitations: OrganizationInvitationPublic[]
+  loading: boolean
+  acceptingInvitationId?: string
+  onAccept: (invitationId: string) => void
+}) {
+  if (loading || invitations.length === 0) {
+    return null
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <MailPlus className="size-5 text-muted-foreground" />
+          <CardTitle>Invitations</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {invitations.map((invitation) => (
+          <div
+            key={invitation.id}
+            className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div className="min-w-0">
+              <div className="truncate font-medium">
+                {invitation.organization_name ?? "Organization invitation"}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                Sent {formatDate(invitation.created_at)}
+              </div>
+            </div>
+            <LoadingButton
+              type="button"
+              size="sm"
+              loading={acceptingInvitationId === invitation.id}
+              onClick={() => onAccept(invitation.id)}
+            >
+              <Check className="size-4" />
+              Accept
+            </LoadingButton>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+function MembersTable({
+  members,
+  currentUserId,
+  isAdmin,
+  pendingMemberId,
+  onRoleChange,
+}: {
+  members: OrganizationMemberPublic[]
+  currentUserId?: string
+  isAdmin: boolean
+  pendingMemberId?: string
+  onRoleChange: (
+    member: OrganizationMemberPublic,
+    role: OrganizationRole,
+  ) => void
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Users className="size-5 text-muted-foreground" />
+        <h3 className="font-semibold">Members</h3>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Role</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {members.length === 0 && (
+            <EmptyRow colSpan={3}>No members found.</EmptyRow>
+          )}
+          {members.map((member) => {
+            const isCurrentUser = member.id === currentUserId
+            const roleControlDisabled =
+              !isAdmin || isCurrentUser || pendingMemberId === member.id
+
+            return (
+              <TableRow key={member.id}>
+                <TableCell className="max-w-[12rem] truncate">
+                  {member.full_name || "N/A"}
+                </TableCell>
+                <TableCell className="max-w-[18rem] truncate">
+                  {member.email}
+                </TableCell>
+                <TableCell>
+                  {isAdmin && !isCurrentUser ? (
+                    <Select
+                      value={member.organization_role}
+                      disabled={roleControlDisabled}
+                      onValueChange={(value) =>
+                        onRoleChange(member, value as OrganizationRole)
+                      }
+                    >
+                      <SelectTrigger size="sm" className="w-32">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="member">Member</SelectItem>
+                        <SelectItem value="admin">Admin</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <RoleBadge role={member.organization_role} />
+                  )}
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </section>
+  )
+}
+
+function PendingInvitations({
+  invitations,
+}: {
+  invitations: OrganizationInvitationPublic[]
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <MailPlus className="size-5 text-muted-foreground" />
+        <h3 className="font-semibold">Pending invitations</h3>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Email</TableHead>
+            <TableHead>Sent</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {invitations.length === 0 && (
+            <EmptyRow colSpan={2}>No pending invitations.</EmptyRow>
+          )}
+          {invitations.map((invitation) => (
+            <TableRow key={invitation.id}>
+              <TableCell className="max-w-[20rem] truncate">
+                {invitation.invited_email}
+              </TableCell>
+              <TableCell>{formatDate(invitation.created_at)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </section>
+  )
+}
+
+export default OrganizationSettings

--- a/src/routes/_layout/settings.tsx
+++ b/src/routes/_layout/settings.tsx
@@ -6,12 +6,14 @@ import Billing from "@/components/UserSettings/Billing"
 import ChangePassword from "@/components/UserSettings/ChangePassword"
 import ConnectAgent from "@/components/UserSettings/ConnectAgent"
 import DeleteAccount from "@/components/UserSettings/DeleteAccount"
+import Organization from "@/components/UserSettings/Organization"
 import UserInformation from "@/components/UserSettings/UserInformation"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import useAuth from "@/hooks/useAuth"
 
 const tabValues = [
   "my-profile",
+  "organization",
   "connect-agent",
   "billing",
   "password",
@@ -30,6 +32,7 @@ const tabsConfig: Array<{
   component: ComponentType
 }> = [
   { value: "my-profile", title: "My profile", component: UserInformation },
+  { value: "organization", title: "Organization", component: Organization },
   { value: "connect-agent", title: "Connect agent", component: ConnectAgent },
   { value: "billing", title: "Billing", component: Billing },
   { value: "password", title: "Password", component: ChangePassword },
@@ -77,7 +80,7 @@ function UserSettings() {
         }}
         className="flex min-h-0 flex-1 flex-col overflow-hidden"
       >
-        <TabsList className="shrink-0">
+        <TabsList className="max-w-full shrink-0 justify-start overflow-x-auto">
           {finalTabs.map((tab) => (
             <TabsTrigger key={tab.value} value={tab.value}>
               {tab.title}

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -1,18 +1,55 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { ArrowLeft, Link as LinkIcon, Pencil, X } from "lucide-react"
+import {
+  ArrowLeft,
+  Building2,
+  Eye,
+  Folder,
+  Link as LinkIcon,
+  Lock,
+  Pencil,
+  Share2,
+  X,
+} from "lucide-react"
 import { useMemo, useRef, useState } from "react"
 
 import {
+  type OrganizationMemberPublic,
+  readMyOrganization,
+} from "@/api/organizations"
+import {
   readV2Document,
+  readV2DocumentFolders,
+  readV2DocumentShares,
+  replaceV2DocumentShares,
   updateV2Document,
   type V2DocumentDetailsSection,
+  type V2DocumentFolderPublic,
   type V2DocumentParagraph,
   type V2DocumentPublic,
+  type V2DocumentSharePermission,
   type V2DocumentUpdate,
+  type V2DocumentVisibility,
 } from "@/api/v2Documents"
 import { useDemoMode } from "@/components/demo-mode-provider"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
 
@@ -50,10 +87,14 @@ type EditableDoc = {
   human_summary: string
   ai_generated_summary: string
   collaborators: string
+  folder_id: string | null
+  visibility: V2DocumentVisibility
   details_file_name: string
   main_body: V2DocumentParagraph[]
   details_markdown_sections: V2DocumentDetailsSection[]
 }
+
+type ShareDraft = Record<string, V2DocumentSharePermission>
 
 function toEditable(document: V2DocumentPublic): EditableDoc {
   return {
@@ -62,6 +103,8 @@ function toEditable(document: V2DocumentPublic): EditableDoc {
     human_summary: document.human_summary,
     ai_generated_summary: document.ai_generated_summary,
     collaborators: document.collaborators.join(", "),
+    folder_id: document.folder_id ?? null,
+    visibility: document.visibility,
     details_file_name: document.details_file_name,
     main_body: document.main_body.map((p) => ({
       segments: p.segments.map((s) => ({ ...s })),
@@ -82,6 +125,8 @@ function toUpdatePayload(edit: EditableDoc): V2DocumentUpdate {
       .split(",")
       .map((c) => c.trim())
       .filter(Boolean),
+    folder_id: edit.folder_id,
+    visibility: edit.visibility,
     details_file_name: edit.details_file_name,
     main_body: edit.main_body,
     details_markdown_sections: edit.details_markdown_sections,
@@ -127,6 +172,7 @@ function TaskforceDocumentDetail() {
   const { isDemoMode } = useDemoMode()
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
+  const { user } = useAuth()
 
   const [viewMode, setViewMode] = useState<ViewMode>("summary")
   const [activeEvidenceAnchorId, setActiveEvidenceAnchorId] = useState<string>()
@@ -135,10 +181,35 @@ function TaskforceDocumentDetail() {
   const [anchorMode, setAnchorMode] = useState(false)
   const [summaryPick, setSummaryPick] = useState<AnchorPick | null>(null)
   const [detailsPick, setDetailsPick] = useState<DetailsPick | null>(null)
+  const [shareDialogOpen, setShareDialogOpen] = useState(false)
+  const [shareDraft, setShareDraft] = useState<ShareDraft>({})
 
   const documentQuery = useQuery({
     queryKey: ["v2-document", documentId, { demo: isDemoMode }],
     queryFn: () => readV2Document(documentId, { demo: isDemoMode }),
+  })
+
+  const document = documentQuery.data
+  const isOwner = Boolean(document && user?.id === document.owner_id)
+  const canEditDocument = Boolean(document && document.user_access !== "viewer")
+  const canManageDocument = isOwner && !isDemoMode
+
+  const foldersQuery = useQuery({
+    queryKey: ["v2-document-folders", { demo: isDemoMode }],
+    queryFn: () => readV2DocumentFolders({ demo: isDemoMode }),
+    enabled: Boolean(document),
+  })
+
+  const organizationQuery = useQuery({
+    queryKey: ["organization-me"],
+    queryFn: readMyOrganization,
+    enabled: canManageDocument,
+  })
+
+  const sharesQuery = useQuery({
+    queryKey: ["v2-document-shares", documentId],
+    queryFn: () => readV2DocumentShares(documentId),
+    enabled: canManageDocument,
   })
 
   const updateMutation = useMutation({
@@ -159,7 +230,31 @@ function TaskforceDocumentDetail() {
     },
   })
 
-  const document = documentQuery.data
+  const shareMutation = useMutation({
+    mutationFn: () =>
+      replaceV2DocumentShares(documentId, {
+        shares: Object.entries(shareDraft).map(([user_id, permission]) => ({
+          user_id,
+          permission,
+        })),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["v2-document", documentId, { demo: isDemoMode }],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["v2-document-shares", documentId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["v2-documents", { demo: isDemoMode }],
+      })
+      setShareDialogOpen(false)
+      showSuccessToast("Sharing updated.")
+    },
+    onError: () => {
+      showErrorToast("Could not update sharing.")
+    },
+  })
 
   const isSplit = viewMode === "split"
   const summaryVisible = viewMode === "summary" || isSplit
@@ -184,7 +279,7 @@ function TaskforceDocumentDetail() {
   }
 
   const enterEdit = () => {
-    if (!document) return
+    if (!document || !canEditDocument) return
     setEditState(toEditable(document))
     setIsEditing(true)
     setAnchorMode(false)
@@ -205,6 +300,16 @@ function TaskforceDocumentDetail() {
         setEditState(null)
       },
     })
+  }
+
+  const openShareDialog = () => {
+    const shares = sharesQuery.data?.data ?? document?.shared_with ?? []
+    setShareDraft(
+      Object.fromEntries(
+        shares.map((share) => [share.user_id, share.permission]),
+      ),
+    )
+    setShareDialogOpen(true)
   }
 
   const confirmAnchor = () => {
@@ -323,7 +428,25 @@ function TaskforceDocumentDetail() {
           </Button>
 
           <div className="flex items-center gap-2">
-            {!editing && (
+            {canManageDocument && !editing && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={openShareDialog}
+                data-testid="document-share"
+              >
+                <Share2 className="size-4" />
+                Share
+              </Button>
+            )}
+            {!canEditDocument && (
+              <Badge variant="outline">
+                <Eye className="size-3" />
+                View only
+              </Badge>
+            )}
+            {!editing && canEditDocument && (
               <Button
                 type="button"
                 variant="outline"
@@ -418,7 +541,7 @@ function TaskforceDocumentDetail() {
                 />
               </div>
 
-              {isSplit && !editing && (
+              {isSplit && !editing && canEditDocument && (
                 <Button
                   type="button"
                   variant={anchorMode ? "default" : "outline"}
@@ -475,7 +598,22 @@ function TaskforceDocumentDetail() {
           editing={editing}
           editState={editState}
           setEditState={setEditState}
+          folders={foldersQuery.data?.data ?? []}
+          canManageLibrary={canManageDocument}
         />
+
+        {canManageDocument && (
+          <DocumentShareDialog
+            open={shareDialogOpen}
+            onOpenChange={setShareDialogOpen}
+            members={organizationQuery.data?.members ?? []}
+            ownerId={document.owner_id}
+            shareDraft={shareDraft}
+            setShareDraft={setShareDraft}
+            onSave={() => shareMutation.mutate()}
+            isSaving={shareMutation.isPending}
+          />
+        )}
 
         {anchorMode && (
           <AnchorHelper summaryPick={summaryPick} detailsPick={detailsPick} />
@@ -529,53 +667,229 @@ function DocumentMetadata({
   editing,
   editState,
   setEditState,
+  folders,
+  canManageLibrary,
 }: {
   document: V2DocumentPublic
   editing: boolean
   editState: EditableDoc | null
   setEditState: (next: EditableDoc) => void
+  folders: V2DocumentFolderPublic[]
+  canManageLibrary: boolean
 }) {
+  const visibilityLabel =
+    document.visibility === "organization" ? "Organization" : "Private"
+
   return (
-    <dl className="mt-5 flex flex-wrap items-center gap-x-2 gap-y-1 border-y py-4 text-sm text-muted-foreground">
-      <dt className="sr-only">Created</dt>
-      <dd>
-        Created{" "}
-        <span className="text-foreground">
+    <dl className="mt-5 grid gap-3 border-y py-4 text-sm text-muted-foreground md:grid-cols-2 xl:grid-cols-4">
+      <div className="min-w-0">
+        <dt className="text-xs uppercase tracking-wide">Created</dt>
+        <dd className="mt-1 text-foreground">
           {formatDateOnly(document.created_at)}
-        </span>
-      </dd>
-      <span aria-hidden="true">·</span>
-      <dt className="sr-only">Updated</dt>
-      <dd>
-        Updated{" "}
-        <span className="text-foreground">
+        </dd>
+      </div>
+      <div className="min-w-0">
+        <dt className="text-xs uppercase tracking-wide">Updated</dt>
+        <dd className="mt-1 text-foreground">
           {formatDateOnly(document.updated_at)}
-        </span>
-      </dd>
-      <span aria-hidden="true">·</span>
-      <dt className="sr-only">Collaborators</dt>
-      <dd>
-        {editing && editState ? (
-          <input
-            type="text"
-            value={editState.collaborators}
-            onChange={(event) =>
-              setEditState({
-                ...editState,
-                collaborators: event.target.value,
-              })
-            }
-            placeholder="Comma-separated"
-            className="min-w-[16rem] border bg-background px-2 py-1 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
-            data-testid="edit-collaborators"
-          />
-        ) : (
-          <span className="text-foreground">
-            {document.collaborators.join(", ")}
-          </span>
-        )}
-      </dd>
+        </dd>
+      </div>
+      <div className="min-w-0">
+        <dt className="text-xs uppercase tracking-wide">Folder</dt>
+        <dd className="mt-1">
+          {editing && editState && canManageLibrary ? (
+            <Select
+              value={editState.folder_id ?? "__none"}
+              onValueChange={(value) =>
+                setEditState({
+                  ...editState,
+                  folder_id: value === "__none" ? null : value,
+                })
+              }
+            >
+              <SelectTrigger className="w-full" size="sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none">Unfiled</SelectItem>
+                {folders.map((folder) => (
+                  <SelectItem key={folder.id} value={folder.id}>
+                    {folder.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <span className="inline-flex min-w-0 items-center gap-1.5 text-foreground">
+              <Folder className="size-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">
+                {document.folder_name ?? "Unfiled"}
+              </span>
+            </span>
+          )}
+        </dd>
+      </div>
+      <div className="min-w-0">
+        <dt className="text-xs uppercase tracking-wide">Access</dt>
+        <dd className="mt-1">
+          {editing && editState && canManageLibrary ? (
+            <Select
+              value={editState.visibility}
+              onValueChange={(value) =>
+                setEditState({
+                  ...editState,
+                  visibility: value as V2DocumentVisibility,
+                })
+              }
+            >
+              <SelectTrigger className="w-full" size="sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="private">Private</SelectItem>
+                <SelectItem value="organization">Organization</SelectItem>
+              </SelectContent>
+            </Select>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 text-foreground">
+              {document.visibility === "organization" ? (
+                <Building2 className="size-4 text-muted-foreground" />
+              ) : (
+                <Lock className="size-4 text-muted-foreground" />
+              )}
+              {visibilityLabel}
+            </span>
+          )}
+        </dd>
+      </div>
+      <div className="min-w-0 md:col-span-2 xl:col-span-4">
+        <dt className="text-xs uppercase tracking-wide">Collaborators</dt>
+        <dd className="mt-1">
+          {editing && editState ? (
+            <input
+              type="text"
+              value={editState.collaborators}
+              onChange={(event) =>
+                setEditState({
+                  ...editState,
+                  collaborators: event.target.value,
+                })
+              }
+              placeholder="Comma-separated"
+              className="w-full border bg-background px-2 py-1 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+              data-testid="edit-collaborators"
+            />
+          ) : (
+            <span className="text-foreground">
+              {document.collaborators.join(", ")}
+            </span>
+          )}
+        </dd>
+      </div>
     </dl>
+  )
+}
+
+function DocumentShareDialog({
+  open,
+  onOpenChange,
+  members,
+  ownerId,
+  shareDraft,
+  setShareDraft,
+  onSave,
+  isSaving,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  members: OrganizationMemberPublic[]
+  ownerId: string
+  shareDraft: ShareDraft
+  setShareDraft: (draft: ShareDraft) => void
+  onSave: () => void
+  isSaving: boolean
+}) {
+  const shareableMembers = members.filter((member) => member.id !== ownerId)
+  const assignedCount = Object.keys(shareDraft).length
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>Share document</DialogTitle>
+        </DialogHeader>
+        <div className="max-h-[55vh] space-y-2 overflow-y-auto pr-1">
+          {shareableMembers.length === 0 && (
+            <div className="border bg-card p-4 text-sm text-muted-foreground">
+              No organization members available.
+            </div>
+          )}
+          {shareableMembers.map((member) => {
+            const permission = shareDraft[member.id]
+            const checked = Boolean(permission)
+            return (
+              <div
+                key={member.id}
+                className="grid grid-cols-[auto_minmax(0,1fr)_130px] items-center gap-3 border p-3"
+              >
+                <Checkbox
+                  id={`share-${member.id}`}
+                  checked={checked}
+                  onCheckedChange={(nextChecked) => {
+                    const next = { ...shareDraft }
+                    if (nextChecked === true) {
+                      next[member.id] = permission ?? "editor"
+                    } else {
+                      delete next[member.id]
+                    }
+                    setShareDraft(next)
+                  }}
+                />
+                <label htmlFor={`share-${member.id}`} className="min-w-0">
+                  <span className="block truncate text-sm font-medium text-foreground">
+                    {member.full_name || member.email}
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {member.email}
+                  </span>
+                </label>
+                <Select
+                  value={permission ?? "editor"}
+                  disabled={!checked}
+                  onValueChange={(value) =>
+                    setShareDraft({
+                      ...shareDraft,
+                      [member.id]: value as V2DocumentSharePermission,
+                    })
+                  }
+                >
+                  <SelectTrigger className="w-full" size="sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="editor">Editor</SelectItem>
+                    <SelectItem value="viewer">Viewer</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )
+          })}
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={onSave} disabled={isSaving}>
+            {isSaving ? "Saving" : `Save ${assignedCount}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -1,14 +1,42 @@
-import { useQuery } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   createFileRoute,
   Link,
   Outlet,
   useRouterState,
 } from "@tanstack/react-router"
-import { CalendarDays, FileText, Users } from "lucide-react"
+import {
+  Building2,
+  CalendarDays,
+  FileText,
+  Folder,
+  FolderPlus,
+  Lock,
+  Share2,
+  Users,
+} from "lucide-react"
+import { type FormEvent, type ReactNode, useMemo, useState } from "react"
 
-import { readV2Documents, type V2DocumentPublic } from "@/api/v2Documents"
+import {
+  createV2DocumentFolder,
+  readV2DocumentFolders,
+  readV2Documents,
+  type V2DocumentFolderPublic,
+  type V2DocumentPublic,
+  type V2DocumentVisibility,
+} from "@/api/v2Documents"
 import { useDemoMode } from "@/components/demo-mode-provider"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import useCustomToast from "@/hooks/useCustomToast"
+import { cn } from "@/lib/utils"
 
 export const Route = createFileRoute("/v2/library")({
   component: TaskforceLibrary,
@@ -32,24 +60,123 @@ function formatDateOnly(value: string | null): string {
 function TaskforceLibrary() {
   const { isDemoMode } = useDemoMode()
   const router = useRouterState()
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const [selectedFolderId, setSelectedFolderId] = useState("all")
+  const [folderName, setFolderName] = useState("")
+  const [folderVisibility, setFolderVisibility] =
+    useState<V2DocumentVisibility>("private")
 
   const documentsQuery = useQuery({
     queryKey: ["v2-documents", { demo: isDemoMode }],
     queryFn: () => readV2Documents({ demo: isDemoMode }),
   })
 
+  const foldersQuery = useQuery({
+    queryKey: ["v2-document-folders", { demo: isDemoMode }],
+    queryFn: () => readV2DocumentFolders({ demo: isDemoMode }),
+  })
+
+  const createFolderMutation = useMutation({
+    mutationFn: () =>
+      createV2DocumentFolder({
+        name: folderName.trim(),
+        visibility: folderVisibility,
+      }),
+    onSuccess: () => {
+      setFolderName("")
+      queryClient.invalidateQueries({
+        queryKey: ["v2-document-folders", { demo: isDemoMode }],
+      })
+      showSuccessToast("Folder created.")
+    },
+    onError: () => {
+      showErrorToast("Could not create folder.")
+    },
+  })
+
+  const documents = documentsQuery.data?.data ?? []
+  const folders = foldersQuery.data?.data ?? []
+  const folderCounts = useMemo(() => {
+    const counts = new Map<string, number>()
+    let unfiled = 0
+    for (const document of documents) {
+      if (document.folder_id) {
+        counts.set(
+          document.folder_id,
+          (counts.get(document.folder_id) ?? 0) + 1,
+        )
+      } else {
+        unfiled += 1
+      }
+    }
+    return { counts, unfiled }
+  }, [documents])
+  const visibleDocuments = useMemo(() => {
+    if (selectedFolderId === "all") return documents
+    if (selectedFolderId === "unfiled") {
+      return documents.filter((document) => !document.folder_id)
+    }
+    return documents.filter(
+      (document) => document.folder_id === selectedFolderId,
+    )
+  }, [documents, selectedFolderId])
+  const isLoading = documentsQuery.isLoading
+  const isEmpty = !isLoading && documents.length === 0
+  const isFolderEmpty =
+    !isLoading && documents.length > 0 && visibleDocuments.length === 0
+
+  const submitFolder = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!folderName.trim() || isDemoMode) return
+    createFolderMutation.mutate()
+  }
+
   if (router.location.pathname.startsWith("/v2/library/")) {
     return <Outlet />
   }
 
-  const documents = documentsQuery.data?.data ?? []
-  const isLoading = documentsQuery.isLoading
-  const isEmpty = !isLoading && documents.length === 0
-
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto">
-      <div className="shrink-0">
+      <div className="flex shrink-0 flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <h1 className="text-2xl font-semibold">Library</h1>
+        {!isDemoMode && (
+          <form
+            className="flex w-full flex-col gap-2 sm:flex-row lg:w-auto"
+            onSubmit={submitFolder}
+          >
+            <input
+              type="text"
+              value={folderName}
+              onChange={(event) => setFolderName(event.target.value)}
+              placeholder="New folder"
+              className="h-9 min-w-0 border bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring sm:w-48"
+              data-testid="new-folder-name"
+            />
+            <Select
+              value={folderVisibility}
+              onValueChange={(value) =>
+                setFolderVisibility(value as V2DocumentVisibility)
+              }
+            >
+              <SelectTrigger className="w-full sm:w-36" size="sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="private">Private</SelectItem>
+                <SelectItem value="organization">Organization</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={!folderName.trim() || createFolderMutation.isPending}
+            >
+              <FolderPlus className="size-4" />
+              {createFolderMutation.isPending ? "Creating" : "Create"}
+            </Button>
+          </form>
+        )}
       </div>
 
       {isLoading && (
@@ -65,17 +192,130 @@ function TaskforceLibrary() {
       )}
 
       {!isLoading && documents.length > 0 && (
-        <div className="grid gap-4 lg:grid-cols-3">
-          {documents.map((document) => (
-            <DocumentCard key={document.id} document={document} />
-          ))}
+        <div className="grid gap-6 xl:grid-cols-[240px_minmax(0,1fr)]">
+          <FolderNav
+            folders={folders}
+            selectedFolderId={selectedFolderId}
+            setSelectedFolderId={setSelectedFolderId}
+            allCount={documents.length}
+            unfiledCount={folderCounts.unfiled}
+            folderCounts={folderCounts.counts}
+            loading={foldersQuery.isLoading}
+          />
+          <div className="min-w-0">
+            {isFolderEmpty && (
+              <div className="border bg-card p-6 text-sm text-muted-foreground">
+                No documents in this folder.
+              </div>
+            )}
+            {!isFolderEmpty && (
+              <div className="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+                {visibleDocuments.map((document) => (
+                  <DocumentCard key={document.id} document={document} />
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       )}
     </section>
   )
 }
 
+function FolderNav({
+  folders,
+  selectedFolderId,
+  setSelectedFolderId,
+  allCount,
+  unfiledCount,
+  folderCounts,
+  loading,
+}: {
+  folders: V2DocumentFolderPublic[]
+  selectedFolderId: string
+  setSelectedFolderId: (folderId: string) => void
+  allCount: number
+  unfiledCount: number
+  folderCounts: Map<string, number>
+  loading: boolean
+}) {
+  return (
+    <nav
+      aria-label="Library folders"
+      className="min-w-0 border bg-card p-2 text-sm xl:sticky xl:top-0 xl:self-start"
+    >
+      <FolderNavButton
+        active={selectedFolderId === "all"}
+        label="All documents"
+        count={allCount}
+        icon={<FileText className="size-4" />}
+        onClick={() => setSelectedFolderId("all")}
+      />
+      <FolderNavButton
+        active={selectedFolderId === "unfiled"}
+        label="Unfiled"
+        count={unfiledCount}
+        icon={<Folder className="size-4" />}
+        onClick={() => setSelectedFolderId("unfiled")}
+      />
+      <div className="my-2 border-t" />
+      {loading && (
+        <div className="px-2 py-2 text-xs text-muted-foreground">
+          Loading folders…
+        </div>
+      )}
+      {!loading &&
+        folders.map((folder) => (
+          <FolderNavButton
+            key={folder.id}
+            active={selectedFolderId === folder.id}
+            label={folder.name}
+            count={folderCounts.get(folder.id) ?? 0}
+            icon={<Folder className="size-4" />}
+            visibility={folder.visibility}
+            onClick={() => setSelectedFolderId(folder.id)}
+          />
+        ))}
+    </nav>
+  )
+}
+
+function FolderNavButton({
+  active,
+  label,
+  count,
+  icon,
+  visibility,
+  onClick,
+}: {
+  active: boolean
+  label: string
+  count: number
+  icon: ReactNode
+  visibility?: V2DocumentVisibility
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-muted",
+        active && "bg-muted text-foreground",
+      )}
+      onClick={onClick}
+    >
+      <span className="shrink-0 text-muted-foreground">{icon}</span>
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      {visibility === "organization" && (
+        <Building2 className="size-3.5 shrink-0 text-muted-foreground" />
+      )}
+      <span className="shrink-0 text-xs text-muted-foreground">{count}</span>
+    </button>
+  )
+}
+
 function DocumentCard({ document }: { document: V2DocumentPublic }) {
+  const sharedCount = document.shared_with?.length ?? 0
   return (
     <Link
       to="/v2/library/$documentId"
@@ -84,6 +324,22 @@ function DocumentCard({ document }: { document: V2DocumentPublic }) {
     >
       <div className="flex items-start">
         <FileText className="mt-1 size-5 shrink-0 text-muted-foreground" />
+        <div className="ml-auto flex flex-wrap justify-end gap-1.5">
+          <Badge variant="outline">
+            {document.visibility === "organization" ? (
+              <Building2 className="size-3" />
+            ) : (
+              <Lock className="size-3" />
+            )}
+            {document.visibility === "organization" ? "Org" : "Private"}
+          </Badge>
+          {sharedCount > 0 && (
+            <Badge variant="secondary">
+              <Share2 className="size-3" />
+              {sharedCount}
+            </Badge>
+          )}
+        </div>
       </div>
 
       <div className="mt-4">
@@ -94,6 +350,11 @@ function DocumentCard({ document }: { document: V2DocumentPublic }) {
       </div>
 
       <dl className="mt-5 grid gap-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <Folder className="size-4" />
+          <dt className="sr-only">Folder</dt>
+          <dd>{document.folder_name ?? "Unfiled"}</dd>
+        </div>
         <div className="flex items-center gap-2">
           <CalendarDays className="size-4" />
           <dt className="sr-only">Updated</dt>

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -6,6 +6,7 @@ import { logInUser, logOutUser } from "./utils/user"
 
 const tabs = [
   "My profile",
+  "Organization",
   "Connect agent",
   "Billing",
   "Password",
@@ -25,6 +26,182 @@ test("All tabs are visible", async ({ page }) => {
   for (const tab of tabs) {
     await expect(page.getByRole("tab", { name: tab })).toBeVisible()
   }
+})
+
+test.describe("Organization", () => {
+  test.use({ storageState: { cookies: [], origins: [] } })
+
+  test("Organization tab shows members, invitations, and admin actions", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("access_token", "frontend-test-token")
+    })
+
+    let organization = {
+      id: "org-1",
+      name: "Frontend Test Organization",
+      created_at: "2026-03-14T20:00:00Z",
+      updated_at: "2026-03-14T20:00:00Z",
+      organization_role: "admin",
+      members: [
+        {
+          id: "user-1",
+          email: "admin@example.com",
+          full_name: "Admin User",
+          organization_role: "admin",
+        },
+        {
+          id: "user-2",
+          email: "member@example.com",
+          full_name: "Member User",
+          organization_role: "member",
+        },
+      ],
+      invitations: [
+        {
+          id: "invite-1",
+          organization_id: "org-1",
+          organization_name: "Frontend Test Organization",
+          invited_email: "pending@example.com",
+          invited_by_user_id: "user-1",
+          created_at: "2026-03-15T20:00:00Z",
+          accepted_at: null,
+          revoked_at: null,
+        },
+      ],
+    }
+
+    await page.route("**/api/v1/users/me", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "user-1",
+          email: "admin@example.com",
+          is_active: true,
+          is_superuser: false,
+          full_name: "Admin User",
+          created_at: "2026-03-14T20:00:00Z",
+        }),
+      })
+    })
+
+    await page.route("**/api/v1/organizations/me", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(organization),
+      })
+    })
+
+    await page.route("**/api/v1/organizations/invitations", async (route) => {
+      if (route.request().method() === "POST") {
+        const invite = {
+          id: "invite-2",
+          organization_id: "org-1",
+          organization_name: "Frontend Test Organization",
+          invited_email: "new@example.com",
+          invited_by_user_id: "user-1",
+          created_at: "2026-03-16T20:00:00Z",
+          accepted_at: null,
+          revoked_at: null,
+        }
+        organization = {
+          ...organization,
+          invitations: [...organization.invitations, invite],
+        }
+        await route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify(invite),
+        })
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: [
+            {
+              id: "invite-incoming",
+              organization_id: "org-2",
+              organization_name: "Partner Organization",
+              invited_email: "admin@example.com",
+              invited_by_user_id: "partner-admin",
+              created_at: "2026-03-17T20:00:00Z",
+              accepted_at: null,
+              revoked_at: null,
+            },
+          ],
+          count: 1,
+        }),
+      })
+    })
+
+    await page.route(
+      "**/api/v1/organizations/invitations/invite-incoming/accept",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ...organization,
+            id: "org-2",
+            name: "Partner Organization",
+            organization_role: "member",
+          }),
+        })
+      },
+    )
+
+    await page.route(
+      "**/api/v1/organizations/members/user-2",
+      async (route) => {
+        organization = {
+          ...organization,
+          members: organization.members.map((member) =>
+            member.id === "user-2"
+              ? { ...member, organization_role: "admin" }
+              : member,
+          ),
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(organization.members[1]),
+        })
+      },
+    )
+
+    await page.goto("/settings?tab=organization")
+
+    await expect(
+      page
+        .locator('[data-slot="card-title"]')
+        .filter({ hasText: "Organization" }),
+    ).toBeVisible()
+    await expect(page.getByText("Frontend Test Organization")).toBeVisible()
+    await expect(page.getByText("Partner Organization")).toBeVisible()
+    await expect(page.getByText("member@example.com")).toBeVisible()
+    await expect(page.getByText("pending@example.com")).toBeVisible()
+
+    await page.getByLabel("Invitation email").fill("new@example.com")
+    await page.getByRole("button", { name: "Invite" }).click()
+    await expect(page.getByText("Invitation sent")).toBeVisible()
+    await expect(page.getByText("new@example.com")).toBeVisible()
+
+    await page
+      .getByRole("row", { name: /Member User/ })
+      .getByRole("combobox")
+      .click()
+    await page.getByRole("option", { name: "Admin" }).click()
+    await expect(page.getByText("Member role updated")).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+    await expect(page.getByText("Invitation accepted")).toBeVisible()
+  })
 })
 
 test.describe("Billing", () => {


### PR DESCRIPTION
## Summary
- Adds a manual organizations API client for current org, pending invitations, invite creation, invitation acceptance, and member role updates.
- Adds an Organization tab inside User Settings with members, pending outgoing invitations, incoming invitation acceptance, and admin-only invite/role controls.
- Completes the existing library sharing UI by exposing document folders, folder filtering, visibility badges, folder assignment, and document member sharing controls.
- Adds mocked Playwright coverage for the Organization settings flow.

## Validation
- `bun run build` passed.
- `bunx biome check --no-errors-on-unmatched --files-ignore-unknown=true src/api/organizations.ts src/api/v2Documents.ts src/components/UserSettings/Organization.tsx src/routes/_layout/settings.tsx src/routes/v2/library.tsx src/routes/v2/library.$documentId.tsx tests/user-settings.spec.ts` passed.
- `FIRST_SUPERUSER=admin@example.com FIRST_SUPERUSER_PASSWORD=changethis VITE_FIREBASE_API_KEY=test-api-key VITE_FIREBASE_AUTH_DOMAIN=test.firebaseapp.com VITE_FIREBASE_PROJECT_ID=test VITE_FIREBASE_STORAGE_BUCKET=test.appspot.com VITE_FIREBASE_MESSAGING_SENDER_ID=123 VITE_FIREBASE_APP_ID=1:123:web:test node node_modules/@playwright/test/cli.js test tests/user-settings.spec.ts --project=chromium --grep "Organization tab" --no-deps --config playwright.config.ts` passed.
- `git diff --check` passed.

## Notes
- The frontend branch depends on the backend PR's organization invitation `organization_name` response field and V2 document folder/share endpoints.