### PR TITLE
Enhance library organization and Taskforce Pro page

### DIFF
--- a/src/api/v2Documents.ts
+++ b/src/api/v2Documents.ts
@@ -38,6 +38,7 @@ export interface V2DocumentPublic {
   folder_name?: string | null
   visibility: V2DocumentVisibility
   user_access: V2DocumentAccess
+  is_favorite: boolean
   title: string
   description: string
   human_summary: string
@@ -74,6 +75,7 @@ export interface V2DocumentFolderPublic {
   id: string
   owner_id: string
   organization_id?: string | null
+  parent_folder_id?: string | null
   name: string
   visibility: V2DocumentVisibility
   created_at: string | null
@@ -88,11 +90,13 @@ export interface V2DocumentFoldersPublic {
 export interface V2DocumentFolderCreate {
   name: string
   visibility?: V2DocumentVisibility
+  parent_folder_id?: string | null
 }
 
 export interface V2DocumentFolderUpdate {
   name?: string
   visibility?: V2DocumentVisibility
+  parent_folder_id?: string | null
 }
 
 export interface V2DocumentSharesPublic {
@@ -206,6 +210,38 @@ export function replaceV2DocumentShares(
       document_id: documentId,
     },
     body,
+  })
+}
+
+export function favoriteV2Document(
+  documentId: string,
+  options: { demo?: boolean } = {},
+): CancelablePromise<V2DocumentPublic> {
+  return request(OpenAPI, {
+    method: "PUT",
+    url: "/api/v1/v2/documents/{document_id}/favorite",
+    path: {
+      document_id: documentId,
+    },
+    query: {
+      demo: options.demo || undefined,
+    },
+  })
+}
+
+export function unfavoriteV2Document(
+  documentId: string,
+  options: { demo?: boolean } = {},
+): CancelablePromise<V2DocumentPublic> {
+  return request(OpenAPI, {
+    method: "DELETE",
+    url: "/api/v1/v2/documents/{document_id}/favorite",
+    path: {
+      document_id: documentId,
+    },
+    query: {
+      demo: options.demo || undefined,
+    },
   })
 }
 

--- a/src/components/V2/Library/FolderControls.tsx
+++ b/src/components/V2/Library/FolderControls.tsx
@@ -1,9 +1,20 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { Building2, Check, Folder, FolderPlus, Search } from "lucide-react"
+import {
+  Building2,
+  Check,
+  Folder,
+  FolderPlus,
+  MoreHorizontal,
+  Pencil,
+  Search,
+  Trash2,
+} from "lucide-react"
 import { useMemo, useState } from "react"
 
 import {
   createV2DocumentFolder,
+  deleteV2DocumentFolder,
+  updateV2DocumentFolder,
   type V2DocumentFolderPublic,
   type V2DocumentVisibility,
 } from "@/api/v2Documents"
@@ -34,31 +45,73 @@ import {
 import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
 
+function getFolderDepths(
+  folders: V2DocumentFolderPublic[],
+): Map<string, number> {
+  const byId = new Map(folders.map((folder) => [folder.id, folder]))
+  const depths = new Map<string, number>()
+
+  const getDepth = (
+    folder: V2DocumentFolderPublic,
+    seen = new Set<string>(),
+  ): number => {
+    if (depths.has(folder.id)) return depths.get(folder.id) ?? 0
+    if (!folder.parent_folder_id || seen.has(folder.id)) {
+      depths.set(folder.id, 0)
+      return 0
+    }
+    const parent = byId.get(folder.parent_folder_id)
+    if (!parent) {
+      depths.set(folder.id, 0)
+      return 0
+    }
+    const nextSeen = new Set(seen).add(folder.id)
+    const depth = getDepth(parent, nextSeen) + 1
+    depths.set(folder.id, depth)
+    return depth
+  }
+
+  for (const folder of folders) {
+    getDepth(folder)
+  }
+  return depths
+}
+
 export function FolderCreateDialog({
   open,
   onOpenChange,
   demo,
+  folders = [],
+  initialParentFolderId = null,
   onCreated,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   demo: boolean
+  folders?: V2DocumentFolderPublic[]
+  initialParentFolderId?: string | null
   onCreated?: (folder: V2DocumentFolderPublic) => void
 }) {
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const [name, setName] = useState("")
   const [visibility, setVisibility] = useState<V2DocumentVisibility>("private")
+  const [parentFolderId, setParentFolderId] = useState<string | null>(
+    initialParentFolderId,
+  )
+  const folderDepths = useMemo(() => getFolderDepths(folders), [folders])
 
   const createMutation = useMutation({
     mutationFn: () =>
       createV2DocumentFolder({
         name: name.trim(),
         visibility,
+        parent_folder_id: parentFolderId,
       }),
     onSuccess: (folder) => {
       setName("")
       setVisibility("private")
+      setParentFolderId(initialParentFolderId)
       queryClient.invalidateQueries({
         queryKey: ["v2-document-folders", { demo }],
       })
@@ -77,7 +130,7 @@ export function FolderCreateDialog({
         <DialogHeader>
           <DialogTitle>Create folder</DialogTitle>
           <DialogDescription>
-            Choose where this folder is visible in the library.
+            Choose where this folder lives and who can access it.
           </DialogDescription>
         </DialogHeader>
         <form
@@ -119,6 +172,32 @@ export function FolderCreateDialog({
               </SelectContent>
             </Select>
           </div>
+          {folders.length > 0 && (
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="folder-parent">
+                Parent folder
+              </label>
+              <Select
+                value={parentFolderId ?? "root"}
+                onValueChange={(value) =>
+                  setParentFolderId(value === "root" ? null : value)
+                }
+              >
+                <SelectTrigger id="folder-parent" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="root">Top level</SelectItem>
+                  {folders.map((folder) => (
+                    <SelectItem key={folder.id} value={folder.id}>
+                      {"  ".repeat(folderDepths.get(folder.id) ?? 0)}
+                      {folder.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
           <DialogFooter>
             <Button
               type="button"
@@ -139,6 +218,188 @@ export function FolderCreateDialog({
         </form>
       </DialogContent>
     </Dialog>
+  )
+}
+
+export function FolderActionsMenu({
+  folder,
+  demo,
+  onDeleted,
+  align = "end",
+}: {
+  folder: V2DocumentFolderPublic
+  demo: boolean
+  onDeleted?: (folderId: string) => void
+  align?: "start" | "center" | "end"
+}) {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const [renameOpen, setRenameOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [name, setName] = useState(folder.name)
+
+  const invalidateLibraryQueries = () => {
+    queryClient.invalidateQueries({
+      queryKey: ["v2-document-folders", { demo }],
+    })
+    queryClient.invalidateQueries({
+      queryKey: ["v2-documents", { demo }],
+    })
+  }
+
+  const renameMutation = useMutation({
+    mutationFn: () =>
+      updateV2DocumentFolder(folder.id, {
+        name: name.trim(),
+      }),
+    onSuccess: () => {
+      invalidateLibraryQueries()
+      setRenameOpen(false)
+      showSuccessToast("Folder renamed.")
+    },
+    onError: () => {
+      showErrorToast("Could not rename folder.")
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteV2DocumentFolder(folder.id),
+    onSuccess: () => {
+      invalidateLibraryQueries()
+      setDeleteOpen(false)
+      onDeleted?.(folder.id)
+      showSuccessToast("Folder deleted.")
+    },
+    onError: () => {
+      showErrorToast("Could not delete folder.")
+    },
+  })
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            disabled={demo}
+            aria-label={`Open options for ${folder.name}`}
+            onClick={(event) => event.stopPropagation()}
+            onDragStart={(event) => event.preventDefault()}
+          >
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align={align} className="w-44">
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault()
+              setName(folder.name)
+              setRenameOpen(true)
+            }}
+          >
+            <Pencil className="size-4" />
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            variant="destructive"
+            onSelect={(event) => {
+              event.preventDefault()
+              setDeleteOpen(true)
+            }}
+          >
+            <Trash2 className="size-4" />
+            Delete folder
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Rename folder</DialogTitle>
+            <DialogDescription>
+              Update the folder name shown in your library.
+            </DialogDescription>
+          </DialogHeader>
+          <form
+            className="space-y-4"
+            onSubmit={(event) => {
+              event.preventDefault()
+              if (!name.trim() || demo) return
+              renameMutation.mutate()
+            }}
+          >
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium"
+                htmlFor={`rename-folder-${folder.id}`}
+              >
+                Folder name
+              </label>
+              <Input
+                id={`rename-folder-${folder.id}`}
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                autoFocus
+              />
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={renameMutation.isPending}
+                onClick={() => setRenameOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  !name.trim() ||
+                  name.trim() === folder.name ||
+                  demo ||
+                  renameMutation.isPending
+                }
+              >
+                {renameMutation.isPending ? "Renaming" : "Rename"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete folder?</DialogTitle>
+            <DialogDescription>
+              This removes “{folder.name}” from the library. Documents in this
+              folder will not be deleted; they will move to Unfiled.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={deleteMutation.isPending}
+              onClick={() => setDeleteOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={demo || deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate()}
+            >
+              {deleteMutation.isPending ? "Deleting" : "Delete folder"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }
 
@@ -163,6 +424,7 @@ export function FolderPickerDropdown({
   const [query, setQuery] = useState("")
 
   const selectedFolder = folders.find((folder) => folder.id === currentFolderId)
+  const folderDepths = useMemo(() => getFolderDepths(folders), [folders])
   const filteredFolders = useMemo(() => {
     const needle = query.trim().toLowerCase()
     if (!needle) return folders
@@ -232,7 +494,14 @@ export function FolderPickerDropdown({
               className="gap-2"
             >
               <Folder className="size-4" />
-              <span className="min-w-0 flex-1 truncate">{folder.name}</span>
+              <span
+                className="min-w-0 flex-1 truncate"
+                style={{
+                  paddingLeft: `${(folderDepths.get(folder.id) ?? 0) * 12}px`,
+                }}
+              >
+                {folder.name}
+              </span>
               {folder.visibility === "organization" && (
                 <Building2 className="size-3.5 text-muted-foreground" />
               )}

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -9,6 +9,7 @@ import {
   BarChart3,
   BookOpenText,
   Component,
+  CreditCard,
   Home,
   Search,
   Shield,
@@ -60,6 +61,7 @@ const taskforceItems: TaskforceNavItem[] = [
   { icon: Home, title: "Home", path: "/v2/home" },
   { icon: BookOpenText, title: "Library", path: "/v2/library" },
   { icon: BarChart3, title: "Metrics", path: "/v2/metrics" },
+  { icon: CreditCard, title: "Taskforce Pro", path: "/v2/pricing" },
 ]
 
 function TaskforceMark() {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as V2IndexRouteImport } from './routes/v2/index'
+import { Route as V2PricingRouteImport } from './routes/v2/pricing'
 import { Route as V2MetricsRouteImport } from './routes/v2/metrics'
 import { Route as V2LibraryRouteImport } from './routes/v2/library'
 import { Route as V2HomeRouteImport } from './routes/v2/home'
@@ -67,6 +68,11 @@ const IndexRoute = IndexRouteImport.update({
 const V2IndexRoute = V2IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => V2Route,
+} as any)
+const V2PricingRoute = V2PricingRouteImport.update({
+  id: '/pricing',
+  path: '/pricing',
   getParentRoute: () => V2Route,
 } as any)
 const V2MetricsRoute = V2MetricsRouteImport.update({
@@ -147,6 +153,7 @@ export interface FileRoutesByFullPath {
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
+  '/v2/pricing': typeof V2PricingRoute
   '/v2/': typeof V2IndexRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
@@ -167,6 +174,7 @@ export interface FileRoutesByTo {
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
+  '/v2/pricing': typeof V2PricingRoute
   '/v2': typeof V2IndexRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
@@ -190,6 +198,7 @@ export interface FileRoutesById {
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
+  '/v2/pricing': typeof V2PricingRoute
   '/v2/': typeof V2IndexRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
@@ -213,6 +222,7 @@ export interface FileRouteTypes {
     | '/v2/home'
     | '/v2/library'
     | '/v2/metrics'
+    | '/v2/pricing'
     | '/v2/'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
@@ -233,6 +243,7 @@ export interface FileRouteTypes {
     | '/v2/home'
     | '/v2/library'
     | '/v2/metrics'
+    | '/v2/pricing'
     | '/v2'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
@@ -255,6 +266,7 @@ export interface FileRouteTypes {
     | '/v2/home'
     | '/v2/library'
     | '/v2/metrics'
+    | '/v2/pricing'
     | '/v2/'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
@@ -326,6 +338,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/v2/'
       preLoaderRoute: typeof V2IndexRouteImport
+      parentRoute: typeof V2Route
+    }
+    '/v2/pricing': {
+      id: '/v2/pricing'
+      path: '/pricing'
+      fullPath: '/v2/pricing'
+      preLoaderRoute: typeof V2PricingRouteImport
       parentRoute: typeof V2Route
     }
     '/v2/metrics': {
@@ -465,6 +484,7 @@ interface V2RouteChildren {
   V2HomeRoute: typeof V2HomeRoute
   V2LibraryRoute: typeof V2LibraryRouteWithChildren
   V2MetricsRoute: typeof V2MetricsRouteWithChildren
+  V2PricingRoute: typeof V2PricingRoute
   V2IndexRoute: typeof V2IndexRoute
 }
 
@@ -473,6 +493,7 @@ const V2RouteChildren: V2RouteChildren = {
   V2HomeRoute: V2HomeRoute,
   V2LibraryRoute: V2LibraryRouteWithChildren,
   V2MetricsRoute: V2MetricsRouteWithChildren,
+  V2PricingRoute: V2PricingRoute,
   V2IndexRoute: V2IndexRoute,
 }
 

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -2,11 +2,9 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import {
   ArrowLeft,
-  Building2,
   Eye,
   Folder,
   Link as LinkIcon,
-  Lock,
   Pencil,
   Search,
   Share2,
@@ -31,7 +29,6 @@ import {
   type V2DocumentSharePermission,
   type V2DocumentSharePublic,
   type V2DocumentUpdate,
-  type V2DocumentVisibility,
 } from "@/api/v2Documents"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Badge } from "@/components/ui/badge"
@@ -43,13 +40,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import {
   FolderCreateDialog,
   FolderPickerDropdown,
@@ -92,7 +82,6 @@ type EditableDoc = {
   human_summary: string
   ai_generated_summary: string
   folder_id: string | null
-  visibility: V2DocumentVisibility
   details_file_name: string
   main_body: V2DocumentParagraph[]
   details_markdown_sections: V2DocumentDetailsSection[]
@@ -107,7 +96,6 @@ function toEditable(document: V2DocumentPublic): EditableDoc {
     human_summary: document.human_summary,
     ai_generated_summary: document.ai_generated_summary,
     folder_id: document.folder_id ?? null,
-    visibility: document.visibility,
     details_file_name: document.details_file_name,
     main_body: document.main_body.map((p) => ({
       segments: p.segments.map((s) => ({ ...s })),
@@ -125,7 +113,6 @@ function toUpdatePayload(edit: EditableDoc): V2DocumentUpdate {
     human_summary: edit.human_summary,
     ai_generated_summary: edit.ai_generated_summary,
     folder_id: edit.folder_id,
-    visibility: edit.visibility,
     details_file_name: edit.details_file_name,
     main_body: edit.main_body,
     details_markdown_sections: edit.details_markdown_sections,
@@ -594,9 +581,6 @@ function TaskforceDocumentDetail() {
 
         <DocumentMetadata
           document={document}
-          editing={editing}
-          editState={editState}
-          setEditState={setEditState}
           folders={foldersQuery.data?.data ?? []}
           canManageLibrary={canManageDocument}
           organizationMembers={organizationQuery.data?.members ?? []}
@@ -618,6 +602,7 @@ function TaskforceDocumentDetail() {
           open={createFolderOpen}
           onOpenChange={setCreateFolderOpen}
           demo={isDemoMode}
+          folders={foldersQuery.data?.data ?? []}
           onCreated={(folder) => moveDocumentToFolder(folder.id)}
         />
 
@@ -670,9 +655,6 @@ function TaskforceDocumentDetail() {
 
 function DocumentMetadata({
   document,
-  editing,
-  editState,
-  setEditState,
   folders,
   canManageLibrary,
   organizationMembers,
@@ -690,9 +672,6 @@ function DocumentMetadata({
   onCreateFolder,
 }: {
   document: V2DocumentPublic
-  editing: boolean
-  editState: EditableDoc | null
-  setEditState: (next: EditableDoc) => void
   folders: V2DocumentFolderPublic[]
   canManageLibrary: boolean
   organizationMembers: OrganizationMemberPublic[]
@@ -709,12 +688,10 @@ function DocumentMetadata({
   isMovingFolder: boolean
   onCreateFolder: () => void
 }) {
-  const visibilityLabel =
-    document.visibility === "organization" ? "Organization" : "Private"
   const sharedCount = shares.length
 
   return (
-    <dl className="mt-5 grid gap-3 border-y py-4 text-sm text-muted-foreground md:grid-cols-2 xl:grid-cols-4">
+    <dl className="mt-5 grid gap-3 border-y py-4 text-sm text-muted-foreground md:grid-cols-2 xl:grid-cols-3">
       <div className="min-w-0">
         <dt className="text-xs uppercase tracking-wide">Created</dt>
         <dd className="mt-1 text-foreground">
@@ -749,40 +726,7 @@ function DocumentMetadata({
           )}
         </dd>
       </div>
-      <div className="min-w-0">
-        <dt className="text-xs uppercase tracking-wide">Visibility</dt>
-        <dd className="mt-1">
-          {editing && editState && canManageLibrary ? (
-            <Select
-              value={editState.visibility}
-              onValueChange={(value) =>
-                setEditState({
-                  ...editState,
-                  visibility: value as V2DocumentVisibility,
-                })
-              }
-            >
-              <SelectTrigger className="w-full" size="sm">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="private">Private</SelectItem>
-                <SelectItem value="organization">Organization</SelectItem>
-              </SelectContent>
-            </Select>
-          ) : (
-            <span className="inline-flex items-center gap-1.5 text-foreground">
-              {document.visibility === "organization" ? (
-                <Building2 className="size-4 text-muted-foreground" />
-              ) : (
-                <Lock className="size-4 text-muted-foreground" />
-              )}
-              {visibilityLabel}
-            </span>
-          )}
-        </dd>
-      </div>
-      <div className="min-w-0 md:col-span-2 xl:col-span-4">
+      <div className="min-w-0 md:col-span-2 xl:col-span-3">
         <dt className="text-xs uppercase tracking-wide">Access</dt>
         <dd className="mt-1">
           {canManageLibrary ? (

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -16,15 +16,20 @@ import {
   FolderPlus,
   Lock,
   Share2,
+  Star,
   Users,
 } from "lucide-react"
 import { type DragEvent, type ReactNode, useMemo, useState } from "react"
 
 import {
+  favoriteV2Document,
   readV2DocumentFolders,
   readV2Documents,
+  unfavoriteV2Document,
   updateV2Document,
+  updateV2DocumentFolder,
   type V2DocumentFolderPublic,
+  type V2DocumentFoldersPublic,
   type V2DocumentPublic,
   type V2DocumentsPublic,
   type V2DocumentVisibility,
@@ -32,7 +37,10 @@ import {
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { FolderCreateDialog } from "@/components/V2/Library/FolderControls"
+import {
+  FolderActionsMenu,
+  FolderCreateDialog,
+} from "@/components/V2/Library/FolderControls"
 import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
 
@@ -55,19 +63,72 @@ function formatDateOnly(value: string | null): string {
   }).format(new Date(value))
 }
 
+type FolderTreeNode = {
+  folder: V2DocumentFolderPublic
+  children: FolderTreeNode[]
+}
+
+type DirectoryDropTargetId = "root" | "unfiled" | string
+type OwnershipFilter = "owned" | "shared"
+type FavoriteUpdate = { documentId: string; favorite: boolean }
+
+function buildFolderTree(folders: V2DocumentFolderPublic[]): FolderTreeNode[] {
+  const nodes = new Map<string, FolderTreeNode>()
+  for (const folder of folders) {
+    nodes.set(folder.id, { folder, children: [] })
+  }
+
+  const roots: FolderTreeNode[] = []
+  for (const node of nodes.values()) {
+    const parentId = node.folder.parent_folder_id
+    const parent =
+      parentId && parentId !== node.folder.id ? nodes.get(parentId) : null
+    if (parent) {
+      parent.children.push(node)
+    } else {
+      roots.push(node)
+    }
+  }
+
+  return roots
+}
+
+function isDescendantFolder(
+  folders: V2DocumentFolderPublic[],
+  parentFolderId: string | null,
+  folderId: string,
+) {
+  if (!parentFolderId) return false
+  const byId = new Map(folders.map((folder) => [folder.id, folder]))
+  let current = byId.get(parentFolderId)
+  const seen = new Set<string>()
+  while (current) {
+    if (current.id === folderId) return true
+    if (!current.parent_folder_id || seen.has(current.id)) return false
+    seen.add(current.id)
+    current = byId.get(current.parent_folder_id)
+  }
+  return false
+}
+
 function TaskforceLibrary() {
+  const { currentUser } = Route.useRouteContext()
   const { isDemoMode } = useDemoMode()
   const router = useRouterState()
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const [libraryView, setLibraryView] = useState<"files" | "folders">("files")
+  const [ownershipFilter, setOwnershipFilter] =
+    useState<OwnershipFilter>("owned")
   const [selectedFolderId, setSelectedFolderId] = useState("all")
   const [createFolderOpen, setCreateFolderOpen] = useState(false)
   const [openFolderIds, setOpenFolderIds] = useState<Set<string>>(
-    () => new Set(["unfiled"]),
+    () => new Set(["favorites", "unfiled"]),
   )
-  const [dragOverFolderId, setDragOverFolderId] = useState<string | null>(null)
+  const [dragOverFolderId, setDragOverFolderId] =
+    useState<DirectoryDropTargetId | null>(null)
   const documentsQueryKey = ["v2-documents", { demo: isDemoMode }] as const
+  const foldersQueryKey = ["v2-document-folders", { demo: isDemoMode }] as const
 
   const documentsQuery = useQuery({
     queryKey: documentsQueryKey,
@@ -75,7 +136,7 @@ function TaskforceLibrary() {
   })
 
   const foldersQuery = useQuery({
-    queryKey: ["v2-document-folders", { demo: isDemoMode }],
+    queryKey: foldersQueryKey,
     queryFn: () => readV2DocumentFolders({ demo: isDemoMode }),
   })
 
@@ -138,8 +199,107 @@ function TaskforceLibrary() {
     },
   })
 
-  const documents = documentsQuery.data?.data ?? []
+  const moveFolderMutation = useMutation({
+    mutationFn: ({
+      folderId,
+      parentFolderId,
+    }: {
+      folderId: string
+      parentFolderId: string | null
+    }) =>
+      updateV2DocumentFolder(folderId, { parent_folder_id: parentFolderId }),
+    onMutate: async ({ folderId, parentFolderId }) => {
+      await queryClient.cancelQueries({ queryKey: foldersQueryKey })
+      const previousFolders =
+        queryClient.getQueryData<V2DocumentFoldersPublic>(foldersQueryKey)
+
+      queryClient.setQueryData<V2DocumentFoldersPublic>(
+        foldersQueryKey,
+        (current) => {
+          if (!current) return current
+          return {
+            ...current,
+            data: current.data.map((folder) =>
+              folder.id === folderId
+                ? { ...folder, parent_folder_id: parentFolderId }
+                : folder,
+            ),
+          }
+        },
+      )
+
+      return { previousFolders }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: foldersQueryKey })
+      showSuccessToast("Folder moved.")
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousFolders) {
+        queryClient.setQueryData(foldersQueryKey, context.previousFolders)
+      }
+      showErrorToast("Could not move folder.")
+    },
+    onSettled: () => {
+      setDragOverFolderId(null)
+    },
+  })
+
+  const favoriteMutation = useMutation({
+    mutationFn: ({ documentId, favorite }: FavoriteUpdate) =>
+      favorite
+        ? favoriteV2Document(documentId, { demo: isDemoMode })
+        : unfavoriteV2Document(documentId, { demo: isDemoMode }),
+    onMutate: async ({ documentId, favorite }) => {
+      await queryClient.cancelQueries({ queryKey: documentsQueryKey })
+      const previousDocuments =
+        queryClient.getQueryData<V2DocumentsPublic>(documentsQueryKey)
+
+      queryClient.setQueryData<V2DocumentsPublic>(
+        documentsQueryKey,
+        (current) => {
+          if (!current) return current
+          return {
+            ...current,
+            data: current.data.map((document) =>
+              document.id === documentId
+                ? { ...document, is_favorite: favorite }
+                : document,
+            ),
+          }
+        },
+      )
+
+      return { previousDocuments }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousDocuments) {
+        queryClient.setQueryData(documentsQueryKey, context.previousDocuments)
+      }
+      showErrorToast("Could not update favorite.")
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: documentsQueryKey })
+    },
+  })
+
+  const allDocuments = documentsQuery.data?.data ?? []
+  const documents = useMemo(() => {
+    if (ownershipFilter === "owned") {
+      return allDocuments.filter(
+        (document) => document.owner_id === currentUser.id,
+      )
+    }
+    return allDocuments.filter(
+      (document) => document.owner_id !== currentUser.id,
+    )
+  }, [allDocuments, currentUser.id, ownershipFilter])
   const folders = foldersQuery.data?.data ?? []
+  const folderTree = useMemo(() => buildFolderTree(folders), [folders])
+  const favoriteDocuments = useMemo(
+    () => documents.filter((document) => document.is_favorite),
+    [documents],
+  )
   const folderCounts = useMemo(() => {
     const counts = new Map<string, number>()
     let unfiled = 0
@@ -157,15 +317,17 @@ function TaskforceLibrary() {
   }, [documents])
   const visibleDocuments = useMemo(() => {
     if (selectedFolderId === "all") return documents
+    if (selectedFolderId === "favorites") return favoriteDocuments
     if (selectedFolderId === "unfiled") {
       return documents.filter((document) => !document.folder_id)
     }
     return documents.filter(
       (document) => document.folder_id === selectedFolderId,
     )
-  }, [documents, selectedFolderId])
+  }, [documents, favoriteDocuments, selectedFolderId])
   const documentsByFolder = useMemo(() => {
     const grouped = new Map<string, V2DocumentPublic[]>()
+    grouped.set("favorites", [])
     grouped.set("unfiled", [])
     for (const folder of folders) {
       grouped.set(folder.id, [])
@@ -176,6 +338,9 @@ function TaskforceLibrary() {
           ? document.folder_id
           : "unfiled"
       grouped.get(folderId)?.push(document)
+      if (document.is_favorite) {
+        grouped.get("favorites")?.push(document)
+      }
     }
     return grouped
   }, [documents, folders])
@@ -186,6 +351,11 @@ function TaskforceLibrary() {
     (libraryView === "files" || folders.length === 0)
   const isFolderEmpty =
     !isLoading && documents.length > 0 && visibleDocuments.length === 0
+  const canMutateLibrary =
+    !isDemoMode &&
+    !moveDocumentMutation.isPending &&
+    !moveFolderMutation.isPending &&
+    !favoriteMutation.isPending
 
   if (router.location.pathname.startsWith("/v2/library/")) {
     return <Outlet />
@@ -204,8 +374,13 @@ function TaskforceLibrary() {
   }
 
   const moveDocument = (documentId: string, folderId: string | null) => {
-    if (isDemoMode || moveDocumentMutation.isPending) return
-    const document = documents.find((item) => item.id === documentId)
+    if (
+      isDemoMode ||
+      moveDocumentMutation.isPending ||
+      moveFolderMutation.isPending
+    )
+      return
+    const document = allDocuments.find((item) => item.id === documentId)
     if (!document || (document.folder_id ?? null) === folderId) {
       setDragOverFolderId(null)
       return
@@ -213,9 +388,29 @@ function TaskforceLibrary() {
     moveDocumentMutation.mutate({ documentId, folderId })
   }
 
+  const moveFolder = (folderId: string, parentFolderId: string | null) => {
+    if (
+      isDemoMode ||
+      moveDocumentMutation.isPending ||
+      moveFolderMutation.isPending
+    )
+      return
+    const folder = folders.find((item) => item.id === folderId)
+    if (
+      !folder ||
+      folder.id === parentFolderId ||
+      (folder.parent_folder_id ?? null) === parentFolderId ||
+      isDescendantFolder(folders, parentFolderId, folder.id)
+    ) {
+      setDragOverFolderId(null)
+      return
+    }
+    moveFolderMutation.mutate({ folderId, parentFolderId })
+  }
+
   const handleFolderDragOver = (
     event: DragEvent<HTMLElement>,
-    folderId: string,
+    folderId: DirectoryDropTargetId,
   ) => {
     if (isDemoMode) return
     event.preventDefault()
@@ -228,6 +423,15 @@ function TaskforceLibrary() {
     folderId: string | null,
   ) => {
     event.preventDefault()
+    const folderDropId = event.dataTransfer.getData("application/x-v2-folder")
+    if (folderDropId) {
+      if (folderId) {
+        setOpenFolderIds((current) => new Set(current).add(folderId))
+      }
+      moveFolder(folderDropId, folderId)
+      return
+    }
+
     const documentId = event.dataTransfer.getData("application/x-v2-document")
     if (!documentId) return
     if (folderId) {
@@ -236,11 +440,63 @@ function TaskforceLibrary() {
     moveDocument(documentId, folderId)
   }
 
+  const handleUnfiledDrop = (event: DragEvent<HTMLElement>) => {
+    event.preventDefault()
+    const documentId = event.dataTransfer.getData("application/x-v2-document")
+    if (documentId) {
+      moveDocument(documentId, null)
+    }
+  }
+
+  const handleRootFolderDrop = (event: DragEvent<HTMLElement>) => {
+    event.preventDefault()
+    const folderId = event.dataTransfer.getData("application/x-v2-folder")
+    if (folderId) {
+      moveFolder(folderId, null)
+    }
+  }
+
+  const toggleFavorite = (document: V2DocumentPublic) => {
+    if (isDemoMode || favoriteMutation.isPending) return
+    favoriteMutation.mutate({
+      documentId: document.id,
+      favorite: !document.is_favorite,
+    })
+  }
+
+  const handleFolderDeleted = (folderId: string) => {
+    if (selectedFolderId === folderId) {
+      setSelectedFolderId("all")
+    }
+  }
+
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto">
-      <div className="flex shrink-0 flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+      <div className="sticky top-0 z-20 flex shrink-0 flex-col gap-4 border-b bg-background/95 py-3 backdrop-blur lg:flex-row lg:items-end lg:justify-between">
         <h1 className="text-2xl font-semibold">Library</h1>
         <div className="flex flex-wrap items-center gap-2">
+          <div
+            role="tablist"
+            aria-label="Document ownership"
+            className="inline-flex h-9 w-fit shrink-0 items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground"
+          >
+            <LibraryViewToggle
+              label="Owned by you"
+              active={ownershipFilter === "owned"}
+              onClick={() => {
+                setOwnershipFilter("owned")
+                setSelectedFolderId("all")
+              }}
+            />
+            <LibraryViewToggle
+              label="Shared with you"
+              active={ownershipFilter === "shared"}
+              onClick={() => {
+                setOwnershipFilter("shared")
+                setSelectedFolderId("all")
+              }}
+            />
+          </div>
           <div
             role="tablist"
             aria-label="Library view"
@@ -275,6 +531,7 @@ function TaskforceLibrary() {
         open={createFolderOpen}
         onOpenChange={setCreateFolderOpen}
         demo={isDemoMode}
+        folders={folders}
         onCreated={(folder) => setSelectedFolderId(folder.id)}
       />
 
@@ -293,13 +550,17 @@ function TaskforceLibrary() {
       {!isLoading && documents.length > 0 && libraryView === "files" && (
         <div className="grid gap-6 xl:grid-cols-[240px_minmax(0,1fr)]">
           <FolderNav
-            folders={folders}
+            folderTree={folderTree}
             selectedFolderId={selectedFolderId}
             setSelectedFolderId={setSelectedFolderId}
             allCount={documents.length}
+            favoritesCount={favoriteDocuments.length}
             unfiledCount={folderCounts.unfiled}
             folderCounts={folderCounts.counts}
             loading={foldersQuery.isLoading}
+            currentUserId={currentUser.id}
+            demo={isDemoMode}
+            onFolderDeleted={handleFolderDeleted}
           />
           <div className="min-w-0">
             {isFolderEmpty && (
@@ -310,7 +571,12 @@ function TaskforceLibrary() {
             {!isFolderEmpty && (
               <div className="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
                 {visibleDocuments.map((document) => (
-                  <DocumentCard key={document.id} document={document} />
+                  <DocumentCard
+                    key={document.id}
+                    document={document}
+                    canFavorite={!isDemoMode && !favoriteMutation.isPending}
+                    onToggleFavorite={toggleFavorite}
+                  />
                 ))}
               </div>
             )}
@@ -322,12 +588,20 @@ function TaskforceLibrary() {
         (documents.length > 0 || folders.length > 0) &&
         libraryView === "folders" && (
           <FolderDirectory
-            folders={folders}
+            folderTree={folderTree}
             documentsByFolder={documentsByFolder}
             openFolderIds={openFolderIds}
             dragOverFolderId={dragOverFolderId}
-            canMoveDocuments={!isDemoMode && !moveDocumentMutation.isPending}
+            canMoveItems={canMutateLibrary}
+            canFavorite={!isDemoMode && !favoriteMutation.isPending}
+            currentUserId={currentUser.id}
+            demo={isDemoMode}
             onToggleFolder={toggleFolderOpen}
+            onFolderDragStart={(event, folder) => {
+              event.stopPropagation()
+              event.dataTransfer.effectAllowed = "move"
+              event.dataTransfer.setData("application/x-v2-folder", folder.id)
+            }}
             onDocumentDragStart={(event, document) => {
               event.dataTransfer.effectAllowed = "move"
               event.dataTransfer.setData(
@@ -336,9 +610,13 @@ function TaskforceLibrary() {
               )
             }}
             onDocumentDragEnd={() => setDragOverFolderId(null)}
+            onToggleFavorite={toggleFavorite}
             onFolderDragOver={handleFolderDragOver}
             onFolderDrop={handleFolderDrop}
+            onUnfiledDrop={handleUnfiledDrop}
+            onRootFolderDrop={handleRootFolderDrop}
             onFolderDragLeave={() => setDragOverFolderId(null)}
+            onFolderDeleted={handleFolderDeleted}
           />
         )}
     </section>
@@ -350,7 +628,7 @@ function LibraryViewToggle({
   active,
   onClick,
 }: {
-  label: "Files" | "Folders"
+  label: string
   active: boolean
   onClick: () => void
 }) {
@@ -369,21 +647,29 @@ function LibraryViewToggle({
 }
 
 function FolderNav({
-  folders,
+  folderTree,
   selectedFolderId,
   setSelectedFolderId,
   allCount,
+  favoritesCount,
   unfiledCount,
   folderCounts,
   loading,
+  currentUserId,
+  demo,
+  onFolderDeleted,
 }: {
-  folders: V2DocumentFolderPublic[]
+  folderTree: FolderTreeNode[]
   selectedFolderId: string
   setSelectedFolderId: (folderId: string) => void
   allCount: number
+  favoritesCount: number
   unfiledCount: number
   folderCounts: Map<string, number>
   loading: boolean
+  currentUserId: string
+  demo: boolean
+  onFolderDeleted: (folderId: string) => void
 }) {
   return (
     <nav
@@ -398,6 +684,13 @@ function FolderNav({
         onClick={() => setSelectedFolderId("all")}
       />
       <FolderNavButton
+        active={selectedFolderId === "favorites"}
+        label="Favorites"
+        count={favoritesCount}
+        icon={<Star className="size-4" />}
+        onClick={() => setSelectedFolderId("favorites")}
+      />
+      <FolderNavButton
         active={selectedFolderId === "unfiled"}
         label="Unfiled"
         count={unfiledCount}
@@ -410,19 +703,77 @@ function FolderNav({
           Loading folders…
         </div>
       )}
-      {!loading &&
-        folders.map((folder) => (
-          <FolderNavButton
-            key={folder.id}
-            active={selectedFolderId === folder.id}
-            label={folder.name}
-            count={folderCounts.get(folder.id) ?? 0}
-            icon={<Folder className="size-4" />}
-            visibility={folder.visibility}
-            onClick={() => setSelectedFolderId(folder.id)}
-          />
-        ))}
+      {!loading && (
+        <FolderNavTree
+          nodes={folderTree}
+          selectedFolderId={selectedFolderId}
+          setSelectedFolderId={setSelectedFolderId}
+          folderCounts={folderCounts}
+          currentUserId={currentUserId}
+          demo={demo}
+          onFolderDeleted={onFolderDeleted}
+        />
+      )}
     </nav>
+  )
+}
+
+function FolderNavTree({
+  nodes,
+  selectedFolderId,
+  setSelectedFolderId,
+  folderCounts,
+  currentUserId,
+  demo,
+  onFolderDeleted,
+  depth = 0,
+}: {
+  nodes: FolderTreeNode[]
+  selectedFolderId: string
+  setSelectedFolderId: (folderId: string) => void
+  folderCounts: Map<string, number>
+  currentUserId: string
+  demo: boolean
+  onFolderDeleted: (folderId: string) => void
+  depth?: number
+}) {
+  return (
+    <>
+      {nodes.map((node) => (
+        <div key={node.folder.id}>
+          <FolderNavButton
+            active={selectedFolderId === node.folder.id}
+            label={node.folder.name}
+            count={folderCounts.get(node.folder.id) ?? 0}
+            depth={depth}
+            icon={<Folder className="size-4" />}
+            visibility={node.folder.visibility}
+            onClick={() => setSelectedFolderId(node.folder.id)}
+            action={
+              node.folder.owner_id === currentUserId ? (
+                <FolderActionsMenu
+                  folder={node.folder}
+                  demo={demo}
+                  onDeleted={onFolderDeleted}
+                />
+              ) : undefined
+            }
+          />
+          {node.children.length > 0 && (
+            <FolderNavTree
+              nodes={node.children}
+              selectedFolderId={selectedFolderId}
+              setSelectedFolderId={setSelectedFolderId}
+              folderCounts={folderCounts}
+              currentUserId={currentUserId}
+              demo={demo}
+              onFolderDeleted={onFolderDeleted}
+              depth={depth + 1}
+            />
+          )}
+        </div>
+      ))}
+    </>
   )
 }
 
@@ -430,138 +781,308 @@ function FolderNavButton({
   active,
   label,
   count,
+  depth = 0,
   icon,
   visibility,
+  action,
   onClick,
 }: {
   active: boolean
   label: string
   count: number
+  depth?: number
   icon: ReactNode
   visibility?: V2DocumentVisibility
+  action?: ReactNode
   onClick: () => void
 }) {
   return (
-    <button
-      type="button"
+    <div
       className={cn(
-        "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-muted",
+        "flex w-full items-center rounded-md transition-colors hover:bg-muted",
         active && "bg-muted text-foreground",
       )}
-      onClick={onClick}
     >
-      <span className="shrink-0 text-muted-foreground">{icon}</span>
-      <span className="min-w-0 flex-1 truncate">{label}</span>
-      {visibility === "organization" && (
-        <Building2 className="size-3.5 shrink-0 text-muted-foreground" />
-      )}
-      <span className="shrink-0 text-xs text-muted-foreground">{count}</span>
-    </button>
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 items-center gap-2 px-2 py-2 text-left"
+        style={{ paddingLeft: `${8 + depth * 16}px` }}
+        onClick={onClick}
+      >
+        <span className="shrink-0 text-muted-foreground">{icon}</span>
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        {visibility === "organization" && (
+          <Building2 className="size-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <span className="shrink-0 text-xs text-muted-foreground">{count}</span>
+      </button>
+      {action && <div className="pr-1">{action}</div>}
+    </div>
   )
 }
 
 function FolderDirectory({
-  folders,
+  folderTree,
   documentsByFolder,
   openFolderIds,
   dragOverFolderId,
-  canMoveDocuments,
+  canMoveItems,
+  canFavorite,
+  currentUserId,
+  demo,
   onToggleFolder,
+  onFolderDragStart,
   onDocumentDragStart,
   onDocumentDragEnd,
+  onToggleFavorite,
   onFolderDragOver,
   onFolderDrop,
+  onUnfiledDrop,
+  onRootFolderDrop,
   onFolderDragLeave,
+  onFolderDeleted,
 }: {
-  folders: V2DocumentFolderPublic[]
+  folderTree: FolderTreeNode[]
   documentsByFolder: Map<string, V2DocumentPublic[]>
   openFolderIds: Set<string>
-  dragOverFolderId: string | null
-  canMoveDocuments: boolean
+  dragOverFolderId: DirectoryDropTargetId | null
+  canMoveItems: boolean
+  canFavorite: boolean
+  currentUserId: string
+  demo: boolean
   onToggleFolder: (folderId: string) => void
+  onFolderDragStart: (
+    event: DragEvent<HTMLButtonElement>,
+    folder: V2DocumentFolderPublic,
+  ) => void
   onDocumentDragStart: (
     event: DragEvent<HTMLAnchorElement>,
     document: V2DocumentPublic,
   ) => void
   onDocumentDragEnd: () => void
-  onFolderDragOver: (event: DragEvent<HTMLElement>, folderId: string) => void
+  onToggleFavorite: (document: V2DocumentPublic) => void
+  onFolderDragOver: (
+    event: DragEvent<HTMLElement>,
+    folderId: DirectoryDropTargetId,
+  ) => void
   onFolderDrop: (event: DragEvent<HTMLElement>, folderId: string | null) => void
+  onUnfiledDrop: (event: DragEvent<HTMLElement>) => void
+  onRootFolderDrop: (event: DragEvent<HTMLElement>) => void
   onFolderDragLeave: () => void
+  onFolderDeleted: (folderId: string) => void
 }) {
+  const favoriteDocuments = documentsByFolder.get("favorites") ?? []
   const unfiledDocuments = documentsByFolder.get("unfiled") ?? []
 
   return (
     <div className="min-w-0 border bg-card text-card-foreground">
-      <DirectoryFolder
-        id="unfiled"
+      <button
+        type="button"
+        className={cn(
+          "flex h-10 w-full items-center gap-2 border-b px-3 text-left text-sm hover:bg-muted",
+          dragOverFolderId === "root" && "bg-muted/70",
+        )}
+        onDragOver={(event) => onFolderDragOver(event, "root")}
+        onDrop={onRootFolderDrop}
+        onDragLeave={onFolderDragLeave}
+      >
+        <Folder className="size-4 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate font-medium">Top level</span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {folderTree.length}
+        </span>
+      </button>
+      <DirectoryUnfiled
+        label="Favorites"
+        icon={<Star className="size-4 shrink-0 text-muted-foreground" />}
+        documents={favoriteDocuments}
+        open={openFolderIds.has("favorites")}
+        dragOver={false}
+        canMoveItems={false}
+        canFavorite={canFavorite}
+        onToggle={() => onToggleFolder("favorites")}
+        onDocumentDragStart={onDocumentDragStart}
+        onDocumentDragEnd={onDocumentDragEnd}
+        onToggleFavorite={onToggleFavorite}
+        onDragOver={(event) => event.preventDefault()}
+        onDrop={(event) => event.preventDefault()}
+        onDragLeave={onFolderDragLeave}
+      />
+      <DirectoryUnfiled
         label="Unfiled"
+        icon={<Folder className="size-4 shrink-0 text-muted-foreground" />}
         documents={unfiledDocuments}
         open={openFolderIds.has("unfiled")}
         dragOver={dragOverFolderId === "unfiled"}
-        canMoveDocuments={canMoveDocuments}
+        canMoveItems={canMoveItems}
+        canFavorite={canFavorite}
         onToggle={() => onToggleFolder("unfiled")}
         onDocumentDragStart={onDocumentDragStart}
         onDocumentDragEnd={onDocumentDragEnd}
+        onToggleFavorite={onToggleFavorite}
         onDragOver={(event) => onFolderDragOver(event, "unfiled")}
-        onDrop={(event) => onFolderDrop(event, null)}
+        onDrop={onUnfiledDrop}
         onDragLeave={onFolderDragLeave}
       />
-      {folders.map((folder) => (
-        <DirectoryFolder
-          key={folder.id}
-          id={folder.id}
-          label={folder.name}
-          visibility={folder.visibility}
-          documents={documentsByFolder.get(folder.id) ?? []}
-          open={openFolderIds.has(folder.id)}
-          dragOver={dragOverFolderId === folder.id}
-          canMoveDocuments={canMoveDocuments}
-          onToggle={() => onToggleFolder(folder.id)}
-          onDocumentDragStart={onDocumentDragStart}
-          onDocumentDragEnd={onDocumentDragEnd}
-          onDragOver={(event) => onFolderDragOver(event, folder.id)}
-          onDrop={(event) => onFolderDrop(event, folder.id)}
-          onDragLeave={onFolderDragLeave}
-        />
-      ))}
+      <DirectoryFolderTree
+        nodes={folderTree}
+        documentsByFolder={documentsByFolder}
+        openFolderIds={openFolderIds}
+        dragOverFolderId={dragOverFolderId}
+        canMoveItems={canMoveItems}
+        canFavorite={canFavorite}
+        currentUserId={currentUserId}
+        demo={demo}
+        onToggleFolder={onToggleFolder}
+        onFolderDragStart={onFolderDragStart}
+        onDocumentDragStart={onDocumentDragStart}
+        onDocumentDragEnd={onDocumentDragEnd}
+        onToggleFavorite={onToggleFavorite}
+        onFolderDragOver={onFolderDragOver}
+        onFolderDrop={onFolderDrop}
+        onFolderDragLeave={onFolderDragLeave}
+        onFolderDeleted={onFolderDeleted}
+      />
     </div>
   )
 }
 
-function DirectoryFolder({
+function DirectoryFolderTree({
+  nodes,
+  documentsByFolder,
+  openFolderIds,
+  dragOverFolderId,
+  canMoveItems,
+  canFavorite,
+  currentUserId,
+  demo,
+  onToggleFolder,
+  onFolderDragStart,
+  onDocumentDragStart,
+  onDocumentDragEnd,
+  onToggleFavorite,
+  onFolderDragOver,
+  onFolderDrop,
+  onFolderDragLeave,
+  onFolderDeleted,
+  depth = 0,
+}: {
+  nodes: FolderTreeNode[]
+  documentsByFolder: Map<string, V2DocumentPublic[]>
+  openFolderIds: Set<string>
+  dragOverFolderId: DirectoryDropTargetId | null
+  canMoveItems: boolean
+  canFavorite: boolean
+  currentUserId: string
+  demo: boolean
+  onToggleFolder: (folderId: string) => void
+  onFolderDragStart: (
+    event: DragEvent<HTMLButtonElement>,
+    folder: V2DocumentFolderPublic,
+  ) => void
+  onDocumentDragStart: (
+    event: DragEvent<HTMLAnchorElement>,
+    document: V2DocumentPublic,
+  ) => void
+  onDocumentDragEnd: () => void
+  onToggleFavorite: (document: V2DocumentPublic) => void
+  onFolderDragOver: (
+    event: DragEvent<HTMLElement>,
+    folderId: DirectoryDropTargetId,
+  ) => void
+  onFolderDrop: (event: DragEvent<HTMLElement>, folderId: string | null) => void
+  onFolderDragLeave: () => void
+  onFolderDeleted: (folderId: string) => void
+  depth?: number
+}) {
+  return (
+    <>
+      {nodes.map((node) => (
+        <DirectoryFolder
+          key={node.folder.id}
+          node={node}
+          documents={documentsByFolder.get(node.folder.id) ?? []}
+          open={openFolderIds.has(node.folder.id)}
+          dragOver={dragOverFolderId === node.folder.id}
+          canMoveItems={canMoveItems}
+          canFavorite={canFavorite}
+          currentUserId={currentUserId}
+          demo={demo}
+          depth={depth}
+          onToggle={() => onToggleFolder(node.folder.id)}
+          onFolderDragStart={onFolderDragStart}
+          onDocumentDragStart={onDocumentDragStart}
+          onDocumentDragEnd={onDocumentDragEnd}
+          onToggleFavorite={onToggleFavorite}
+          onDragOver={(event) => onFolderDragOver(event, node.folder.id)}
+          onDrop={(event) => onFolderDrop(event, node.folder.id)}
+          onDragLeave={onFolderDragLeave}
+          onFolderDeleted={onFolderDeleted}
+          renderChildren={() => (
+            <DirectoryFolderTree
+              nodes={node.children}
+              documentsByFolder={documentsByFolder}
+              openFolderIds={openFolderIds}
+              dragOverFolderId={dragOverFolderId}
+              canMoveItems={canMoveItems}
+              canFavorite={canFavorite}
+              currentUserId={currentUserId}
+              demo={demo}
+              onToggleFolder={onToggleFolder}
+              onFolderDragStart={onFolderDragStart}
+              onDocumentDragStart={onDocumentDragStart}
+              onDocumentDragEnd={onDocumentDragEnd}
+              onToggleFavorite={onToggleFavorite}
+              onFolderDragOver={onFolderDragOver}
+              onFolderDrop={onFolderDrop}
+              onFolderDragLeave={onFolderDragLeave}
+              onFolderDeleted={onFolderDeleted}
+              depth={depth + 1}
+            />
+          )}
+        />
+      ))}
+    </>
+  )
+}
+
+function DirectoryUnfiled({
   label,
-  visibility,
+  icon,
   documents,
   open,
   dragOver,
-  canMoveDocuments,
+  canMoveItems,
+  canFavorite,
   onToggle,
   onDocumentDragStart,
   onDocumentDragEnd,
+  onToggleFavorite,
   onDragOver,
   onDrop,
   onDragLeave,
 }: {
-  id: string
   label: string
-  visibility?: V2DocumentVisibility
+  icon: ReactNode
   documents: V2DocumentPublic[]
   open: boolean
   dragOver: boolean
-  canMoveDocuments: boolean
+  canMoveItems: boolean
+  canFavorite: boolean
   onToggle: () => void
   onDocumentDragStart: (
     event: DragEvent<HTMLAnchorElement>,
     document: V2DocumentPublic,
   ) => void
   onDocumentDragEnd: () => void
+  onToggleFavorite: (document: V2DocumentPublic) => void
   onDragOver: (event: DragEvent<HTMLElement>) => void
   onDrop: (event: DragEvent<HTMLElement>) => void
   onDragLeave: () => void
 }) {
   return (
     <fieldset
-      aria-label={`${label} folder`}
+      aria-label={`${label} documents`}
       className={cn("border-b last:border-b-0", dragOver && "bg-muted/70")}
       onDragOver={onDragOver}
       onDrop={onDrop}
@@ -577,15 +1098,8 @@ function DirectoryFolder({
         ) : (
           <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
         )}
-        {open ? (
-          <FolderOpen className="size-4 shrink-0 text-muted-foreground" />
-        ) : (
-          <Folder className="size-4 shrink-0 text-muted-foreground" />
-        )}
+        {icon}
         <span className="min-w-0 flex-1 truncate font-medium">{label}</span>
-        {visibility === "organization" && (
-          <Building2 className="size-3.5 shrink-0 text-muted-foreground" />
-        )}
         <span className="shrink-0 text-xs text-muted-foreground">
           {documents.length}
         </span>
@@ -601,9 +1115,141 @@ function DirectoryFolder({
             <DirectoryDocumentRow
               key={document.id}
               document={document}
-              draggable={canMoveDocuments}
+              depth={0}
+              draggable={canMoveItems}
+              canFavorite={canFavorite}
               onDragStart={onDocumentDragStart}
               onDragEnd={onDocumentDragEnd}
+              onToggleFavorite={onToggleFavorite}
+            />
+          ))}
+        </div>
+      )}
+    </fieldset>
+  )
+}
+
+function DirectoryFolder({
+  node,
+  documents,
+  open,
+  dragOver,
+  canMoveItems,
+  canFavorite,
+  currentUserId,
+  demo,
+  depth,
+  onToggle,
+  onFolderDragStart,
+  onDocumentDragStart,
+  onDocumentDragEnd,
+  onToggleFavorite,
+  onDragOver,
+  onDrop,
+  onDragLeave,
+  onFolderDeleted,
+  renderChildren,
+}: {
+  node: FolderTreeNode
+  documents: V2DocumentPublic[]
+  open: boolean
+  dragOver: boolean
+  canMoveItems: boolean
+  canFavorite: boolean
+  currentUserId: string
+  demo: boolean
+  depth: number
+  onToggle: () => void
+  onFolderDragStart: (
+    event: DragEvent<HTMLButtonElement>,
+    folder: V2DocumentFolderPublic,
+  ) => void
+  onDocumentDragStart: (
+    event: DragEvent<HTMLAnchorElement>,
+    document: V2DocumentPublic,
+  ) => void
+  onDocumentDragEnd: () => void
+  onToggleFavorite: (document: V2DocumentPublic) => void
+  onDragOver: (event: DragEvent<HTMLElement>) => void
+  onDrop: (event: DragEvent<HTMLElement>) => void
+  onDragLeave: () => void
+  onFolderDeleted: (folderId: string) => void
+  renderChildren: () => ReactNode
+}) {
+  const childCount = node.children.length
+  const itemCount = childCount + documents.length
+
+  return (
+    <fieldset
+      aria-label={`${node.folder.name} folder`}
+      className={cn("border-b last:border-b-0", dragOver && "bg-muted/70")}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragLeave={onDragLeave}
+    >
+      <div className="flex items-center hover:bg-muted">
+        <button
+          type="button"
+          draggable={canMoveItems}
+          className={cn(
+            "flex h-11 min-w-0 flex-1 items-center gap-2 px-3 text-left text-sm",
+            canMoveItems && "cursor-grab active:cursor-grabbing",
+          )}
+          style={{ paddingLeft: `${12 + depth * 24}px` }}
+          onClick={onToggle}
+          onDragStart={(event) => onFolderDragStart(event, node.folder)}
+        >
+          {open ? (
+            <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+          )}
+          {open ? (
+            <FolderOpen className="size-4 shrink-0 text-muted-foreground" />
+          ) : (
+            <Folder className="size-4 shrink-0 text-muted-foreground" />
+          )}
+          <span className="min-w-0 flex-1 truncate font-medium">
+            {node.folder.name}
+          </span>
+          {node.folder.visibility === "organization" && (
+            <Building2 className="size-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {itemCount}
+          </span>
+        </button>
+        {node.folder.owner_id === currentUserId && (
+          <div className="pr-2">
+            <FolderActionsMenu
+              folder={node.folder}
+              demo={demo}
+              onDeleted={onFolderDeleted}
+            />
+          </div>
+        )}
+      </div>
+      {open && (
+        <div className="pb-2">
+          {itemCount === 0 && (
+            <div
+              className="px-3 py-2 text-sm text-muted-foreground"
+              style={{ marginLeft: `${40 + depth * 24}px` }}
+            >
+              Empty folder
+            </div>
+          )}
+          {childCount > 0 && renderChildren()}
+          {documents.map((document) => (
+            <DirectoryDocumentRow
+              key={document.id}
+              document={document}
+              depth={depth + 1}
+              draggable={canMoveItems}
+              canFavorite={canFavorite}
+              onDragStart={onDocumentDragStart}
+              onDragEnd={onDocumentDragEnd}
+              onToggleFavorite={onToggleFavorite}
             />
           ))}
         </div>
@@ -614,45 +1260,101 @@ function DirectoryFolder({
 
 function DirectoryDocumentRow({
   document,
+  depth,
   draggable,
+  canFavorite,
   onDragStart,
   onDragEnd,
+  onToggleFavorite,
 }: {
   document: V2DocumentPublic
+  depth: number
   draggable: boolean
+  canFavorite: boolean
   onDragStart: (
     event: DragEvent<HTMLAnchorElement>,
     document: V2DocumentPublic,
   ) => void
   onDragEnd: () => void
+  onToggleFavorite: (document: V2DocumentPublic) => void
 }) {
   return (
-    <Link
-      to="/v2/library/$documentId"
-      params={{ documentId: document.id }}
-      draggable={draggable}
-      onDragStart={(event) => onDragStart(event, document)}
-      onDragEnd={onDragEnd}
-      className={cn(
-        "ml-10 grid min-h-10 grid-cols-[minmax(0,1fr)_160px_130px] items-center gap-3 px-3 py-2 text-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring max-md:grid-cols-[minmax(0,1fr)]",
-        draggable && "cursor-grab active:cursor-grabbing",
-      )}
-    >
-      <span className="flex min-w-0 items-center gap-2">
-        <FileText className="size-4 shrink-0 text-muted-foreground" />
-        <span className="truncate font-medium">{document.title}</span>
-      </span>
-      <span className="truncate text-xs text-muted-foreground max-md:hidden">
-        {document.visibility === "organization" ? "Organization" : "Private"}
-      </span>
-      <span className="truncate text-xs text-muted-foreground max-md:hidden">
-        {formatDateOnly(document.updated_at)}
-      </span>
-    </Link>
+    <div className="flex items-center hover:bg-muted">
+      <Link
+        to="/v2/library/$documentId"
+        params={{ documentId: document.id }}
+        draggable={draggable}
+        onDragStart={(event) => onDragStart(event, document)}
+        onDragEnd={onDragEnd}
+        className={cn(
+          "grid min-h-10 min-w-0 flex-1 grid-cols-[minmax(0,1fr)_160px_130px] items-center gap-3 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring max-md:grid-cols-[minmax(0,1fr)]",
+          draggable && "cursor-grab active:cursor-grabbing",
+        )}
+        style={{ marginLeft: `${40 + depth * 24}px` }}
+      >
+        <span className="flex min-w-0 items-center gap-2">
+          <FileText className="size-4 shrink-0 text-muted-foreground" />
+          <span className="truncate font-medium">{document.title}</span>
+        </span>
+        <span className="truncate text-xs text-muted-foreground max-md:hidden">
+          {document.visibility === "organization" ? "Organization" : "Private"}
+        </span>
+        <span className="truncate text-xs text-muted-foreground max-md:hidden">
+          {formatDateOnly(document.updated_at)}
+        </span>
+      </Link>
+      <FavoriteButton
+        document={document}
+        disabled={!canFavorite}
+        onToggle={onToggleFavorite}
+      />
+    </div>
   )
 }
 
-function DocumentCard({ document }: { document: V2DocumentPublic }) {
+function FavoriteButton({
+  document,
+  disabled,
+  onToggle,
+}: {
+  document: V2DocumentPublic
+  disabled: boolean
+  onToggle: (document: V2DocumentPublic) => void
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      disabled={disabled}
+      aria-label={document.is_favorite ? "Remove favorite" : "Add favorite"}
+      onClick={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        onToggle(document)
+      }}
+    >
+      <Star
+        className={cn(
+          "size-4",
+          document.is_favorite
+            ? "fill-yellow-400 text-yellow-500"
+            : "text-muted-foreground",
+        )}
+      />
+    </Button>
+  )
+}
+
+function DocumentCard({
+  document,
+  canFavorite,
+  onToggleFavorite,
+}: {
+  document: V2DocumentPublic
+  canFavorite: boolean
+  onToggleFavorite: (document: V2DocumentPublic) => void
+}) {
   const sharedCount = document.shared_with?.length ?? 0
   return (
     <Link
@@ -663,6 +1365,11 @@ function DocumentCard({ document }: { document: V2DocumentPublic }) {
       <div className="flex items-start">
         <FileText className="mt-1 size-5 shrink-0 text-muted-foreground" />
         <div className="ml-auto flex flex-wrap justify-end gap-1.5">
+          <FavoriteButton
+            document={document}
+            disabled={!canFavorite}
+            onToggle={onToggleFavorite}
+          />
           <Badge variant="outline">
             {document.visibility === "organization" ? (
               <Building2 className="size-3" />

--- a/src/routes/v2/pricing.tsx
+++ b/src/routes/v2/pricing.tsx
@@ -1,0 +1,92 @@
+import { useMutation } from "@tanstack/react-query"
+import { createFileRoute } from "@tanstack/react-router"
+import { Check, ExternalLink } from "lucide-react"
+
+import { createCheckoutSession } from "@/api/billing"
+import { LoadingButton } from "@/components/ui/loading-button"
+import useCustomToast from "@/hooks/useCustomToast"
+import { handleError } from "@/utils"
+
+export const Route = createFileRoute("/v2/pricing")({
+  component: TaskforcePricing,
+  head: () => ({
+    meta: [
+      {
+        title: "Taskforce Pro",
+      },
+    ],
+  }),
+})
+
+function TaskforcePricing() {
+  const { showErrorToast } = useCustomToast()
+  const checkoutMutation = useMutation({
+    mutationFn: createCheckoutSession,
+    onSuccess: (result) => {
+      window.location.assign(result.url)
+    },
+    onError: handleError.bind(showErrorToast),
+  })
+
+  return (
+    <section className="flex min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 py-8">
+        <div className="space-y-3">
+          <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+            Taskforce Pro
+          </p>
+          <h1 className="text-3xl font-semibold tracking-tight">
+            Early adopter access for Taskforce.
+          </h1>
+          <p className="max-w-2xl text-base leading-7 text-muted-foreground">
+            A focused plan for the first users shaping the product. More plan
+            details can be added here as the Pro offering settles.
+          </p>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="border bg-card p-6 text-card-foreground">
+            <h2 className="text-lg font-semibold">What is included</h2>
+            <ul className="mt-5 grid gap-3 text-sm text-muted-foreground">
+              {[
+                "First 3 months of Taskforce usage",
+                "Access to current Taskforce Pro workflows",
+                "Early adopter pricing while the plan is finalized",
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-3">
+                  <Check className="mt-0.5 size-4 shrink-0 text-emerald-600" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="border bg-card p-6 text-card-foreground">
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-muted-foreground">
+                Early adopter special
+              </p>
+              <div className="flex items-baseline gap-2">
+                <span className="text-4xl font-semibold">$4.99</span>
+                <span className="text-sm text-muted-foreground">/ month</span>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Covers the first 3 months of Taskforce usage.
+              </p>
+            </div>
+
+            <LoadingButton
+              type="button"
+              className="mt-6 w-full"
+              loading={checkoutMutation.isPending}
+              onClick={() => checkoutMutation.mutate()}
+            >
+              <ExternalLink className="size-4" />
+              Complete checkout
+            </LoadingButton>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add Library Owned by you / Shared with you filtering
- make the Library header controls sticky while scrolling
- add nested folder rendering and drag/drop folder nesting
- add folder options for rename and delete with confirmation
- add document favorite/unfavorite stars plus Favorites in files and folder views
- remove document-page Visibility controls now that Access owns sharing
- add a minimal Taskforce Pro pricing page with checkout CTA and sidebar link

## Validation
- npx biome check --write src/routes/v2/library.tsx src/components/V2/Library/FolderControls.tsx src/api/v2Documents.ts src/components/V2/TaskforceShell.tsx src/routes/v2/pricing.tsx src/routes/v2/library.$documentId.tsx
- npx @tanstack/router-cli generate
- npm run build

Note: build still prints the existing Vite warning that Node 18.19.1 is below Vite's recommended 20.19+ / 22.12+ range, but it exits successfully.