### PR TITLE
Remove active user admin UI

### DIFF
--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -49,7 +49,6 @@ export type UpdatePassword = {
 
 export type UserCreate = {
     email: string;
-    is_active?: boolean;
     is_superuser?: boolean;
     full_name?: (string | null);
     password?: (string | null);
@@ -57,7 +56,6 @@ export type UserCreate = {
 
 export type UserPublic = {
     email: string;
-    is_active?: boolean;
     is_superuser?: boolean;
     full_name?: (string | null);
     id: string;
@@ -83,7 +81,6 @@ export type UsersPublic = {
 
 export type UserUpdate = {
     email?: (string | null);
-    is_active?: boolean;
     is_superuser?: boolean;
     full_name?: (string | null);
     password?: (string | null);

--- a/src/components/Admin/AddUser.tsx
+++ b/src/components/Admin/AddUser.tsx
@@ -37,7 +37,6 @@ const formSchema = z.object({
   email: z.email({ message: "Invalid email address" }),
   full_name: z.string().optional(),
   is_superuser: z.boolean(),
-  is_active: z.boolean(),
 })
 
 type FormData = z.infer<typeof formSchema>
@@ -55,7 +54,6 @@ const AddUser = () => {
       email: "",
       full_name: "",
       is_superuser: false,
-      is_active: false,
     },
   })
 
@@ -146,22 +144,6 @@ const AddUser = () => {
                       />
                     </FormControl>
                     <FormLabel className="font-normal">Is superuser?</FormLabel>
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="is_active"
-                render={({ field }) => (
-                  <FormItem className="flex items-center gap-3 space-y-0">
-                    <FormControl>
-                      <Checkbox
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-                    <FormLabel className="font-normal">Is active?</FormLabel>
                   </FormItem>
                 )}
               />

--- a/src/components/Admin/EditUser.tsx
+++ b/src/components/Admin/EditUser.tsx
@@ -35,7 +35,6 @@ const formSchema = z.object({
   email: z.email({ message: "Invalid email address" }),
   full_name: z.string().optional(),
   is_superuser: z.boolean().optional(),
-  is_active: z.boolean().optional(),
 })
 
 type FormData = z.infer<typeof formSchema>
@@ -58,7 +57,6 @@ const EditUser = ({ user, onSuccess }: EditUserProps) => {
       email: user.email,
       full_name: user.full_name ?? undefined,
       is_superuser: user.is_superuser,
-      is_active: user.is_active,
     },
   })
 
@@ -146,22 +144,6 @@ const EditUser = ({ user, onSuccess }: EditUserProps) => {
                       />
                     </FormControl>
                     <FormLabel className="font-normal">Is superuser?</FormLabel>
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="is_active"
-                render={({ field }) => (
-                  <FormItem className="flex items-center gap-3 space-y-0">
-                    <FormControl>
-                      <Checkbox
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-                    <FormLabel className="font-normal">Is active?</FormLabel>
                   </FormItem>
                 )}
               />

--- a/src/components/Admin/columns.tsx
+++ b/src/components/Admin/columns.tsx
@@ -91,23 +91,6 @@ export const columns: ColumnDef<UserTableData>[] = [
     ),
   },
   {
-    accessorKey: "is_active",
-    header: "Access",
-    cell: ({ row }) => (
-      <div className="flex items-center gap-2">
-        <span
-          className={cn(
-            "size-2 rounded-full",
-            row.original.is_active ? "bg-green-500" : "bg-gray-400",
-          )}
-        />
-        <span className={row.original.is_active ? "" : "text-muted-foreground"}>
-          {row.original.is_active ? "Active" : "Inactive"}
-        </span>
-      </div>
-    ),
-  },
-  {
     accessorKey: "stripe_subscription_status",
     header: "Billing",
     cell: ({ row }) => {


### PR DESCRIPTION
## Summary

Removes the redundant active-user controls from admin user management now that billing/subscription state is the relevant account status.

## Changes

- Removed the Admin Users active/inactive `Access` column.
- Removed `Is active?` from Add User and Edit User dialogs.
- Removed `is_active` from generated user create/update/public TypeScript types.

## Validation

- `npm run build` passed.
- Note: Vite printed the existing environment warning that this shell uses Node `18.19.1`; Vite requires Node `20.19+` or `22.12+`. The build still completed successfully.