### PR TITLE
TF-166/167/168/172: Sidebar and settings polish

### DIFF
--- a/src/components/Sidebar/AppSidebar.tsx
+++ b/src/components/Sidebar/AppSidebar.tsx
@@ -1,6 +1,5 @@
 import { Box, Boxes, Home, Sparkles, Users } from "lucide-react"
 
-import { SidebarAppearance } from "@/components/Common/Appearance"
 import { Logo } from "@/components/Common/Logo"
 import { SidebarCollapseToggle } from "@/components/Common/SidebarCollapseToggle"
 import {
@@ -40,7 +39,6 @@ export function AppSidebar() {
         <DemoModeToggle />
         <V2ModeSwitch enabled={Boolean(currentUser?.v2)} />
         <SidebarCollapseToggle />
-        <SidebarAppearance />
         <User user={currentUser} />
       </SidebarFooter>
     </Sidebar>

--- a/src/components/Sidebar/ModeSwitches.tsx
+++ b/src/components/Sidebar/ModeSwitches.tsx
@@ -70,13 +70,13 @@ export function V2ModeSwitch({ active = false, enabled }: V2ModeSwitchProps) {
       setOpenMobile(false)
     }
 
-    await navigate({ to: active ? "/home" : "/v2/home" })
+    await navigate({ to: active ? "/home" : "/v2/library" })
   }
 
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
-        tooltip={active ? "Return to current app" : "Open Taskforce v2"}
+        tooltip={active ? "Return to current app" : "Open Taskforce"}
         data-testid="v2-mode-switch"
         role="switch"
         aria-checked={active}
@@ -84,7 +84,7 @@ export function V2ModeSwitch({ active = false, enabled }: V2ModeSwitchProps) {
         onClick={handleSwitchMode}
       >
         <Component className="size-[18px] text-muted-foreground transition-colors" />
-        <span>Taskforce v2</span>
+        <span>Taskforce</span>
         <div
           aria-hidden="true"
           data-testid="v2-mode-switch-track"

--- a/src/components/UserSettings/Appearance.tsx
+++ b/src/components/UserSettings/Appearance.tsx
@@ -1,0 +1,83 @@
+import { Check, Monitor, Moon, Sun } from "lucide-react"
+
+import { type Theme, useTheme } from "@/components/theme-provider"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+type ThemeOption = {
+  value: Theme
+  title: string
+  description: string
+  icon: typeof Sun
+}
+
+const themeOptions: ThemeOption[] = [
+  {
+    value: "light",
+    title: "Light",
+    description: "Use the light interface.",
+    icon: Sun,
+  },
+  {
+    value: "dark",
+    title: "Dark",
+    description: "Use the dark interface.",
+    icon: Moon,
+  },
+  {
+    value: "system",
+    title: "System",
+    description: "Match this device.",
+    icon: Monitor,
+  },
+]
+
+export default function AppearanceSettings() {
+  const { setTheme, theme } = useTheme()
+
+  return (
+    <section className="max-w-2xl space-y-4">
+      <div>
+        <h3 className="py-4 text-lg font-semibold">Appearance</h3>
+        <p className="text-sm text-muted-foreground">
+          Choose how Taskforce looks on this device.
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        {themeOptions.map((option) => {
+          const Icon = option.icon
+          const active = theme === option.value
+
+          return (
+            <Button
+              key={option.value}
+              type="button"
+              variant="outline"
+              className={cn(
+                "h-auto justify-start rounded-lg p-4 text-left",
+                active && "border-sidebar-ring bg-sidebar-accent",
+              )}
+              aria-pressed={active}
+              data-testid={`${option.value}-mode`}
+              onClick={() => setTheme(option.value)}
+            >
+              <div className="flex w-full items-start gap-3">
+                <Icon className="mt-0.5 size-5 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium">{option.title}</span>
+                    {active ? <Check className="size-4" /> : null}
+                  </div>
+                  <p className="mt-1 whitespace-normal text-xs leading-5 text-muted-foreground">
+                    {option.description}
+                  </p>
+                </div>
+              </div>
+            </Button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -11,6 +11,7 @@ import {
   ChevronDown,
   ChevronUp,
   Component,
+  Cpu,
   GripHorizontal,
   MessageCircle,
   Rocket,
@@ -55,14 +56,15 @@ type TaskforceShellProps = {
 }
 
 type TaskforceNavItem = {
-  icon: typeof BookOpenText
+  icon: typeof Search
   title: string
   path: string
 }
 
 const taskforceItems: TaskforceNavItem[] = [
-  { icon: BookOpenText, title: "Library", path: "/v2/library" },
   { icon: Search, title: "Search", path: "/v2/search" },
+  { icon: BookOpenText, title: "Library", path: "/v2/library" },
+  { icon: Cpu, title: "Agents", path: "/v2/agents" },
   { icon: BarChart3, title: "Metrics", path: "/v2/metrics" },
 ]
 

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -8,8 +8,12 @@ import {
 import {
   BarChart3,
   BookOpenText,
+  ChevronDown,
+  ChevronUp,
   Component,
+  GripHorizontal,
   Home,
+  MessageCircle,
   Rocket,
   Search,
   Shield,
@@ -17,6 +21,7 @@ import {
 import {
   Fragment,
   type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
   useEffect,
   useId,
   useMemo,
@@ -69,6 +74,8 @@ const upgradeItem: TaskforceNavItem = {
   title: "Upgrade",
   path: "/v2/pricing",
 }
+
+const TASKFORCE_DISCORD_URL = ""
 
 function hasActiveSubscription(user: UserPublic): boolean {
   return ["active", "trialing"].includes(user.stripe_subscription_status ?? "")
@@ -126,6 +133,116 @@ function TaskforceNav({ currentUser }: TaskforceShellProps) {
         )
       })}
     </SidebarMenu>
+  )
+}
+
+function DiscordButton() {
+  const content = (
+    <>
+      <MessageCircle className="size-[18px] text-muted-foreground transition-colors" />
+      <span>Discord</span>
+    </>
+  )
+
+  if (TASKFORCE_DISCORD_URL) {
+    return (
+      <SidebarMenuItem>
+        <SidebarMenuButton tooltip="Join Discord" asChild>
+          <a
+            href={TASKFORCE_DISCORD_URL}
+            target="_blank"
+            rel="noreferrer"
+            data-testid="taskforce-discord-link"
+          >
+            {content}
+          </a>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    )
+  }
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        type="button"
+        tooltip="Discord link coming soon"
+        data-testid="taskforce-discord-placeholder"
+        aria-disabled="true"
+        className="text-sidebar-foreground/70 hover:text-sidebar-foreground"
+      >
+        {content}
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  )
+}
+
+function SidebarUtilityDrawer() {
+  const [isCollapsed, setIsCollapsed] = useState(false)
+  const dragStartYRef = useRef<number | null>(null)
+  const didDragRef = useRef(false)
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    dragStartYRef.current = event.clientY
+    didDragRef.current = false
+    event.currentTarget.setPointerCapture(event.pointerId)
+  }
+
+  const handlePointerMove = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (dragStartYRef.current === null) return
+    const deltaY = event.clientY - dragStartYRef.current
+    if (Math.abs(deltaY) < 32) return
+
+    didDragRef.current = true
+    setIsCollapsed(deltaY > 0)
+  }
+
+  const handlePointerUp = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    dragStartYRef.current = null
+    event.currentTarget.releasePointerCapture(event.pointerId)
+  }
+
+  const handleHandleClick = () => {
+    if (didDragRef.current) {
+      didDragRef.current = false
+      return
+    }
+    setIsCollapsed((collapsed) => !collapsed)
+  }
+
+  return (
+    <div
+      data-testid="taskforce-sidebar-utility-drawer"
+      data-collapsed={isCollapsed}
+      className="border-sidebar-border/80 border-t pt-1 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:w-12"
+    >
+      <button
+        type="button"
+        data-testid="taskforce-sidebar-utility-handle"
+        aria-expanded={!isCollapsed}
+        className="flex h-8 w-full cursor-ns-resize items-center justify-between rounded-md px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
+        onClick={handleHandleClick}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+      >
+        <GripHorizontal className="size-4" />
+        <span className="group-data-[collapsible=icon]:sr-only">Community</span>
+        <span className="group-data-[collapsible=icon]:hidden">
+          {isCollapsed ? (
+            <ChevronUp className="size-4" />
+          ) : (
+            <ChevronDown className="size-4" />
+          )}
+        </span>
+      </button>
+      {!isCollapsed && (
+        <SidebarMenu className="mt-1">
+          <DiscordButton />
+          <DemoModeToggle />
+        </SidebarMenu>
+      )}
+    </div>
   )
 }
 
@@ -434,7 +551,7 @@ export function TaskforceShell({ currentUser }: TaskforceShellProps) {
           <TaskforceNav currentUser={currentUser} />
         </SidebarContent>
         <SidebarFooter className="gap-1">
-          <DemoModeToggle />
+          <SidebarUtilityDrawer />
           <V2ModeSwitch active enabled={Boolean(currentUser.v2)} />
           <SidebarCollapseToggle />
           <SidebarAppearance />

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -12,7 +12,6 @@ import {
   ChevronUp,
   Component,
   GripHorizontal,
-  Home,
   MessageCircle,
   Rocket,
   Search,
@@ -30,7 +29,6 @@ import {
 } from "react"
 import { readV2Documents, type V2DocumentPublic } from "@/api/v2Documents"
 import type { UserPublic } from "@/client"
-import { SidebarAppearance } from "@/components/Common/Appearance"
 import { SidebarCollapseToggle } from "@/components/Common/SidebarCollapseToggle"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { DemoModeToggle, V2ModeSwitch } from "@/components/Sidebar/ModeSwitches"
@@ -57,13 +55,12 @@ type TaskforceShellProps = {
 }
 
 type TaskforceNavItem = {
-  icon: typeof Home
+  icon: typeof BookOpenText
   title: string
   path: string
 }
 
 const taskforceItems: TaskforceNavItem[] = [
-  { icon: Home, title: "Home", path: "/v2/home" },
   { icon: BookOpenText, title: "Library", path: "/v2/library" },
   { icon: Search, title: "Search", path: "/v2/search" },
   { icon: BarChart3, title: "Metrics", path: "/v2/metrics" },
@@ -84,7 +81,7 @@ function hasActiveSubscription(user: UserPublic): boolean {
 function TaskforceMark() {
   return (
     <RouterLink
-      to="/v2/home"
+      to="/v2/library"
       className="min-w-0 px-1 text-sidebar-foreground group-data-[collapsible=icon]:px-0"
     >
       <span className="text-[1.7rem] font-semibold group-data-[collapsible=icon]:hidden">
@@ -554,7 +551,6 @@ export function TaskforceShell({ currentUser }: TaskforceShellProps) {
           <SidebarUtilityDrawer />
           <V2ModeSwitch active enabled={Boolean(currentUser.v2)} />
           <SidebarCollapseToggle />
-          <SidebarAppearance />
           <User user={currentUser} />
         </SidebarFooter>
       </Sidebar>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as V2PricingRouteImport } from './routes/v2/pricing'
 import { Route as V2MetricsRouteImport } from './routes/v2/metrics'
 import { Route as V2LibraryRouteImport } from './routes/v2/library'
 import { Route as V2HomeRouteImport } from './routes/v2/home'
+import { Route as V2AgentsRouteImport } from './routes/v2/agents'
 import { Route as V2AdminRouteImport } from './routes/v2/admin'
 import { Route as LayoutTopicsRouteImport } from './routes/_layout/topics'
 import { Route as LayoutSkillsRouteImport } from './routes/_layout/skills'
@@ -96,6 +97,11 @@ const V2HomeRoute = V2HomeRouteImport.update({
   path: '/home',
   getParentRoute: () => V2Route,
 } as any)
+const V2AgentsRoute = V2AgentsRouteImport.update({
+  id: '/agents',
+  path: '/agents',
+  getParentRoute: () => V2Route,
+} as any)
 const V2AdminRoute = V2AdminRouteImport.update({
   id: '/admin',
   path: '/admin',
@@ -156,6 +162,7 @@ export interface FileRoutesByFullPath {
   '/skills': typeof LayoutSkillsRoute
   '/topics': typeof LayoutTopicsRoute
   '/v2/admin': typeof V2AdminRoute
+  '/v2/agents': typeof V2AgentsRoute
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
@@ -178,6 +185,7 @@ export interface FileRoutesByTo {
   '/skills': typeof LayoutSkillsRoute
   '/topics': typeof LayoutTopicsRoute
   '/v2/admin': typeof V2AdminRoute
+  '/v2/agents': typeof V2AgentsRoute
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
@@ -203,6 +211,7 @@ export interface FileRoutesById {
   '/_layout/skills': typeof LayoutSkillsRoute
   '/_layout/topics': typeof LayoutTopicsRoute
   '/v2/admin': typeof V2AdminRoute
+  '/v2/agents': typeof V2AgentsRoute
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
@@ -228,6 +237,7 @@ export interface FileRouteTypes {
     | '/skills'
     | '/topics'
     | '/v2/admin'
+    | '/v2/agents'
     | '/v2/home'
     | '/v2/library'
     | '/v2/metrics'
@@ -250,6 +260,7 @@ export interface FileRouteTypes {
     | '/skills'
     | '/topics'
     | '/v2/admin'
+    | '/v2/agents'
     | '/v2/home'
     | '/v2/library'
     | '/v2/metrics'
@@ -274,6 +285,7 @@ export interface FileRouteTypes {
     | '/_layout/skills'
     | '/_layout/topics'
     | '/v2/admin'
+    | '/v2/agents'
     | '/v2/home'
     | '/v2/library'
     | '/v2/metrics'
@@ -385,6 +397,13 @@ declare module '@tanstack/react-router' {
       path: '/home'
       fullPath: '/v2/home'
       preLoaderRoute: typeof V2HomeRouteImport
+      parentRoute: typeof V2Route
+    }
+    '/v2/agents': {
+      id: '/v2/agents'
+      path: '/agents'
+      fullPath: '/v2/agents'
+      preLoaderRoute: typeof V2AgentsRouteImport
       parentRoute: typeof V2Route
     }
     '/v2/admin': {
@@ -500,6 +519,7 @@ const V2MetricsRouteWithChildren = V2MetricsRoute._addFileChildren(
 
 interface V2RouteChildren {
   V2AdminRoute: typeof V2AdminRoute
+  V2AgentsRoute: typeof V2AgentsRoute
   V2HomeRoute: typeof V2HomeRoute
   V2LibraryRoute: typeof V2LibraryRouteWithChildren
   V2MetricsRoute: typeof V2MetricsRouteWithChildren
@@ -510,6 +530,7 @@ interface V2RouteChildren {
 
 const V2RouteChildren: V2RouteChildren = {
   V2AdminRoute: V2AdminRoute,
+  V2AgentsRoute: V2AgentsRoute,
   V2HomeRoute: V2HomeRoute,
   V2LibraryRoute: V2LibraryRouteWithChildren,
   V2MetricsRoute: V2MetricsRouteWithChildren,

--- a/src/routes/_layout/settings.tsx
+++ b/src/routes/_layout/settings.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import type { ComponentType } from "react"
 import { z } from "zod"
 
+import AppearanceSettings from "@/components/UserSettings/Appearance"
 import Billing from "@/components/UserSettings/Billing"
 import ChangePassword from "@/components/UserSettings/ChangePassword"
 import ConnectAgent from "@/components/UserSettings/ConnectAgent"
@@ -14,6 +15,7 @@ import useAuth from "@/hooks/useAuth"
 const tabValues = [
   "my-profile",
   "organization",
+  "appearance",
   "connect-agent",
   "billing",
   "password",
@@ -33,6 +35,7 @@ const tabsConfig: Array<{
 }> = [
   { value: "my-profile", title: "My profile", component: UserInformation },
   { value: "organization", title: "Organization", component: Organization },
+  { value: "appearance", title: "Appearance", component: AppearanceSettings },
   { value: "connect-agent", title: "Connect agent", component: ConnectAgent },
   { value: "billing", title: "Billing", component: Billing },
   { value: "password", title: "Password", component: ChangePassword },

--- a/src/routes/v2/admin.tsx
+++ b/src/routes/v2/admin.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute("/v2/admin")({
     const user = await UsersService.readUserMe()
     if (!user.is_superuser) {
       throw redirect({
-        to: "/v2/home",
+        to: "/v2/library",
       })
     }
   },

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { TaskforcePlaceholder } from "@/components/V2/TaskforceShell"
+
+export const Route = createFileRoute("/v2/agents")({
+  component: TaskforceAgents,
+  head: () => ({
+    meta: [
+      {
+        title: "Taskforce | Agents",
+      },
+    ],
+  }),
+})
+
+function TaskforceAgents() {
+  return (
+    <TaskforcePlaceholder
+      eyebrow="Taskforce"
+      title="Agents"
+      description="Agent workspace placeholder."
+    />
+  )
+}

--- a/src/routes/v2/index.tsx
+++ b/src/routes/v2/index.tsx
@@ -2,6 +2,6 @@ import { createFileRoute, redirect } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/v2/")({
   beforeLoad: () => {
-    throw redirect({ to: "/v2/home" })
+    throw redirect({ to: "/v2/library" })
   },
 })


### PR DESCRIPTION
## Summary
- Adds a bottom Community drawer to the Taskforce V2 sidebar
- Adds a Discord placeholder button with a fillable URL constant for later
- Moves Demo mode into the hideable drawer
- Moves Appearance controls into User Settings and removes them from sidebars
- Renames the app switch from Taskforce v2 to Taskforce
- Removes Home from the Taskforce sidebar and sends Taskforce entry/default redirects to Library
- Reorders Taskforce nav to Search, Library, Agents, Metrics and adds a minimal Agents placeholder route

## Jira
- TF-166
- TF-167
- TF-168
- TF-172

## Validation
- `npx biome check --write src/components/V2/TaskforceShell.tsx`
- `npx biome check --write src/components/UserSettings/Appearance.tsx src/routes/_layout/settings.tsx src/components/Sidebar/AppSidebar.tsx src/components/Sidebar/ModeSwitches.tsx src/components/V2/TaskforceShell.tsx src/routes/v2/index.tsx src/routes/v2/admin.tsx`
- `npx @tanstack/router-cli generate`
- `npx biome check --write src/components/V2/TaskforceShell.tsx src/routes/v2/agents.tsx`
- `npm run build`
- `git diff --check`

Note: build passes with the existing Node 18.19.1 warning from Vite requesting Node 20.19+ or 22.12+.