### PR TITLE
Taskforce V2 Search — frontend (Phase 1)

### DIFF
--- a/.github/workflows/deploy-frontend-pages.yml
+++ b/.github/workflows/deploy-frontend-pages.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Static route entrypoints for GitHub Pages
         run: |
-          for route in login signup recover-password reset-password topics cases settings admin v2 v2/home v2/library v2/library/8c9b0f48-2f3f-4e8d-9f7d-b4f0607d6a32 v2/library/5b7462e9-6b0e-4d48-81a2-07f052534a12 v2/library/0fd8a545-a3b7-4a9f-bb65-1ecf76bd8b6d v2/admin v2/metrics v2/metrics/methodology; do
+          for route in login signup recover-password reset-password topics cases settings admin v2 v2/home v2/library v2/library/8c9b0f48-2f3f-4e8d-9f7d-b4f0607d6a32 v2/library/5b7462e9-6b0e-4d48-81a2-07f052534a12 v2/library/0fd8a545-a3b7-4a9f-bb65-1ecf76bd8b6d v2/admin v2/metrics v2/metrics/methodology v2/search; do
             mkdir -p "dist/$route"
             cp dist/index.html "dist/$route/index.html"
           done

--- a/src/api/v2Search.ts
+++ b/src/api/v2Search.ts
@@ -1,0 +1,66 @@
+import { type CancelablePromise, OpenAPI } from "@/client"
+import { request } from "@/client/core/request"
+
+export type SearchTier = "free" | "pro" | "max"
+export type SearchRoute = "managed" | "byok:anthropic" | "byok:openai"
+export type SearchReason = "upgrade_required" | "byok_required"
+export type ByokProvider = "anthropic" | "openai"
+
+export interface ByokCredentialPublic {
+  provider: ByokProvider
+  key_fingerprint: string
+  created_at: string
+  last_validated_at: string | null
+  revoked_at: string | null
+}
+
+export interface ByokCredentialsPublic {
+  credentials: ByokCredentialPublic[]
+}
+
+export interface SearchEligibilityPublic {
+  tier: SearchTier
+  allowed: boolean
+  route: SearchRoute | null
+  reason: SearchReason | null
+  byok: ByokCredentialPublic[]
+}
+
+export function readSearchEligibility(): CancelablePromise<SearchEligibilityPublic> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/search/eligibility",
+  })
+}
+
+export function listByokCredentials(): CancelablePromise<ByokCredentialsPublic> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/byok",
+  })
+}
+
+export interface CreateByokArgs {
+  provider: ByokProvider
+  api_key: string
+}
+
+export function createByokCredential(
+  args: CreateByokArgs,
+): CancelablePromise<ByokCredentialPublic> {
+  return request(OpenAPI, {
+    method: "POST",
+    url: "/api/v1/v2/byok",
+    body: args,
+    mediaType: "application/json",
+  })
+}
+
+export function revokeByokCredential(
+  provider: ByokProvider,
+): CancelablePromise<{ message: string }> {
+  return request(OpenAPI, {
+    method: "DELETE",
+    url: `/api/v1/v2/byok/${provider}`,
+  })
+}

--- a/src/components/V2/Search/ByokSetup.tsx
+++ b/src/components/V2/Search/ByokSetup.tsx
@@ -1,0 +1,95 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { KeyRound } from "lucide-react"
+import { useState } from "react"
+
+import {
+  createByokCredential,
+  type ByokProvider,
+} from "@/api/v2Search"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+export function ByokSetup({ onSaved }: { onSaved: () => void }) {
+  const queryClient = useQueryClient()
+  const [provider, setProvider] = useState<ByokProvider>("openai")
+  const [apiKey, setApiKey] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: () => createByokCredential({ provider, api_key: apiKey }),
+    onSuccess: () => {
+      setApiKey("")
+      setError(null)
+      queryClient.invalidateQueries({ queryKey: ["v2-search-eligibility"] })
+      onSaved()
+    },
+    onError: (err) => {
+      setError((err as Error).message || "Could not save the key.")
+    },
+  })
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <KeyRound className="size-5" /> Add an API key to unlock Search
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <p className="text-sm text-muted-foreground">
+          Pro plans run Search through your own Anthropic or OpenAI key. We
+          encrypt the key at rest and never write it to logs. Switch to{" "}
+          <strong>Max</strong> to skip BYOK and have Taskforce cover the LLM
+          cost instead.
+        </p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="sm:w-40">
+            <label className="mb-1 block text-xs uppercase text-muted-foreground">
+              Provider
+            </label>
+            <Select
+              value={provider}
+              onValueChange={(v) => setProvider(v as ByokProvider)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="anthropic">Anthropic</SelectItem>
+                <SelectItem value="openai">OpenAI</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex-1">
+            <label className="mb-1 block text-xs uppercase text-muted-foreground">
+              API key
+            </label>
+            <Input
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              type="password"
+              placeholder={provider === "openai" ? "sk-…" : "sk-ant-…"}
+              autoComplete="off"
+            />
+          </div>
+          <Button
+            type="button"
+            onClick={() => mutation.mutate()}
+            disabled={!apiKey.trim() || mutation.isPending}
+          >
+            {mutation.isPending ? "Saving…" : "Save"}
+          </Button>
+        </div>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/V2/Search/ChatComposer.tsx
+++ b/src/components/V2/Search/ChatComposer.tsx
@@ -1,0 +1,59 @@
+import { Send } from "lucide-react"
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  useCallback,
+  useState,
+} from "react"
+
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+
+export function ChatComposer({
+  disabled,
+  onSend,
+}: {
+  disabled: boolean
+  onSend: (query: string) => void
+}) {
+  const [value, setValue] = useState("")
+
+  const submit = useCallback(() => {
+    const trimmed = value.trim()
+    if (!trimmed || disabled) return
+    onSend(trimmed)
+    setValue("")
+  }, [value, disabled, onSend])
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    submit()
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      submit()
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex items-end gap-2 rounded-lg border border-border bg-card p-2"
+    >
+      <Textarea
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Ask Taskforce…"
+        rows={1}
+        className="min-h-10 resize-none border-0 bg-transparent focus-visible:ring-0"
+        disabled={disabled}
+      />
+      <Button type="submit" disabled={disabled || !value.trim()} size="icon">
+        <Send className="size-4" />
+      </Button>
+    </form>
+  )
+}

--- a/src/components/V2/Search/CitationChip.tsx
+++ b/src/components/V2/Search/CitationChip.tsx
@@ -1,0 +1,23 @@
+import { Link as RouterLink } from "@tanstack/react-router"
+
+import type { SearchCitationEvent } from "@/lib/searchStream"
+
+export function CitationChip({
+  citation,
+  index,
+}: {
+  citation: SearchCitationEvent
+  index: number
+}) {
+  return (
+    <RouterLink
+      to={citation.url_path}
+      className="inline-flex max-w-full items-center gap-1.5 truncate rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs hover:bg-muted"
+      title={`${citation.title} · score ${citation.score.toFixed(2)}`}
+    >
+      <span className="text-muted-foreground">[{index}]</span>
+      <span className="truncate">{citation.title || citation.source_item_id}</span>
+      <span className="text-muted-foreground">#{citation.chunk_anchor_id}</span>
+    </RouterLink>
+  )
+}

--- a/src/components/V2/Search/MessageList.tsx
+++ b/src/components/V2/Search/MessageList.tsx
@@ -1,0 +1,90 @@
+import { Sparkles, User2 } from "lucide-react"
+import { useEffect, useRef } from "react"
+
+import type { SearchCitationEvent } from "@/lib/searchStream"
+
+import { CitationChip } from "./CitationChip"
+
+export interface Message {
+  id: string
+  role: "user" | "assistant"
+  text: string
+  citations: SearchCitationEvent[]
+  billed_to?: "managed" | "byok:anthropic" | "byok:openai"
+  model_id?: string
+  tokens_consumed?: {
+    input_tokens: number
+    output_tokens: number
+    cache_read_tokens: number
+    cache_creation_tokens: number
+  }
+  error?: boolean
+}
+
+export function MessageList({
+  messages,
+  isStreaming,
+}: {
+  messages: Message[]
+  isStreaming: boolean
+}) {
+  const endRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [messages, isStreaming])
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+        Ask a question to get started — try{" "}
+        <em className="mx-1">"what did we decide about the metrics page?"</em>
+        or <em className="mx-1">"who looked at the auth flow last week?"</em>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 overflow-y-auto pb-4">
+      {messages.map((message) => (
+        <MessageRow key={message.id} message={message} />
+      ))}
+      <div ref={endRef} />
+    </div>
+  )
+}
+
+function MessageRow({ message }: { message: Message }) {
+  const isUser = message.role === "user"
+  return (
+    <div className="flex gap-3">
+      <div className="mt-0.5 text-muted-foreground">
+        {isUser ? <User2 className="size-5" /> : <Sparkles className="size-5" />}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div
+          className={
+            "whitespace-pre-wrap break-words text-sm" +
+            (message.error ? " text-destructive" : "")
+          }
+        >
+          {message.text || (isUser ? "" : "…")}
+        </div>
+        {message.citations.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {message.citations.map((c, i) => (
+              <CitationChip key={`${c.source_item_id}-${c.chunk_anchor_id}-${i}`} citation={c} index={i + 1} />
+            ))}
+          </div>
+        )}
+        {message.tokens_consumed && (
+          <div className="text-xs text-muted-foreground">
+            {message.billed_to === "managed" ? "Managed" : "BYOK"} ·{" "}
+            {message.model_id} ·{" "}
+            {message.tokens_consumed.input_tokens.toLocaleString()} in /{" "}
+            {message.tokens_consumed.output_tokens.toLocaleString()} out
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/V2/Search/SearchPage.tsx
+++ b/src/components/V2/Search/SearchPage.tsx
@@ -1,0 +1,233 @@
+import { useQuery } from "@tanstack/react-query"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import {
+  readSearchEligibility,
+  type SearchEligibilityPublic,
+} from "@/api/v2Search"
+import type { UserPublic } from "@/client"
+import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  streamSearch,
+  type SearchCitationEvent,
+  type SearchEvent,
+} from "@/lib/searchStream"
+
+import { ByokSetup } from "./ByokSetup"
+import { ChatComposer } from "./ChatComposer"
+import { MessageList, type Message } from "./MessageList"
+import { SearchUpsell } from "./SearchUpsell"
+
+interface SearchPageProps {
+  currentUser: UserPublic
+}
+
+export function SearchPage({ currentUser: _currentUser }: SearchPageProps) {
+  const {
+    data: eligibility,
+    isLoading,
+    refetch,
+  } = useQuery({
+    queryKey: ["v2-search-eligibility"],
+    queryFn: () => readSearchEligibility(),
+  })
+
+  const [messages, setMessages] = useState<Message[]>([])
+  const [isStreaming, setIsStreaming] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+
+  // Stop any in-flight stream when the user navigates away.
+  useEffect(() => () => abortRef.current?.abort(), [])
+
+  const handleSend = useCallback(async (query: string) => {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    const userMessage: Message = {
+      id: crypto.randomUUID(),
+      role: "user",
+      text: query,
+      citations: [],
+    }
+    const assistantId = crypto.randomUUID()
+    setMessages((prev) => [
+      ...prev,
+      userMessage,
+      {
+        id: assistantId,
+        role: "assistant",
+        text: "",
+        citations: [],
+      },
+    ])
+    setIsStreaming(true)
+
+    try {
+      const citations: SearchCitationEvent[] = []
+      for await (const event of streamSearch({
+        query,
+        signal: controller.signal,
+      })) {
+        applyEvent(assistantId, event, setMessages, citations)
+      }
+    } catch (e) {
+      if (controller.signal.aborted) return
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId
+            ? {
+                ...m,
+                text:
+                  m.text +
+                  (m.text ? "\n\n" : "") +
+                  `(stream failed: ${(e as Error).message})`,
+                error: true,
+              }
+            : m,
+        ),
+      )
+    } finally {
+      setIsStreaming(false)
+    }
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col gap-4 p-6">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    )
+  }
+
+  if (!eligibility) {
+    return (
+      <div className="mx-auto max-w-3xl p-6">
+        <Card>
+          <CardContent className="p-6 text-sm text-muted-foreground">
+            Could not load Search eligibility. Try refreshing the page.
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto flex h-full max-w-3xl flex-col gap-4 p-6">
+      <Header eligibility={eligibility} />
+      <Gate
+        eligibility={eligibility}
+        onByokSaved={() => refetch()}
+        messages={messages}
+        isStreaming={isStreaming}
+        onSend={handleSend}
+      />
+    </div>
+  )
+}
+
+function Header({ eligibility }: { eligibility: SearchEligibilityPublic }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <h1 className="text-2xl font-semibold">Search</h1>
+      <p className="text-sm text-muted-foreground">
+        Ask anything about the work you've captured in Taskforce — your
+        documents are the source of truth.{" "}
+        <RoutePill eligibility={eligibility} />
+      </p>
+    </div>
+  )
+}
+
+function RoutePill({ eligibility }: { eligibility: SearchEligibilityPublic }) {
+  if (!eligibility.allowed || !eligibility.route) return null
+  if (eligibility.route === "managed") return null
+  const label =
+    eligibility.route === "byok:anthropic"
+      ? "Using your Anthropic key"
+      : "Using your OpenAI key"
+  return (
+    <span className="ml-2 inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs">
+      {label}
+    </span>
+  )
+}
+
+function Gate({
+  eligibility,
+  onByokSaved,
+  messages,
+  isStreaming,
+  onSend,
+}: {
+  eligibility: SearchEligibilityPublic
+  onByokSaved: () => void
+  messages: Message[]
+  isStreaming: boolean
+  onSend: (query: string) => void
+}) {
+  if (eligibility.reason === "upgrade_required") {
+    return <SearchUpsell />
+  }
+  if (eligibility.reason === "byok_required") {
+    return <ByokSetup onSaved={onByokSaved} />
+  }
+  return (
+    <>
+      <MessageList messages={messages} isStreaming={isStreaming} />
+      <ChatComposer disabled={isStreaming} onSend={onSend} />
+    </>
+  )
+}
+
+function applyEvent(
+  assistantId: string,
+  event: SearchEvent,
+  setMessages: React.Dispatch<React.SetStateAction<Message[]>>,
+  citations: SearchCitationEvent[],
+): void {
+  if (event.kind === "token") {
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.id === assistantId ? { ...m, text: m.text + event.text } : m,
+      ),
+    )
+  } else if (event.kind === "citation") {
+    citations.push(event)
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.id === assistantId ? { ...m, citations: [...citations] } : m,
+      ),
+    )
+  } else if (event.kind === "done") {
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.id === assistantId
+          ? {
+              ...m,
+              billed_to: event.billed_to,
+              model_id: event.model_id,
+              tokens_consumed: event.tokens_consumed,
+            }
+          : m,
+      ),
+    )
+  } else if (event.kind === "error") {
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.id === assistantId
+          ? {
+              ...m,
+              text:
+                m.text +
+                (m.text ? "\n\n" : "") +
+                `(${event.code}: ${event.message})`,
+              error: true,
+            }
+          : m,
+      ),
+    )
+  }
+}

--- a/src/components/V2/Search/SearchUpsell.tsx
+++ b/src/components/V2/Search/SearchUpsell.tsx
@@ -1,0 +1,29 @@
+import { Link as RouterLink } from "@tanstack/react-router"
+import { Sparkles } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+export function SearchUpsell() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Sparkles className="size-5" /> Search is a paid feature
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4 text-sm text-muted-foreground">
+        <p>
+          Ask anything about the work you've captured in Taskforce and get
+          cited answers grounded in your own documents. Available on Pro
+          (bring-your-own-key) and Max (we cover the LLM cost).
+        </p>
+        <div>
+          <Button asChild>
+            <RouterLink to="/v2/pricing">View plans</RouterLink>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -60,6 +60,7 @@ type TaskforceNavItem = {
 const taskforceItems: TaskforceNavItem[] = [
   { icon: Home, title: "Home", path: "/v2/home" },
   { icon: BookOpenText, title: "Library", path: "/v2/library" },
+  { icon: Search, title: "Search", path: "/v2/search" },
   { icon: BarChart3, title: "Metrics", path: "/v2/metrics" },
 ]
 

--- a/src/lib/searchStream.ts
+++ b/src/lib/searchStream.ts
@@ -1,0 +1,157 @@
+/**
+ * Hand-rolled SSE client for POST /api/v1/v2/search.
+ *
+ * The auto-generated openapi-ts client wraps axios and has no notion
+ * of streaming responses, so Search talks to the backend through this
+ * helper instead. We use the Streams API rather than `EventSource`
+ * because EventSource only supports GET; we need POST for the query
+ * body.
+ */
+
+import { OpenAPI } from "@/client"
+
+export type SearchTokenEvent = { kind: "token"; text: string }
+export type SearchCitationEvent = {
+  kind: "citation"
+  source_kind: string
+  source_item_id: string
+  chunk_anchor_id: string
+  title: string
+  url_path: string
+  score: number
+}
+export type SearchDoneEvent = {
+  kind: "done"
+  billed_to: "managed" | "byok:anthropic" | "byok:openai"
+  model_id: string
+  tokens_consumed: {
+    input_tokens: number
+    output_tokens: number
+    cache_read_tokens: number
+    cache_creation_tokens: number
+  }
+}
+export type SearchErrorEvent = {
+  kind: "error"
+  code: string
+  message: string
+}
+export type SearchEvent =
+  | SearchTokenEvent
+  | SearchCitationEvent
+  | SearchDoneEvent
+  | SearchErrorEvent
+
+export interface StreamSearchArgs {
+  query: string
+  top_k?: number
+  demo?: boolean
+  signal?: AbortSignal
+}
+
+function resolveBaseUrl(): string {
+  // OpenAPI.BASE is the client base URL configured in main.tsx. Falls
+  // back to the relative path so dev/test contexts still work.
+  return OpenAPI.BASE ?? ""
+}
+
+async function resolveAuthHeader(): Promise<Record<string, string>> {
+  const token = OpenAPI.TOKEN
+  if (!token) return {}
+  // The OpenAPI token resolver accepts a request-options object; we
+  // pass a minimal stub since the resolver in our client only reads
+  // the localStorage-backed access token regardless of the request.
+  const stub = { method: "POST" as const, url: "/api/v1/v2/search" }
+  const value =
+    typeof token === "function" ? await Promise.resolve(token(stub)) : token
+  return value ? { Authorization: `Bearer ${value}` } : {}
+}
+
+/**
+ * Parses a Server-Sent Events stream from a Response body. Yields one
+ * `SearchEvent` per `event:` block. Stops when the stream ends or the
+ * signal fires.
+ */
+export async function* streamSearch(
+  args: StreamSearchArgs,
+): AsyncGenerator<SearchEvent> {
+  const base = resolveBaseUrl()
+  const url = `${base}/api/v1/v2/search`
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "text/event-stream",
+    ...(await resolveAuthHeader()),
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      query: args.query,
+      top_k: args.top_k,
+      demo: args.demo ?? false,
+    }),
+    signal: args.signal,
+  })
+
+  if (!response.ok) {
+    let detail = response.statusText
+    try {
+      const payload = await response.json()
+      detail = payload?.detail ?? detail
+    } catch {
+      /* response body may not be JSON */
+    }
+    yield {
+      kind: "error",
+      code: `http_${response.status}`,
+      message: String(detail),
+    }
+    return
+  }
+
+  if (!response.body) {
+    yield { kind: "error", code: "no_body", message: "Empty response body." }
+    return
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+
+    // SSE messages are separated by blank lines. Split greedily on
+    // "\n\n" so we yield each complete message as it arrives.
+    let nl: number
+    while ((nl = buffer.indexOf("\n\n")) !== -1) {
+      const rawMessage = buffer.slice(0, nl)
+      buffer = buffer.slice(nl + 2)
+      const event = parseSseMessage(rawMessage)
+      if (event) yield event
+    }
+  }
+}
+
+function parseSseMessage(raw: string): SearchEvent | null {
+  let eventName = ""
+  let dataLines: string[] = []
+  for (const line of raw.split("\n")) {
+    if (line.startsWith("event:")) {
+      eventName = line.slice("event:".length).trim()
+    } else if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).trimStart())
+    }
+  }
+  if (!eventName || dataLines.length === 0) return null
+  let payload: Record<string, unknown> = {}
+  try {
+    payload = JSON.parse(dataLines.join("\n"))
+  } catch {
+    return null
+  }
+  return { kind: eventName, ...payload } as SearchEvent
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as V2IndexRouteImport } from './routes/v2/index'
+import { Route as V2SearchRouteImport } from './routes/v2/search'
 import { Route as V2PricingRouteImport } from './routes/v2/pricing'
 import { Route as V2MetricsRouteImport } from './routes/v2/metrics'
 import { Route as V2LibraryRouteImport } from './routes/v2/library'
@@ -68,6 +69,11 @@ const IndexRoute = IndexRouteImport.update({
 const V2IndexRoute = V2IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => V2Route,
+} as any)
+const V2SearchRoute = V2SearchRouteImport.update({
+  id: '/search',
+  path: '/search',
   getParentRoute: () => V2Route,
 } as any)
 const V2PricingRoute = V2PricingRouteImport.update({
@@ -154,6 +160,7 @@ export interface FileRoutesByFullPath {
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2/pricing': typeof V2PricingRoute
+  '/v2/search': typeof V2SearchRoute
   '/v2/': typeof V2IndexRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
@@ -175,6 +182,7 @@ export interface FileRoutesByTo {
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2/pricing': typeof V2PricingRoute
+  '/v2/search': typeof V2SearchRoute
   '/v2': typeof V2IndexRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
@@ -199,6 +207,7 @@ export interface FileRoutesById {
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2/pricing': typeof V2PricingRoute
+  '/v2/search': typeof V2SearchRoute
   '/v2/': typeof V2IndexRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
@@ -223,6 +232,7 @@ export interface FileRouteTypes {
     | '/v2/library'
     | '/v2/metrics'
     | '/v2/pricing'
+    | '/v2/search'
     | '/v2/'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
@@ -244,6 +254,7 @@ export interface FileRouteTypes {
     | '/v2/library'
     | '/v2/metrics'
     | '/v2/pricing'
+    | '/v2/search'
     | '/v2'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
@@ -267,6 +278,7 @@ export interface FileRouteTypes {
     | '/v2/library'
     | '/v2/metrics'
     | '/v2/pricing'
+    | '/v2/search'
     | '/v2/'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
@@ -338,6 +350,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/v2/'
       preLoaderRoute: typeof V2IndexRouteImport
+      parentRoute: typeof V2Route
+    }
+    '/v2/search': {
+      id: '/v2/search'
+      path: '/search'
+      fullPath: '/v2/search'
+      preLoaderRoute: typeof V2SearchRouteImport
       parentRoute: typeof V2Route
     }
     '/v2/pricing': {
@@ -485,6 +504,7 @@ interface V2RouteChildren {
   V2LibraryRoute: typeof V2LibraryRouteWithChildren
   V2MetricsRoute: typeof V2MetricsRouteWithChildren
   V2PricingRoute: typeof V2PricingRoute
+  V2SearchRoute: typeof V2SearchRoute
   V2IndexRoute: typeof V2IndexRoute
 }
 
@@ -494,6 +514,7 @@ const V2RouteChildren: V2RouteChildren = {
   V2LibraryRoute: V2LibraryRouteWithChildren,
   V2MetricsRoute: V2MetricsRouteWithChildren,
   V2PricingRoute: V2PricingRoute,
+  V2SearchRoute: V2SearchRoute,
   V2IndexRoute: V2IndexRoute,
 }
 

--- a/src/routes/v2/search.tsx
+++ b/src/routes/v2/search.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { SearchPage } from "@/components/V2/Search/SearchPage"
+
+export const Route = createFileRoute("/v2/search")({
+  component: TaskforceSearch,
+  head: () => ({
+    meta: [
+      {
+        title: "Taskforce | Search",
+      },
+    ],
+  }),
+})
+
+function TaskforceSearch() {
+  const { currentUser } = Route.useRouteContext()
+  return <SearchPage currentUser={currentUser} />
+}


### PR DESCRIPTION
## Summary

Pairs with [al-exe/EnderAI#50](https://github.com/al-exe/EnderAI/pull/50) (backend). Adds:

- `/v2/search` route + chat surface — ChatGPT-style composer, streaming token render, inline citation chips that link back to source documents.
- Tier-aware gate: Free sees an upsell card, Pro without BYOK sees a key-paste card, Pro+BYOK and Max go straight to the chat.
- Hand-rolled SSE consumer at `src/lib/searchStream.ts` (the auto-generated openapi-ts client doesn't speak streaming).
- Deploy workflow update so `/v2/search` returns 200 on hard refresh (same kind of fix as #99 applied to the new route).

## What changed

- `src/routes/v2/search.tsx` — file-based route.
- `src/components/V2/Search/{SearchPage,MessageList,CitationChip,ChatComposer,ByokSetup,SearchUpsell}.tsx` — chat + gate components.
- `src/api/v2Search.ts` — eligibility + BYOK CRUD on the openapi-ts client.
- `src/lib/searchStream.ts` — fetch + ReadableStream SSE consumer.
- `src/components/V2/TaskforceShell.tsx` — Search nav item between Library and Metrics.
- `src/routeTree.gen.ts` — regenerated to register the new route.
- `.github/workflows/deploy-frontend-pages.yml` — `v2/search` appended to the static-entrypoint list.

## Test plan

- [x] `bun run build` — clean (TypeScript + Vite production build).
- [ ] Free tier: visit `/v2/search`, expect SearchUpsell card.
- [ ] Pro tier without BYOK: visit `/v2/search`, expect ByokSetup card; paste a valid OpenAI key, expect chat to appear after save.
- [ ] Pro tier with BYOK: chat enabled, "Using your OpenAI key" pill visible.
- [ ] Max tier: chat enabled, no pill, citations render correctly, Metrics tab reflects spend.
- [ ] Hard-refresh `/v2/search` on the Pages preview — expect 200, not 404.

## Dependencies

This UI requires the backend PR (al-exe/EnderAI#50) to be merged and deployed; without it the `/v2/search/eligibility` call returns 404 and the page shows the empty-state error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)