### PR TITLE
Add Taskforce Metrics sub-tab + methodology page (Phase 5)

### DIFF
--- a/src/api/v2Metrics.ts
+++ b/src/api/v2Metrics.ts
@@ -1,0 +1,85 @@
+import { type CancelablePromise, OpenAPI } from "@/client"
+import { request } from "@/client/core/request"
+
+export type MetricUnit = "tokens" | "usd" | "count" | "ratio"
+export type MetricFormat = "compact-int" | "usd" | "ratio" | "count"
+export type MetricsWindow = "7d" | "30d" | "all"
+export type MetricsScope = "personal" | "organization"
+
+export interface MetricPresentationPublic {
+  format: MetricFormat
+  trend: boolean
+  icon: string | null
+}
+
+export interface MetricDefinitionPublic {
+  name: string
+  display_name: string
+  unit: MetricUnit
+  description: string
+  presentation: MetricPresentationPublic
+}
+
+export interface MetricDefinitionsResponse {
+  data: MetricDefinitionPublic[]
+}
+
+export interface MetricSeriesPoint {
+  day: string
+  value: string
+}
+
+export interface MetricBreakdownEntry {
+  key: string
+  label: string
+  tokens: number
+  usd: string
+}
+
+export interface MetricValuePublic {
+  total: string
+  delta_vs_prev_window: string | null
+  series: MetricSeriesPoint[]
+  breakdown_by_source: MetricBreakdownEntry[] | null
+  top_models: MetricBreakdownEntry[] | null
+}
+
+export interface MetricsResponse {
+  window: MetricsWindow
+  from: string | null
+  to: string
+  scope: MetricsScope
+  is_demo: boolean
+  metrics: Record<string, MetricValuePublic>
+}
+
+export function readMetricDefinitions(): CancelablePromise<MetricDefinitionsResponse> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/metrics/definitions",
+  })
+}
+
+export interface ReadMetricsArgs {
+  window?: MetricsWindow
+  metrics?: string[]
+  scope?: MetricsScope
+  demo?: boolean
+}
+
+export function readMetrics(
+  args: ReadMetricsArgs = {},
+): CancelablePromise<MetricsResponse> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/metrics",
+    query: {
+      window: args.window ?? "7d",
+      scope: args.scope ?? "personal",
+      demo: args.demo ?? false,
+      ...(args.metrics && args.metrics.length > 0
+        ? { metrics: args.metrics.join(",") }
+        : {}),
+    },
+  })
+}

--- a/src/components/V2/Metrics/MethodologyLink.tsx
+++ b/src/components/V2/Metrics/MethodologyLink.tsx
@@ -1,0 +1,14 @@
+import { Link } from "@tanstack/react-router"
+
+export function MethodologyLink() {
+  return (
+    <div className="text-sm">
+      <Link
+        to="/v2/metrics/methodology"
+        className="text-primary underline-offset-4 hover:underline"
+      >
+        Learn how we calculate savings →
+      </Link>
+    </div>
+  )
+}

--- a/src/components/V2/Metrics/MetricBreakdown.tsx
+++ b/src/components/V2/Metrics/MetricBreakdown.tsx
@@ -1,0 +1,48 @@
+import type { MetricBreakdownEntry } from "@/api/v2Metrics"
+import { formatMetricValue } from "./formatters"
+
+type Props = {
+  title: string
+  rows: MetricBreakdownEntry[]
+  format?: "compact-int" | "usd"
+}
+
+export function MetricBreakdown({
+  title,
+  rows,
+  format = "compact-int",
+}: Props) {
+  const total = rows.reduce((acc, row) => acc + row.tokens, 0)
+  return (
+    <div className="rounded-lg border border-border bg-background p-4 shadow-sm">
+      <h3 className="mb-3 text-sm font-medium text-muted-foreground">
+        {title}
+      </h3>
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No data yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {rows.map((row) => {
+            const share = total > 0 ? row.tokens / total : 0
+            return (
+              <li key={row.key} className="space-y-1">
+                <div className="flex items-baseline justify-between text-sm">
+                  <span>{row.label}</span>
+                  <span className="tabular-nums text-muted-foreground">
+                    {formatMetricValue(row.tokens, format)}
+                  </span>
+                </div>
+                <div className="h-1 rounded bg-muted">
+                  <div
+                    className="h-1 rounded bg-foreground/60"
+                    style={{ width: `${Math.round(share * 100)}%` }}
+                  />
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/V2/Metrics/MetricCard.tsx
+++ b/src/components/V2/Metrics/MetricCard.tsx
@@ -1,0 +1,42 @@
+import type { MetricDefinitionPublic, MetricValuePublic } from "@/api/v2Metrics"
+import { cn } from "@/lib/utils"
+import { formatDelta, formatMetricValue } from "./formatters"
+
+type Props = {
+  definition: MetricDefinitionPublic
+  value: MetricValuePublic | undefined
+}
+
+export function MetricCard({ definition, value }: Props) {
+  const format = definition.presentation.format
+  const total = formatMetricValue(value?.total, format)
+  const delta =
+    definition.presentation.trend && value?.delta_vs_prev_window != null
+      ? formatDelta(value.delta_vs_prev_window, format)
+      : null
+
+  return (
+    <div className="rounded-lg border border-border bg-background p-4 shadow-sm">
+      <div className="text-sm font-medium text-muted-foreground">
+        {definition.display_name}
+      </div>
+      <div className="mt-1 text-3xl font-semibold tabular-nums">{total}</div>
+      {delta && (
+        <div
+          className={cn(
+            "mt-1 text-sm tabular-nums",
+            delta.sign === "up" && "text-emerald-600 dark:text-emerald-400",
+            delta.sign === "down" && "text-rose-600 dark:text-rose-400",
+            delta.sign === "flat" && "text-muted-foreground",
+          )}
+        >
+          {delta.sign === "up" ? "▲ " : delta.sign === "down" ? "▼ " : ""}
+          {delta.label} vs prev
+        </div>
+      )}
+      <p className="mt-3 text-xs text-muted-foreground">
+        {definition.description}
+      </p>
+    </div>
+  )
+}

--- a/src/components/V2/Metrics/MetricTrendChart.tsx
+++ b/src/components/V2/Metrics/MetricTrendChart.tsx
@@ -1,0 +1,59 @@
+import type { MetricSeriesPoint } from "@/api/v2Metrics"
+
+type Props = {
+  title: string
+  series: MetricSeriesPoint[]
+}
+
+function toNumber(s: string): number {
+  const n = Number.parseFloat(s)
+  return Number.isFinite(n) ? n : 0
+}
+
+export function MetricTrendChart({ title, series }: Props) {
+  if (series.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-background p-4 shadow-sm">
+        <h3 className="mb-2 text-sm font-medium text-muted-foreground">
+          {title}
+        </h3>
+        <p className="text-sm text-muted-foreground">No data in this window.</p>
+      </div>
+    )
+  }
+  const values = series.map((p) => toNumber(p.value))
+  const max = Math.max(...values, 1)
+  const min = Math.min(...values, 0)
+  const span = Math.max(max - min, 1)
+  const width = 600
+  const height = 120
+  const stepX = series.length > 1 ? width / (series.length - 1) : 0
+  const points = values
+    .map((v, i) => {
+      const x = i * stepX
+      const y = height - ((v - min) / span) * height
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(" ")
+  return (
+    <div className="rounded-lg border border-border bg-background p-4 shadow-sm">
+      <h3 className="mb-3 text-sm font-medium text-muted-foreground">
+        {title}
+      </h3>
+      <svg
+        role="img"
+        aria-label={title}
+        viewBox={`0 0 ${width} ${height}`}
+        className="h-32 w-full"
+        preserveAspectRatio="none"
+      >
+        <polyline
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          points={points}
+        />
+      </svg>
+    </div>
+  )
+}

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -1,0 +1,135 @@
+import { useQuery } from "@tanstack/react-query"
+import { useMemo, useState } from "react"
+import {
+  type MetricDefinitionPublic,
+  type MetricsWindow,
+  readMetricDefinitions,
+  readMetrics,
+} from "@/api/v2Metrics"
+import type { UserPublic } from "@/client"
+import { useDemoMode } from "@/components/demo-mode-provider"
+import { MethodologyLink } from "./MethodologyLink"
+import { MetricBreakdown } from "./MetricBreakdown"
+import { MetricCard } from "./MetricCard"
+import { MetricsTimeRange } from "./MetricsTimeRange"
+import { MetricTrendChart } from "./MetricTrendChart"
+
+type Props = {
+  currentUser: UserPublic
+}
+
+const PRIMARY_METRICS = ["tokens_saved", "usd_saved", "reuse_rate"]
+const SECONDARY_METRICS = [
+  "tokens_consumed",
+  "usd_consumed",
+  "documents_touched",
+]
+
+// Org-scope toggle is intentionally deferred. The backend supports
+// scope=organization on /v2/metrics (admin-gated), but the generated
+// OpenAPI client doesn't yet expose organization_id / organization_role
+// on UserPublic in this repo. When the client is regenerated, restore
+// the MetricsScopeToggle import and the `scope` state below.
+export function MetricsPage({ currentUser: _currentUser }: Props) {
+  const { isDemoMode } = useDemoMode()
+  const [window, setWindow] = useState<MetricsWindow>("7d")
+
+  const definitionsQuery = useQuery({
+    queryKey: ["v2-metrics-definitions"],
+    queryFn: () => readMetricDefinitions(),
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const metricsQuery = useQuery({
+    queryKey: ["v2-metrics", { window, demo: isDemoMode }],
+    queryFn: () => readMetrics({ window, scope: "personal", demo: isDemoMode }),
+    staleTime: 30 * 1000,
+  })
+
+  const definitionsByName = useMemo(() => {
+    const out: Record<string, MetricDefinitionPublic> = {}
+    for (const d of definitionsQuery.data?.data ?? []) {
+      out[d.name] = d
+    }
+    return out
+  }, [definitionsQuery.data])
+
+  const metrics = metricsQuery.data?.metrics ?? {}
+  const tokensSaved = metrics.tokens_saved
+  const tokensConsumed = metrics.tokens_consumed
+  const isEmpty =
+    metricsQuery.isSuccess &&
+    Object.values(metrics).every((m) => {
+      const total = Number.parseFloat(m.total)
+      return !Number.isFinite(total) || total === 0
+    })
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Metrics</h1>
+          <p className="text-sm text-muted-foreground">
+            Tokens and dollars saved by Taskforce, plus what was consumed.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <MetricsTimeRange value={window} onChange={setWindow} />
+        </div>
+      </div>
+
+      {metricsQuery.isError && (
+        <div className="rounded border border-destructive bg-destructive/10 p-3 text-sm">
+          Failed to load metrics. Try again in a moment.
+        </div>
+      )}
+
+      {isEmpty && (
+        <div className="rounded-lg border border-dashed border-border p-6 text-sm text-muted-foreground">
+          No metrics yet. Connect your MCP and start using Taskforce — events
+          show up here within a minute of the agent's first call.
+        </div>
+      )}
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {PRIMARY_METRICS.map((name) => {
+          const def = definitionsByName[name]
+          if (!def) return null
+          return (
+            <MetricCard key={name} definition={def} value={metrics[name]} />
+          )
+        })}
+      </section>
+
+      <MethodologyLink />
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <MetricTrendChart
+          title="Tokens saved per day"
+          series={tokensSaved?.series ?? []}
+        />
+        <MetricBreakdown
+          title="Savings by source"
+          rows={tokensSaved?.breakdown_by_source ?? []}
+        />
+      </section>
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {SECONDARY_METRICS.map((name) => {
+          const def = definitionsByName[name]
+          if (!def) return null
+          return (
+            <MetricCard key={name} definition={def} value={metrics[name]} />
+          )
+        })}
+      </section>
+
+      <section>
+        <MetricBreakdown
+          title="Top models by tokens used"
+          rows={tokensConsumed?.top_models ?? []}
+        />
+      </section>
+    </div>
+  )
+}

--- a/src/components/V2/Metrics/MetricsScopeToggle.tsx
+++ b/src/components/V2/Metrics/MetricsScopeToggle.tsx
@@ -1,0 +1,48 @@
+import type { MetricsScope } from "@/api/v2Metrics"
+import { cn } from "@/lib/utils"
+
+type Props = {
+  value: MetricsScope
+  onChange: (scope: MetricsScope) => void
+  disabled?: boolean
+}
+
+const OPTIONS: { value: MetricsScope; label: string }[] = [
+  { value: "personal", label: "Personal" },
+  { value: "organization", label: "Organization" },
+]
+
+export function MetricsScopeToggle({ value, onChange, disabled }: Props) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Scope"
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md border border-border bg-muted/30 p-1",
+        disabled && "opacity-50",
+      )}
+    >
+      {OPTIONS.map((opt) => {
+        const selected = value === opt.value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            disabled={disabled}
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              "rounded px-3 py-1 text-sm transition-colors",
+              selected
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/V2/Metrics/MetricsTimeRange.tsx
+++ b/src/components/V2/Metrics/MetricsTimeRange.tsx
@@ -1,0 +1,44 @@
+import type { MetricsWindow } from "@/api/v2Metrics"
+import { cn } from "@/lib/utils"
+
+type Props = {
+  value: MetricsWindow
+  onChange: (window: MetricsWindow) => void
+}
+
+const OPTIONS: { value: MetricsWindow; label: string }[] = [
+  { value: "7d", label: "7 days" },
+  { value: "30d", label: "30 days" },
+  { value: "all", label: "All time" },
+]
+
+export function MetricsTimeRange({ value, onChange }: Props) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Time range"
+      className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/30 p-1"
+    >
+      {OPTIONS.map((opt) => {
+        const selected = value === opt.value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              "rounded px-3 py-1 text-sm transition-colors",
+              selected
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/V2/Metrics/formatters.ts
+++ b/src/components/V2/Metrics/formatters.ts
@@ -1,0 +1,73 @@
+import type { MetricFormat } from "@/api/v2Metrics"
+
+const compactInt = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+})
+
+const usd = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+})
+
+const count = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+})
+
+const ratioPct = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  maximumFractionDigits: 1,
+})
+
+const deltaPct = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  signDisplay: "exceptZero",
+  maximumFractionDigits: 1,
+})
+
+const deltaAbs = new Intl.NumberFormat("en-US", {
+  signDisplay: "exceptZero",
+  maximumFractionDigits: 2,
+})
+
+function toNumber(value: string | number | null | undefined): number {
+  if (value == null) return 0
+  if (typeof value === "number") return value
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+export function formatMetricValue(
+  value: string | number | null | undefined,
+  format: MetricFormat,
+): string {
+  const n = toNumber(value)
+  switch (format) {
+    case "compact-int":
+      return compactInt.format(n)
+    case "usd":
+      return usd.format(n)
+    case "ratio":
+      return ratioPct.format(n)
+    case "count":
+      return count.format(n)
+    default:
+      return String(n)
+  }
+}
+
+export function formatDelta(
+  value: string | number | null | undefined,
+  format: MetricFormat,
+): { label: string; sign: "up" | "down" | "flat" } | null {
+  if (value == null) return null
+  const n = toNumber(value)
+  if (!Number.isFinite(n)) return null
+  const sign = n > 0 ? "up" : n < 0 ? "down" : "flat"
+  if (format === "ratio") {
+    return { label: `${deltaAbs.format(n * 100)} pp`, sign }
+  }
+  return { label: deltaPct.format(n), sign }
+}

--- a/src/components/V2/Metrics/methodology.md
+++ b/src/components/V2/Metrics/methodology.md
@@ -1,0 +1,37 @@
+# How we calculate savings
+
+Tokens Saved and USD Saved come from three **attributable** sources. Anything we can't attribute cleanly is not counted — keeping the dollar figure defensible matters more than making it look bigger.
+
+## What "actually used" means
+
+We count tokens the API call **billed**, not the byte size of the document. Cache reads count at the cache-read rate. Tokens prepared in a tool result but never returned to the model don't count. Raw Details markdown sitting on the doc but not loaded into the turn doesn't count.
+
+Every metrics event that carries a USD figure is priced against the model-pricing row that was effective at the moment the event occurred. Historical figures stay reproducible across price changes.
+
+## The three sources
+
+### Cache savings — *measured*
+
+Every cache-read token costs ~10% of base input under the Anthropic pricing schedule. We count the delta — `(base_input − cache_read) × cache_read_tokens` — as saved.
+
+### Summary-instead-of-Details — *measured*
+
+When the agent reports `view_consulted: "summary"` on a turn, it told us the model didn't read the full Details payload. We attribute `details_tokens × base_input` as saved — the tokens that would otherwise have been loaded.
+
+If the agent doesn't pass that flag, we don't claim the saving.
+
+### Reuse-on-begin — *estimated*
+
+When the scoring engine reuses an existing document instead of creating a fresh one, we estimate `min(20k, summary_tokens + details_tokens) × base_input` as saved — a conservative floor on what a from-scratch session would have to re-derive. The 20k cap is intentional; a 200k-token doc doesn't mean a from-scratch session would re-derive 200k of context.
+
+## What we don't count
+
+- Conversations the agent shortened heuristically without telling us. Not measurable.
+- Conflict signals that blocked a bad reuse — saved future tokens, but the counterfactual is too speculative for a dollar figure.
+- Tokens loaded but never attended to by the model.
+
+These show up as observability (counts), not as dollars saved.
+
+## Pricing
+
+We use the rates published at [platform.claude.com pricing](https://platform.claude.com/docs/en/about-claude/pricing). Each price change is recorded as a new effective-from row; events priced before the change keep pointing at their original snapshot. No retroactive rewriting.

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -5,7 +5,14 @@ import {
   useNavigate,
   useRouterState,
 } from "@tanstack/react-router"
-import { BookOpenText, Component, Home, Search, Shield } from "lucide-react"
+import {
+  BarChart3,
+  BookOpenText,
+  Component,
+  Home,
+  Search,
+  Shield,
+} from "lucide-react"
 import {
   Fragment,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -52,6 +59,7 @@ type TaskforceNavItem = {
 const taskforceItems: TaskforceNavItem[] = [
   { icon: Home, title: "Home", path: "/v2/home" },
   { icon: BookOpenText, title: "Library", path: "/v2/library" },
+  { icon: BarChart3, title: "Metrics", path: "/v2/metrics" },
 ]
 
 function TaskforceMark() {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as V2IndexRouteImport } from './routes/v2/index'
+import { Route as V2MetricsRouteImport } from './routes/v2/metrics'
 import { Route as V2LibraryRouteImport } from './routes/v2/library'
 import { Route as V2HomeRouteImport } from './routes/v2/home'
 import { Route as V2AdminRouteImport } from './routes/v2/admin'
@@ -26,6 +27,7 @@ import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
 import { Route as LayoutHomeRouteImport } from './routes/_layout/home'
 import { Route as LayoutCasesRouteImport } from './routes/_layout/cases'
 import { Route as LayoutAdminRouteImport } from './routes/_layout/admin'
+import { Route as V2MetricsMethodologyRouteImport } from './routes/v2/metrics.methodology'
 import { Route as V2LibraryDocumentIdRouteImport } from './routes/v2/library.$documentId'
 
 const V2Route = V2RouteImport.update({
@@ -65,6 +67,11 @@ const IndexRoute = IndexRouteImport.update({
 const V2IndexRoute = V2IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => V2Route,
+} as any)
+const V2MetricsRoute = V2MetricsRouteImport.update({
+  id: '/metrics',
+  path: '/metrics',
   getParentRoute: () => V2Route,
 } as any)
 const V2LibraryRoute = V2LibraryRouteImport.update({
@@ -112,6 +119,11 @@ const LayoutAdminRoute = LayoutAdminRouteImport.update({
   path: '/admin',
   getParentRoute: () => LayoutRoute,
 } as any)
+const V2MetricsMethodologyRoute = V2MetricsMethodologyRouteImport.update({
+  id: '/methodology',
+  path: '/methodology',
+  getParentRoute: () => V2MetricsRoute,
+} as any)
 const V2LibraryDocumentIdRoute = V2LibraryDocumentIdRouteImport.update({
   id: '/$documentId',
   path: '/$documentId',
@@ -134,8 +146,10 @@ export interface FileRoutesByFullPath {
   '/v2/admin': typeof V2AdminRoute
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
+  '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2/': typeof V2IndexRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
+  '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -152,8 +166,10 @@ export interface FileRoutesByTo {
   '/v2/admin': typeof V2AdminRoute
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
+  '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2': typeof V2IndexRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
+  '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -173,8 +189,10 @@ export interface FileRoutesById {
   '/v2/admin': typeof V2AdminRoute
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
+  '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2/': typeof V2IndexRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
+  '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -194,8 +212,10 @@ export interface FileRouteTypes {
     | '/v2/admin'
     | '/v2/home'
     | '/v2/library'
+    | '/v2/metrics'
     | '/v2/'
     | '/v2/library/$documentId'
+    | '/v2/metrics/methodology'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -212,8 +232,10 @@ export interface FileRouteTypes {
     | '/v2/admin'
     | '/v2/home'
     | '/v2/library'
+    | '/v2/metrics'
     | '/v2'
     | '/v2/library/$documentId'
+    | '/v2/metrics/methodology'
   id:
     | '__root__'
     | '/'
@@ -232,8 +254,10 @@ export interface FileRouteTypes {
     | '/v2/admin'
     | '/v2/home'
     | '/v2/library'
+    | '/v2/metrics'
     | '/v2/'
     | '/v2/library/$documentId'
+    | '/v2/metrics/methodology'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -304,6 +328,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof V2IndexRouteImport
       parentRoute: typeof V2Route
     }
+    '/v2/metrics': {
+      id: '/v2/metrics'
+      path: '/metrics'
+      fullPath: '/v2/metrics'
+      preLoaderRoute: typeof V2MetricsRouteImport
+      parentRoute: typeof V2Route
+    }
     '/v2/library': {
       id: '/v2/library'
       path: '/library'
@@ -367,6 +398,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutAdminRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/v2/metrics/methodology': {
+      id: '/v2/metrics/methodology'
+      path: '/methodology'
+      fullPath: '/v2/metrics/methodology'
+      preLoaderRoute: typeof V2MetricsMethodologyRouteImport
+      parentRoute: typeof V2MetricsRoute
+    }
     '/v2/library/$documentId': {
       id: '/v2/library/$documentId'
       path: '/$documentId'
@@ -410,10 +448,23 @@ const V2LibraryRouteWithChildren = V2LibraryRoute._addFileChildren(
   V2LibraryRouteChildren,
 )
 
+interface V2MetricsRouteChildren {
+  V2MetricsMethodologyRoute: typeof V2MetricsMethodologyRoute
+}
+
+const V2MetricsRouteChildren: V2MetricsRouteChildren = {
+  V2MetricsMethodologyRoute: V2MetricsMethodologyRoute,
+}
+
+const V2MetricsRouteWithChildren = V2MetricsRoute._addFileChildren(
+  V2MetricsRouteChildren,
+)
+
 interface V2RouteChildren {
   V2AdminRoute: typeof V2AdminRoute
   V2HomeRoute: typeof V2HomeRoute
   V2LibraryRoute: typeof V2LibraryRouteWithChildren
+  V2MetricsRoute: typeof V2MetricsRouteWithChildren
   V2IndexRoute: typeof V2IndexRoute
 }
 
@@ -421,6 +472,7 @@ const V2RouteChildren: V2RouteChildren = {
   V2AdminRoute: V2AdminRoute,
   V2HomeRoute: V2HomeRoute,
   V2LibraryRoute: V2LibraryRouteWithChildren,
+  V2MetricsRoute: V2MetricsRouteWithChildren,
   V2IndexRoute: V2IndexRoute,
 }
 

--- a/src/routes/v2/metrics.methodology.tsx
+++ b/src/routes/v2/metrics.methodology.tsx
@@ -1,0 +1,149 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { ArrowLeft } from "lucide-react"
+
+import methodologyRaw from "@/components/V2/Metrics/methodology.md?raw"
+
+export const Route = createFileRoute("/v2/metrics/methodology")({
+  component: MetricsMethodology,
+  head: () => ({
+    meta: [
+      {
+        title: "Taskforce | Metrics methodology",
+      },
+    ],
+  }),
+})
+
+function MetricsMethodology() {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
+      <Link
+        to="/v2/metrics"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="size-4" />
+        Back to Metrics
+      </Link>
+      <article className="prose prose-sm max-w-none dark:prose-invert">
+        <Markdown source={methodologyRaw} />
+      </article>
+    </div>
+  )
+}
+
+// Tiny inline markdown renderer — the page is a single static doc and we
+// don't want to pull in a full markdown lib for one route. Handles the
+// subset of constructs used in methodology.md.
+function Markdown({ source }: { source: string }) {
+  const lines = source.split("\n")
+  const blocks: React.ReactNode[] = []
+  let listBuffer: string[] = []
+  let paragraphBuffer: string[] = []
+
+  const flushList = () => {
+    if (listBuffer.length > 0) {
+      blocks.push(
+        <ul key={`ul-${blocks.length}`} className="my-3 list-disc pl-6">
+          {listBuffer.map((item, i) => (
+            <li key={i}>{renderInline(item)}</li>
+          ))}
+        </ul>,
+      )
+      listBuffer = []
+    }
+  }
+  const flushParagraph = () => {
+    if (paragraphBuffer.length > 0) {
+      const text = paragraphBuffer.join(" ")
+      blocks.push(
+        <p key={`p-${blocks.length}`} className="my-3">
+          {renderInline(text)}
+        </p>,
+      )
+      paragraphBuffer = []
+    }
+  }
+
+  for (const raw of lines) {
+    const line = raw.trimEnd()
+    if (line.startsWith("# ")) {
+      flushList()
+      flushParagraph()
+      blocks.push(
+        <h1 key={`h-${blocks.length}`} className="mt-6 text-2xl font-semibold">
+          {line.slice(2)}
+        </h1>,
+      )
+    } else if (line.startsWith("## ")) {
+      flushList()
+      flushParagraph()
+      blocks.push(
+        <h2 key={`h-${blocks.length}`} className="mt-6 text-lg font-semibold">
+          {line.slice(3)}
+        </h2>,
+      )
+    } else if (line.startsWith("### ")) {
+      flushList()
+      flushParagraph()
+      blocks.push(
+        <h3 key={`h-${blocks.length}`} className="mt-4 text-base font-semibold">
+          {line.slice(4)}
+        </h3>,
+      )
+    } else if (line.startsWith("- ")) {
+      flushParagraph()
+      listBuffer.push(line.slice(2))
+    } else if (line === "") {
+      flushList()
+      flushParagraph()
+    } else {
+      flushList()
+      paragraphBuffer.push(line)
+    }
+  }
+  flushList()
+  flushParagraph()
+  return <>{blocks}</>
+}
+
+function renderInline(text: string): React.ReactNode {
+  // Italic via *...*, code via `...`, links via [text](url). Run them in that
+  // order so nesting works out for the methodology doc's content.
+  const parts: React.ReactNode[] = []
+  let cursor = 0
+  const re = /\[([^\]]+)\]\(([^)]+)\)|`([^`]+)`|\*([^*]+)\*/g
+  let match: RegExpExecArray | null
+  let i = 0
+  match = re.exec(text)
+  while (match !== null) {
+    if (match.index > cursor) {
+      parts.push(text.slice(cursor, match.index))
+    }
+    if (match[1] != null && match[2] != null) {
+      parts.push(
+        <a
+          key={i}
+          href={match[2]}
+          className="text-primary underline-offset-4 hover:underline"
+          target="_blank"
+          rel="noreferrer"
+        >
+          {match[1]}
+        </a>,
+      )
+    } else if (match[3] != null) {
+      parts.push(
+        <code key={i} className="rounded bg-muted px-1 py-0.5 text-[0.85em]">
+          {match[3]}
+        </code>,
+      )
+    } else if (match[4] != null) {
+      parts.push(<em key={i}>{match[4]}</em>)
+    }
+    cursor = re.lastIndex
+    i += 1
+    match = re.exec(text)
+  }
+  if (cursor < text.length) parts.push(text.slice(cursor))
+  return parts
+}

--- a/src/routes/v2/metrics.tsx
+++ b/src/routes/v2/metrics.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { MetricsPage } from "@/components/V2/Metrics/MetricsPage"
+
+export const Route = createFileRoute("/v2/metrics")({
+  component: TaskforceMetrics,
+  head: () => ({
+    meta: [
+      {
+        title: "Taskforce | Metrics",
+      },
+    ],
+  }),
+})
+
+function TaskforceMetrics() {
+  const { currentUser } = Route.useRouteContext()
+  return <MetricsPage currentUser={currentUser} />
+}


### PR DESCRIPTION
## Summary

Phase 5 of the Taskforce Metrics engine plan — the user-facing payoff. Builds on the read endpoints landed in `EnderAI#47` (Phase 4) to give Taskforce users a definition-driven Metrics view at `/v2/metrics` plus a methodology page at `/v2/metrics/methodology`.

### Files

- `src/api/v2Metrics.ts` — typed client for the two new backend endpoints. Hand-rolled rather than auto-generated for this PR; an OpenAPI regeneration sweep can replace it later without behavior changes.
- `src/components/V2/Metrics/`
  - `MetricsPage.tsx` — top-level layout (header + time-range + cards + breakdowns + methodology link)
  - `MetricCard.tsx` — renders any `MetricDefinition` + value; doesn't know about specific metrics
  - `MetricsTimeRange.tsx` — 7d / 30d / All time toggle
  - `MetricTrendChart.tsx` — inline SVG polyline; no chart-lib dep yet (recharts/visx can come later if needed)
  - `MetricBreakdown.tsx` — used for both savings-by-source and top-models
  - `MethodologyLink.tsx` — the "Learn how we calculate savings →" link
  - `methodology.md` — user-facing copy for the three attributable savings sources plus "what we don't count"
  - `formatters.ts` — compact-int / usd / ratio / pp deltas
- `src/routes/v2/metrics.tsx`, `src/routes/v2/metrics.methodology.tsx` — TanStack Router file routes
- `src/components/V2/TaskforceShell.tsx` — Metrics nav entry between Library and Admin

### Design

Card-based and definition-driven per plan §8.2 — `MetricCard` doesn't know about specific metrics. Adding a new metric on the backend (Phase 4 `REGISTRY`) is picked up automatically because `GET /v2/metrics/definitions` self-describes the layout.

### Decisions

- **Org-scope toggle deferred**: backend supports `scope=organization` (admin-gated) but `UserPublic` in the generated OpenAPI client here doesn't yet carry `organization_id` / `organization_role`. Wiring the toggle back on is a one-line change once the client is regenerated; the existing `scope: "personal"` is hard-coded in the read call and commented in `MetricsPage.tsx`.
- **Inline markdown renderer** for the methodology page. Pulling in a full markdown lib for one static doc didn't seem worth the bundle weight. Handles headings / paragraphs / bullets / inline code / italics / links — the subset used in `methodology.md`.
- **No chart library**: trend chart is a single inline `<svg>` polyline. Good enough for the v1 layout; we can swap in a chart lib later if richer interactions are needed.

## Test plan

- [x] `npx tsc -p tsconfig.build.json` — clean
- [x] `npx biome check` — clean on changed files
- [x] `npm run build` — succeeds
- [ ] Manual smoke: visit `/v2/metrics` against a backend with #47 deployed; verify cards render, methodology link routes correctly, empty state shows for zero-event users
- [ ] Backfill an OpenAPI regen sweep so `v2Metrics.ts` matches the canonical generator (and add the org-scope toggle back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)