### PR TITLE
Add document folder and access controls

### DIFF
--- a/src/components/V2/Library/FolderControls.tsx
+++ b/src/components/V2/Library/FolderControls.tsx
@@ -1,0 +1,266 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { Building2, Check, Folder, FolderPlus, Search } from "lucide-react"
+import { useMemo, useState } from "react"
+
+import {
+  createV2DocumentFolder,
+  type V2DocumentFolderPublic,
+  type V2DocumentVisibility,
+} from "@/api/v2Documents"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import useCustomToast from "@/hooks/useCustomToast"
+import { cn } from "@/lib/utils"
+
+export function FolderCreateDialog({
+  open,
+  onOpenChange,
+  demo,
+  onCreated,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  demo: boolean
+  onCreated?: (folder: V2DocumentFolderPublic) => void
+}) {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const [name, setName] = useState("")
+  const [visibility, setVisibility] = useState<V2DocumentVisibility>("private")
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createV2DocumentFolder({
+        name: name.trim(),
+        visibility,
+      }),
+    onSuccess: (folder) => {
+      setName("")
+      setVisibility("private")
+      queryClient.invalidateQueries({
+        queryKey: ["v2-document-folders", { demo }],
+      })
+      onCreated?.(folder)
+      onOpenChange(false)
+      showSuccessToast("Folder created.")
+    },
+    onError: () => {
+      showErrorToast("Could not create folder.")
+    },
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create folder</DialogTitle>
+          <DialogDescription>
+            Choose where this folder is visible in the library.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          className="space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            if (!name.trim() || demo) return
+            createMutation.mutate()
+          }}
+        >
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="folder-name">
+              Folder name
+            </label>
+            <Input
+              id="folder-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Folder name"
+              autoFocus
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="folder-access">
+              Access
+            </label>
+            <Select
+              value={visibility}
+              onValueChange={(value) =>
+                setVisibility(value as V2DocumentVisibility)
+              }
+            >
+              <SelectTrigger id="folder-access" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="private">Private</SelectItem>
+                <SelectItem value="organization">Organization</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={createMutation.isPending}
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!name.trim() || demo || createMutation.isPending}
+            >
+              <FolderPlus className="size-4" />
+              {createMutation.isPending ? "Creating" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function FolderPickerDropdown({
+  folders,
+  currentFolderId,
+  disabled,
+  onSelect,
+  onCreateFolder,
+  align = "start",
+  triggerLabel,
+}: {
+  folders: V2DocumentFolderPublic[]
+  currentFolderId: string | null
+  disabled?: boolean
+  onSelect: (folderId: string | null) => void
+  onCreateFolder: () => void
+  align?: "start" | "center" | "end"
+  triggerLabel?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+
+  const selectedFolder = folders.find((folder) => folder.id === currentFolderId)
+  const filteredFolders = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    if (!needle) return folders
+    return folders.filter((folder) =>
+      folder.name.toLowerCase().includes(needle),
+    )
+  }, [folders, query])
+
+  const selectFolder = (folderId: string | null) => {
+    onSelect(folderId)
+    setOpen(false)
+    setQuery("")
+  }
+
+  return (
+    <DropdownMenu
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen)
+        if (!nextOpen) setQuery("")
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          className="max-w-full justify-start"
+        >
+          <Folder className="size-4" />
+          <span className="truncate">
+            {triggerLabel ?? selectedFolder?.name ?? "Unfiled"}
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={align} className="w-72 p-2">
+        <div className="relative mb-2">
+          <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => event.stopPropagation()}
+            placeholder="Search folders"
+            className="h-8 pl-8"
+          />
+        </div>
+        <div className="max-h-64 overflow-y-auto">
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault()
+              selectFolder(null)
+            }}
+            className="gap-2"
+          >
+            <Folder className="size-4" />
+            <span className="min-w-0 flex-1 truncate">Unfiled</span>
+            {currentFolderId === null && <Check className="size-4" />}
+          </DropdownMenuItem>
+          {filteredFolders.map((folder) => (
+            <DropdownMenuItem
+              key={folder.id}
+              onSelect={(event) => {
+                event.preventDefault()
+                selectFolder(folder.id)
+              }}
+              className="gap-2"
+            >
+              <Folder className="size-4" />
+              <span className="min-w-0 flex-1 truncate">{folder.name}</span>
+              {folder.visibility === "organization" && (
+                <Building2 className="size-3.5 text-muted-foreground" />
+              )}
+              {folder.id === currentFolderId && <Check className="size-4" />}
+            </DropdownMenuItem>
+          ))}
+          {filteredFolders.length === 0 && (
+            <div className="px-2 py-3 text-sm text-muted-foreground">
+              No folders found.
+            </div>
+          )}
+        </div>
+        <DropdownMenuSeparator />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className={cn("w-full justify-start")}
+          onClick={() => {
+            setOpen(false)
+            setQuery("")
+            onCreateFolder()
+          }}
+        >
+          <FolderPlus className="size-4" />
+          Create folder
+        </Button>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -8,6 +8,7 @@ import {
   Link as LinkIcon,
   Lock,
   Pencil,
+  Search,
   Share2,
   X,
 } from "lucide-react"
@@ -28,6 +29,7 @@ import {
   type V2DocumentParagraph,
   type V2DocumentPublic,
   type V2DocumentSharePermission,
+  type V2DocumentSharePublic,
   type V2DocumentUpdate,
   type V2DocumentVisibility,
 } from "@/api/v2Documents"
@@ -36,12 +38,11 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Input } from "@/components/ui/input"
 import {
   Select,
   SelectContent,
@@ -49,6 +50,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  FolderCreateDialog,
+  FolderPickerDropdown,
+} from "@/components/V2/Library/FolderControls"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
@@ -86,7 +91,6 @@ type EditableDoc = {
   description: string
   human_summary: string
   ai_generated_summary: string
-  collaborators: string
   folder_id: string | null
   visibility: V2DocumentVisibility
   details_file_name: string
@@ -102,7 +106,6 @@ function toEditable(document: V2DocumentPublic): EditableDoc {
     description: document.description,
     human_summary: document.human_summary,
     ai_generated_summary: document.ai_generated_summary,
-    collaborators: document.collaborators.join(", "),
     folder_id: document.folder_id ?? null,
     visibility: document.visibility,
     details_file_name: document.details_file_name,
@@ -121,10 +124,6 @@ function toUpdatePayload(edit: EditableDoc): V2DocumentUpdate {
     description: edit.description,
     human_summary: edit.human_summary,
     ai_generated_summary: edit.ai_generated_summary,
-    collaborators: edit.collaborators
-      .split(",")
-      .map((c) => c.trim())
-      .filter(Boolean),
     folder_id: edit.folder_id,
     visibility: edit.visibility,
     details_file_name: edit.details_file_name,
@@ -181,8 +180,9 @@ function TaskforceDocumentDetail() {
   const [anchorMode, setAnchorMode] = useState(false)
   const [summaryPick, setSummaryPick] = useState<AnchorPick | null>(null)
   const [detailsPick, setDetailsPick] = useState<DetailsPick | null>(null)
-  const [shareDialogOpen, setShareDialogOpen] = useState(false)
+  const [accessOpen, setAccessOpen] = useState(false)
   const [shareDraft, setShareDraft] = useState<ShareDraft>({})
+  const [createFolderOpen, setCreateFolderOpen] = useState(false)
 
   const documentQuery = useQuery({
     queryKey: ["v2-document", documentId, { demo: isDemoMode }],
@@ -223,6 +223,9 @@ function TaskforceDocumentDetail() {
       queryClient.invalidateQueries({
         queryKey: ["v2-documents", { demo: isDemoMode }],
       })
+      queryClient.invalidateQueries({
+        queryKey: ["v2-document-folders", { demo: isDemoMode }],
+      })
       showSuccessToast("Document saved.")
     },
     onError: () => {
@@ -248,7 +251,7 @@ function TaskforceDocumentDetail() {
       queryClient.invalidateQueries({
         queryKey: ["v2-documents", { demo: isDemoMode }],
       })
-      setShareDialogOpen(false)
+      setAccessOpen(false)
       showSuccessToast("Sharing updated.")
     },
     onError: () => {
@@ -302,14 +305,22 @@ function TaskforceDocumentDetail() {
     })
   }
 
-  const openShareDialog = () => {
+  const seedShareDraft = () => {
     const shares = sharesQuery.data?.data ?? document?.shared_with ?? []
     setShareDraft(
       Object.fromEntries(
         shares.map((share) => [share.user_id, share.permission]),
       ),
     )
-    setShareDialogOpen(true)
+  }
+
+  const setAccessDropdownOpen = (open: boolean) => {
+    if (open) seedShareDraft()
+    setAccessOpen(open)
+  }
+
+  const moveDocumentToFolder = (folderId: string | null) => {
+    updateMutation.mutate({ folder_id: folderId })
   }
 
   const confirmAnchor = () => {
@@ -428,18 +439,6 @@ function TaskforceDocumentDetail() {
           </Button>
 
           <div className="flex items-center gap-2">
-            {canManageDocument && !editing && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={openShareDialog}
-                data-testid="document-share"
-              >
-                <Share2 className="size-4" />
-                Share
-              </Button>
-            )}
             {!canEditDocument && (
               <Badge variant="outline">
                 <Eye className="size-3" />
@@ -600,20 +599,27 @@ function TaskforceDocumentDetail() {
           setEditState={setEditState}
           folders={foldersQuery.data?.data ?? []}
           canManageLibrary={canManageDocument}
+          organizationMembers={organizationQuery.data?.members ?? []}
+          shares={sharesQuery.data?.data ?? document.shared_with ?? []}
+          ownerId={document.owner_id}
+          accessOpen={accessOpen}
+          onAccessOpenChange={setAccessDropdownOpen}
+          shareDraft={shareDraft}
+          setShareDraft={setShareDraft}
+          onSaveAccess={() => shareMutation.mutate()}
+          isSavingAccess={shareMutation.isPending}
+          isLoadingAccess={sharesQuery.isLoading || organizationQuery.isLoading}
+          onMoveFolder={moveDocumentToFolder}
+          isMovingFolder={updateMutation.isPending}
+          onCreateFolder={() => setCreateFolderOpen(true)}
         />
 
-        {canManageDocument && (
-          <DocumentShareDialog
-            open={shareDialogOpen}
-            onOpenChange={setShareDialogOpen}
-            members={organizationQuery.data?.members ?? []}
-            ownerId={document.owner_id}
-            shareDraft={shareDraft}
-            setShareDraft={setShareDraft}
-            onSave={() => shareMutation.mutate()}
-            isSaving={shareMutation.isPending}
-          />
-        )}
+        <FolderCreateDialog
+          open={createFolderOpen}
+          onOpenChange={setCreateFolderOpen}
+          demo={isDemoMode}
+          onCreated={(folder) => moveDocumentToFolder(folder.id)}
+        />
 
         {anchorMode && (
           <AnchorHelper summaryPick={summaryPick} detailsPick={detailsPick} />
@@ -669,6 +675,19 @@ function DocumentMetadata({
   setEditState,
   folders,
   canManageLibrary,
+  organizationMembers,
+  shares,
+  ownerId,
+  accessOpen,
+  onAccessOpenChange,
+  shareDraft,
+  setShareDraft,
+  onSaveAccess,
+  isSavingAccess,
+  isLoadingAccess,
+  onMoveFolder,
+  isMovingFolder,
+  onCreateFolder,
 }: {
   document: V2DocumentPublic
   editing: boolean
@@ -676,9 +695,23 @@ function DocumentMetadata({
   setEditState: (next: EditableDoc) => void
   folders: V2DocumentFolderPublic[]
   canManageLibrary: boolean
+  organizationMembers: OrganizationMemberPublic[]
+  shares: V2DocumentSharePublic[]
+  ownerId: string
+  accessOpen: boolean
+  onAccessOpenChange: (open: boolean) => void
+  shareDraft: ShareDraft
+  setShareDraft: (next: ShareDraft) => void
+  onSaveAccess: () => void
+  isSavingAccess: boolean
+  isLoadingAccess: boolean
+  onMoveFolder: (folderId: string | null) => void
+  isMovingFolder: boolean
+  onCreateFolder: () => void
 }) {
   const visibilityLabel =
     document.visibility === "organization" ? "Organization" : "Private"
+  const sharedCount = shares.length
 
   return (
     <dl className="mt-5 grid gap-3 border-y py-4 text-sm text-muted-foreground md:grid-cols-2 xl:grid-cols-4">
@@ -697,28 +730,15 @@ function DocumentMetadata({
       <div className="min-w-0">
         <dt className="text-xs uppercase tracking-wide">Folder</dt>
         <dd className="mt-1">
-          {editing && editState && canManageLibrary ? (
-            <Select
-              value={editState.folder_id ?? "__none"}
-              onValueChange={(value) =>
-                setEditState({
-                  ...editState,
-                  folder_id: value === "__none" ? null : value,
-                })
-              }
-            >
-              <SelectTrigger className="w-full" size="sm">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__none">Unfiled</SelectItem>
-                {folders.map((folder) => (
-                  <SelectItem key={folder.id} value={folder.id}>
-                    {folder.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          {canManageLibrary ? (
+            <FolderPickerDropdown
+              folders={folders}
+              currentFolderId={document.folder_id ?? null}
+              disabled={isMovingFolder}
+              onSelect={onMoveFolder}
+              onCreateFolder={onCreateFolder}
+              triggerLabel={document.folder_name ?? "Unfiled"}
+            />
           ) : (
             <span className="inline-flex min-w-0 items-center gap-1.5 text-foreground">
               <Folder className="size-4 shrink-0 text-muted-foreground" />
@@ -730,7 +750,7 @@ function DocumentMetadata({
         </dd>
       </div>
       <div className="min-w-0">
-        <dt className="text-xs uppercase tracking-wide">Access</dt>
+        <dt className="text-xs uppercase tracking-wide">Visibility</dt>
         <dd className="mt-1">
           {editing && editState && canManageLibrary ? (
             <Select
@@ -763,25 +783,26 @@ function DocumentMetadata({
         </dd>
       </div>
       <div className="min-w-0 md:col-span-2 xl:col-span-4">
-        <dt className="text-xs uppercase tracking-wide">Collaborators</dt>
+        <dt className="text-xs uppercase tracking-wide">Access</dt>
         <dd className="mt-1">
-          {editing && editState ? (
-            <input
-              type="text"
-              value={editState.collaborators}
-              onChange={(event) =>
-                setEditState({
-                  ...editState,
-                  collaborators: event.target.value,
-                })
-              }
-              placeholder="Comma-separated"
-              className="w-full border bg-background px-2 py-1 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
-              data-testid="edit-collaborators"
+          {canManageLibrary ? (
+            <DocumentAccessDropdown
+              open={accessOpen}
+              onOpenChange={onAccessOpenChange}
+              members={organizationMembers}
+              ownerId={ownerId}
+              shares={shares}
+              shareDraft={shareDraft}
+              setShareDraft={setShareDraft}
+              onSave={onSaveAccess}
+              isSaving={isSavingAccess}
+              isLoading={isLoadingAccess}
             />
           ) : (
             <span className="text-foreground">
-              {document.collaborators.join(", ")}
+              {sharedCount > 0
+                ? `${sharedCount} member${sharedCount === 1 ? "" : "s"}`
+                : "Only owner"}
             </span>
           )}
         </dd>
@@ -790,106 +811,161 @@ function DocumentMetadata({
   )
 }
 
-function DocumentShareDialog({
+function DocumentAccessDropdown({
   open,
   onOpenChange,
   members,
   ownerId,
+  shares,
   shareDraft,
   setShareDraft,
   onSave,
   isSaving,
+  isLoading,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   members: OrganizationMemberPublic[]
   ownerId: string
+  shares: V2DocumentSharePublic[]
   shareDraft: ShareDraft
   setShareDraft: (draft: ShareDraft) => void
   onSave: () => void
   isSaving: boolean
+  isLoading: boolean
 }) {
+  const [query, setQuery] = useState("")
   const shareableMembers = members.filter((member) => member.id !== ownerId)
+  const filteredMembers = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    if (!needle) return shareableMembers
+    return shareableMembers.filter((member) =>
+      [member.full_name, member.email]
+        .filter(Boolean)
+        .some((value) => value?.toLowerCase().includes(needle)),
+    )
+  }, [query, shareableMembers])
   const assignedCount = Object.keys(shareDraft).length
+  const persistedCount = shares.length
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[560px]">
-        <DialogHeader>
-          <DialogTitle>Share document</DialogTitle>
-        </DialogHeader>
-        <div className="max-h-[55vh] space-y-2 overflow-y-auto pr-1">
-          {shareableMembers.length === 0 && (
-            <div className="border bg-card p-4 text-sm text-muted-foreground">
+    <DropdownMenu
+      open={open}
+      onOpenChange={(nextOpen) => {
+        onOpenChange(nextOpen)
+        if (!nextOpen) setQuery("")
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-testid="document-access"
+        >
+          <Share2 className="size-4" />
+          {persistedCount > 0
+            ? `${persistedCount} member${persistedCount === 1 ? "" : "s"}`
+            : "Only owner"}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[360px] p-2">
+        <div className="relative mb-2">
+          <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => event.stopPropagation()}
+            placeholder="Search organization users"
+            className="h-8 pl-8"
+          />
+        </div>
+        <div className="max-h-72 space-y-1 overflow-y-auto">
+          {isLoading && (
+            <div className="px-2 py-3 text-sm text-muted-foreground">
+              Loading access…
+            </div>
+          )}
+          {!isLoading && shareableMembers.length === 0 && (
+            <div className="px-2 py-3 text-sm text-muted-foreground">
               No organization members available.
             </div>
           )}
-          {shareableMembers.map((member) => {
-            const permission = shareDraft[member.id]
-            const checked = Boolean(permission)
-            return (
-              <div
-                key={member.id}
-                className="grid grid-cols-[auto_minmax(0,1fr)_130px] items-center gap-3 border p-3"
-              >
-                <Checkbox
-                  id={`share-${member.id}`}
-                  checked={checked}
-                  onCheckedChange={(nextChecked) => {
-                    const next = { ...shareDraft }
-                    if (nextChecked === true) {
-                      next[member.id] = permission ?? "editor"
-                    } else {
-                      delete next[member.id]
-                    }
-                    setShareDraft(next)
-                  }}
-                />
-                <label htmlFor={`share-${member.id}`} className="min-w-0">
-                  <span className="block truncate text-sm font-medium text-foreground">
-                    {member.full_name || member.email}
-                  </span>
-                  <span className="block truncate text-xs text-muted-foreground">
-                    {member.email}
-                  </span>
-                </label>
-                <Select
-                  value={permission ?? "editor"}
-                  disabled={!checked}
-                  onValueChange={(value) =>
-                    setShareDraft({
-                      ...shareDraft,
-                      [member.id]: value as V2DocumentSharePermission,
-                    })
-                  }
-                >
-                  <SelectTrigger className="w-full" size="sm">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="editor">Editor</SelectItem>
-                    <SelectItem value="viewer">Viewer</SelectItem>
-                  </SelectContent>
-                </Select>
+          {!isLoading &&
+            filteredMembers.length === 0 &&
+            shareableMembers.length > 0 && (
+              <div className="px-2 py-3 text-sm text-muted-foreground">
+                No users found.
               </div>
-            )
-          })}
+            )}
+          {!isLoading &&
+            filteredMembers.map((member) => {
+              const permission = shareDraft[member.id]
+              const checked = Boolean(permission)
+              return (
+                <div
+                  key={member.id}
+                  className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-md border p-2"
+                >
+                  <Checkbox
+                    id={`share-${member.id}`}
+                    checked={checked}
+                    onCheckedChange={(nextChecked) => {
+                      const next = { ...shareDraft }
+                      if (nextChecked === true) {
+                        next[member.id] = permission ?? "editor"
+                      } else {
+                        delete next[member.id]
+                      }
+                      setShareDraft(next)
+                    }}
+                  />
+                  <label htmlFor={`share-${member.id}`} className="min-w-0">
+                    <span className="block truncate text-sm font-medium text-foreground">
+                      {member.full_name || member.email}
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {member.email}
+                    </span>
+                  </label>
+                  <div className="flex rounded-md border p-0.5">
+                    {(["viewer", "editor"] as V2DocumentSharePermission[]).map(
+                      (option) => (
+                        <button
+                          key={option}
+                          type="button"
+                          disabled={!checked}
+                          onClick={() =>
+                            setShareDraft({
+                              ...shareDraft,
+                              [member.id]: option,
+                            })
+                          }
+                          className={cn(
+                            "rounded px-2 py-1 text-xs capitalize disabled:opacity-40",
+                            permission === option &&
+                              "bg-foreground text-background",
+                          )}
+                        >
+                          {option}
+                        </button>
+                      ),
+                    )}
+                  </div>
+                </div>
+              )
+            })}
         </div>
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={() => onOpenChange(false)}
-            disabled={isSaving}
-          >
-            Cancel
+        <div className="mt-2 flex items-center justify-between border-t pt-2">
+          <span className="text-xs text-muted-foreground">
+            {assignedCount} selected
+          </span>
+          <Button type="button" size="sm" onClick={onSave} disabled={isSaving}>
+            {isSaving ? "Saving" : "Save access"}
           </Button>
-          <Button type="button" onClick={onSave} disabled={isSaving}>
-            {isSaving ? "Saving" : `Save ${assignedCount}`}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 import {
   createFileRoute,
   Link,
@@ -15,10 +15,9 @@ import {
   Share2,
   Users,
 } from "lucide-react"
-import { type FormEvent, type ReactNode, useMemo, useState } from "react"
+import { type ReactNode, useMemo, useState } from "react"
 
 import {
-  createV2DocumentFolder,
   readV2DocumentFolders,
   readV2Documents,
   type V2DocumentFolderPublic,
@@ -28,14 +27,7 @@ import {
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import useCustomToast from "@/hooks/useCustomToast"
+import { FolderCreateDialog } from "@/components/V2/Library/FolderControls"
 import { cn } from "@/lib/utils"
 
 export const Route = createFileRoute("/v2/library")({
@@ -60,12 +52,8 @@ function formatDateOnly(value: string | null): string {
 function TaskforceLibrary() {
   const { isDemoMode } = useDemoMode()
   const router = useRouterState()
-  const queryClient = useQueryClient()
-  const { showSuccessToast, showErrorToast } = useCustomToast()
   const [selectedFolderId, setSelectedFolderId] = useState("all")
-  const [folderName, setFolderName] = useState("")
-  const [folderVisibility, setFolderVisibility] =
-    useState<V2DocumentVisibility>("private")
+  const [createFolderOpen, setCreateFolderOpen] = useState(false)
 
   const documentsQuery = useQuery({
     queryKey: ["v2-documents", { demo: isDemoMode }],
@@ -75,24 +63,6 @@ function TaskforceLibrary() {
   const foldersQuery = useQuery({
     queryKey: ["v2-document-folders", { demo: isDemoMode }],
     queryFn: () => readV2DocumentFolders({ demo: isDemoMode }),
-  })
-
-  const createFolderMutation = useMutation({
-    mutationFn: () =>
-      createV2DocumentFolder({
-        name: folderName.trim(),
-        visibility: folderVisibility,
-      }),
-    onSuccess: () => {
-      setFolderName("")
-      queryClient.invalidateQueries({
-        queryKey: ["v2-document-folders", { demo: isDemoMode }],
-      })
-      showSuccessToast("Folder created.")
-    },
-    onError: () => {
-      showErrorToast("Could not create folder.")
-    },
   })
 
   const documents = documentsQuery.data?.data ?? []
@@ -126,12 +96,6 @@ function TaskforceLibrary() {
   const isFolderEmpty =
     !isLoading && documents.length > 0 && visibleDocuments.length === 0
 
-  const submitFolder = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!folderName.trim() || isDemoMode) return
-    createFolderMutation.mutate()
-  }
-
   if (router.location.pathname.startsWith("/v2/library/")) {
     return <Outlet />
   }
@@ -141,43 +105,24 @@ function TaskforceLibrary() {
       <div className="flex shrink-0 flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <h1 className="text-2xl font-semibold">Library</h1>
         {!isDemoMode && (
-          <form
-            className="flex w-full flex-col gap-2 sm:flex-row lg:w-auto"
-            onSubmit={submitFolder}
+          <Button
+            type="button"
+            size="sm"
+            className="w-fit"
+            onClick={() => setCreateFolderOpen(true)}
           >
-            <input
-              type="text"
-              value={folderName}
-              onChange={(event) => setFolderName(event.target.value)}
-              placeholder="New folder"
-              className="h-9 min-w-0 border bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring sm:w-48"
-              data-testid="new-folder-name"
-            />
-            <Select
-              value={folderVisibility}
-              onValueChange={(value) =>
-                setFolderVisibility(value as V2DocumentVisibility)
-              }
-            >
-              <SelectTrigger className="w-full sm:w-36" size="sm">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="private">Private</SelectItem>
-                <SelectItem value="organization">Organization</SelectItem>
-              </SelectContent>
-            </Select>
-            <Button
-              type="submit"
-              size="sm"
-              disabled={!folderName.trim() || createFolderMutation.isPending}
-            >
-              <FolderPlus className="size-4" />
-              {createFolderMutation.isPending ? "Creating" : "Create"}
-            </Button>
-          </form>
+            <FolderPlus className="size-4" />
+            Create folder
+          </Button>
         )}
       </div>
+
+      <FolderCreateDialog
+        open={createFolderOpen}
+        onOpenChange={setCreateFolderOpen}
+        demo={isDemoMode}
+        onCreated={(folder) => setSelectedFolderId(folder.id)}
+      />
 
       {isLoading && (
         <div className="border bg-card p-6 text-sm text-muted-foreground">
@@ -365,8 +310,12 @@ function DocumentCard({ document }: { document: V2DocumentPublic }) {
         </div>
         <div className="flex items-center gap-2">
           <Users className="size-4" />
-          <dt className="sr-only">Collaborators</dt>
-          <dd>{document.collaborators.join(", ")}</dd>
+          <dt className="sr-only">Access</dt>
+          <dd>
+            {sharedCount > 0
+              ? `${sharedCount} shared member${sharedCount === 1 ? "" : "s"}`
+              : "Only owner"}
+          </dd>
         </div>
       </dl>
 


### PR DESCRIPTION
## Summary

Adds document-level folder movement and access management controls for the V2 library.

## Changes

- Adds a reusable folder create modal with folder name and access visibility.
- Replaces the inline library folder creation form with the shared create modal.
- Adds a searchable folder dropdown on the document page; selecting a folder moves the document immediately.
- Lets users create a new folder from the document folder dropdown and moves the document into the new folder after creation.
- Removes the document-page Collaborators field from editing/metadata.
- Adds an Access dropdown on the document page with organization-user search, add/remove sharing, and viewer/editor permissions.
- Updates library cards to show document access/share count instead of collaborators.

## Validation

- `npx biome check src/routes/v2/library.tsx 'src/routes/v2/library.$documentId.tsx' src/components/V2/Library/FolderControls.tsx`
- `npm run build`

Note: Vite prints the existing warning that the local shell is Node `18.19.1`; Vite wants Node `20.19+` or `22.12+`. The build completed successfully.