### PR TITLE
Surface Claude Code Stop hook install in Connect Agent

### DIFF
--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -49,6 +49,36 @@ function formatTimestamp(value: string | null): string {
   }).format(new Date(value))
 }
 
+// One-liner that drops the Claude Code Stop hook on disk + chmods it.
+// Pulls the canonical script straight from the EnderAI repo so users
+// always get the latest version (the script logs to ~/.claude/enderai-record-usage.log
+// and fails silent — see the script's header comments for full env vars).
+const STOP_HOOK_INSTALL_COMMAND = [
+  "mkdir -p ~/.claude/hooks",
+  "curl -fsSL -o ~/.claude/hooks/enderai-record-usage.sh \\",
+  "  https://raw.githubusercontent.com/al-exe/EnderAI/main/scripts/claude-code-record-usage.sh",
+  "chmod +x ~/.claude/hooks/enderai-record-usage.sh",
+].join("\n")
+
+// JSON snippet the user merges into ~/.claude/settings.json so Claude
+// Code actually fires the hook after every assistant turn.
+const STOP_HOOK_SETTINGS_JSON = `{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/enderai-record-usage.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}`
+
 function buildPersistentShellSnippet(mcpToken: string): string {
   const lines = [
     `printf '%s\\n' '${mcpToken}' > ~/.enderai_mcp_token`,
@@ -594,6 +624,41 @@ const ConnectAgent = () => {
               </AlertDescription>
             </Alert>
           )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Claude Code cost tracking</CardTitle>
+        </CardHeader>
+        <CardContent className={styles.cardContent}>
+          <p className={styles.mutedText}>
+            Optional — Claude Code only. Drop this Stop hook in to auto-record
+            every assistant turn's token usage to the Taskforce Metrics page,
+            so cost charts populate without the agent having to introspect
+            itself. Requires the MCP token above (already created when you
+            generate a credential).
+          </p>
+          <SnippetBlock
+            title="Install the hook"
+            description="Run once in a terminal. Pulls the canonical script from the EnderAI repo."
+            snippet={STOP_HOOK_INSTALL_COMMAND}
+            copiedText={copiedText}
+            onCopy={(value) => {
+              void copy(value)
+            }}
+            testId="connect-agent-stop-hook-install"
+          />
+          <SnippetBlock
+            title="~/.claude/settings.json"
+            description="Merge this `hooks` block into your existing settings.json. Restart Claude Code after editing so it picks up the hook."
+            snippet={STOP_HOOK_SETTINGS_JSON}
+            copiedText={copiedText}
+            onCopy={(value) => {
+              void copy(value)
+            }}
+            testId="connect-agent-stop-hook-settings"
+          />
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary

[al-exe/EnderAI#51](https://github.com/al-exe/EnderAI/pull/51) added a Claude Code Stop hook that auto-records every assistant turn's token usage to \`/v2/metrics/usage\`. Right now the only people who know about it are folks reading the repo.

This adds a "Claude Code cost tracking" card to the Connect Agent settings page that shows:

- A one-line install command that \`curl\`s the canonical script from the EnderAI repo into \`~/.claude/hooks/\`.
- The exact JSON block to merge into \`~/.claude/settings.json\` so Claude Code actually fires the hook.

Pairing with the MCP token snippet directly above means users see the full Claude Code setup in one place: paste token → install hook → done.

## Test plan

- [x] \`bun run build\` clean.
- [ ] After deploy: visit \`Settings → Connect Agent\`, see the new card between Setup and Credentials, copy + run the install snippet, verify the script lands in \`~/.claude/hooks/enderai-record-usage.sh\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)