### PR TITLE
Tell V2 agents to report token usage and unbreak /v2/metrics deep links

### DIFF
--- a/.github/workflows/deploy-frontend-pages.yml
+++ b/.github/workflows/deploy-frontend-pages.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Static route entrypoints for GitHub Pages
         run: |
-          for route in login signup recover-password reset-password topics cases settings admin v2 v2/home v2/library v2/library/8c9b0f48-2f3f-4e8d-9f7d-b4f0607d6a32 v2/library/5b7462e9-6b0e-4d48-81a2-07f052534a12 v2/library/0fd8a545-a3b7-4a9f-bb65-1ecf76bd8b6d v2/admin; do
+          for route in login signup recover-password reset-password topics cases settings admin v2 v2/home v2/library v2/library/8c9b0f48-2f3f-4e8d-9f7d-b4f0607d6a32 v2/library/5b7462e9-6b0e-4d48-81a2-07f052534a12 v2/library/0fd8a545-a3b7-4a9f-bb65-1ecf76bd8b6d v2/admin v2/metrics v2/metrics/methodology; do
             mkdir -p "dist/$route"
             cp dist/index.html "dist/$route/index.html"
           done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ For V2-enabled users:
 4. maintain both document views: a concise Summary view shown by default and a comprehensive Details view available on demand
 5. back every Summary claim with evidence anchors that navigate to the relevant Details section or another source document
 6. finish/finalize the document when the work is complete or stops
+7. on each begin/update/finish call, report per-turn token usage (model_id, input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens) from the most recent assistant turn so the Taskforce Metrics page can price it and attribute savings; when answering from Summary alone without expanding Details, also report `view_consulted: "summary"` to unlock the summary-only savings calculation
 
 For approved V1 fallback:
 1. call `enderai_begin_case`

--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -95,6 +95,7 @@ function buildAgentInstructionSnippet({
       "- Use `enderai_update_document` as material progress develops (commands, files, links, decisions, changes, open questions, progress notes). Pass `details_sections` with stable `anchor_id`s to upsert specific Details sections, and `summary_points` for new Summary claims.",
       "- Back every Summary claim with `evidence_anchor_id` segments that point at a Details section. Do not edit `human_summary` unless the user explicitly asks.",
       "- Use `enderai_finish_document` when the work completes or pauses; it writes an Outcome section (status, outcome, validation, follow-ups) and clears the active document pointer.",
+      "- On each `enderai_begin_document` / `enderai_update_document` / `enderai_finish_document` call, pass `usage` with the model_id and per-turn token counts (input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens) from your most recent assistant turn so the Taskforce Metrics page can price it and attribute savings. When you answered from the document's Summary view without expanding Details, also set `view_consulted` to `\"summary\"` so the summary-only savings calculation fires.",
       "- Prefer Taskforce V2 document tools over the legacy V1 `enderai_begin_case` workflow and over raw `enderai_request` when both are available.",
       "- If Taskforce V2 document tools are unavailable, do not fabricate tool calls; tell the user they are unavailable and fall back only to tools the user explicitly approves.",
     ].join("\n")


### PR DESCRIPTION
## Summary

- The directive that V2 users actually receive — `buildAgentInstructionSnippet` in `ConnectAgent.tsx` and the portable template at `AGENTS.md` — never told the agent to report `usage`, even though the backend (#43–#47) and now the MCP tool schemas (al-exe/EnderAI#48) expect it. Without this, the Taskforce Metrics page stays empty.
- Fixes a deploy-pipeline gap where `/v2/metrics` and `/v2/metrics/methodology` 4 0 4'd on direct hits and refreshes. The Pages workflow hand-lists deep routes that get a 200 entrypoint and these two were missing — that's why "How this is calculated" on prod returns a 404.

## What changed

- `src/components/UserSettings/ConnectAgent.tsx`: V2 snippet now instructs the agent to pass `usage` (`model_id`, `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`) on each begin/update/finish call, and to set `view_consulted` to `"summary"` when answering from Summary alone.
- `AGENTS.md`: portable template gets the same step (#7) in the Meaningful Work Workflow.
- `.github/workflows/deploy-frontend-pages.yml`: adds `v2/metrics` and `v2/metrics/methodology` to the static-entrypoint route list.

## Test plan

- [ ] Open the Connect Agent UI; verify the V2 snippet contains the new "report usage" line.
- [ ] After deploy, hard-refresh `https://www.enderai.xyz/v2/metrics/methodology` and verify it returns 200 and renders the methodology doc.
- [ ] Hard-refresh `https://www.enderai.xyz/v2/metrics` and verify it returns 200 and renders the Metrics tab.

## Related

- al-exe/EnderAI#48 — exposes `usage` on the V2 document MCP tool input schemas. Ship that and this together to fully close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)