### PR TITLE
TF-149: Surface subscription tiers

### DIFF
--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -8,6 +8,7 @@ export interface BillingStatusPublic {
   subscription_cancel_at_period_end: boolean
   price_id: string | null
   is_subscription_active: boolean
+  subscription_tier: "free" | "pro" | "max" | "admin"
 }
 
 export interface BillingSessionPublic {

--- a/src/api/v2Search.ts
+++ b/src/api/v2Search.ts
@@ -1,7 +1,7 @@
 import { type CancelablePromise, OpenAPI } from "@/client"
 import { request } from "@/client/core/request"
 
-export type SearchTier = "free" | "pro" | "max"
+export type SearchTier = "free" | "pro" | "max" | "admin"
 export type SearchRoute = "managed" | "byok:anthropic" | "byok:openai"
 export type SearchReason = "upgrade_required" | "byok_required"
 export type ByokProvider = "anthropic" | "openai"

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -66,6 +66,7 @@ export type UserPublic = {
     stripe_subscription_current_period_end?: (string | null);
     stripe_subscription_cancel_at_period_end?: boolean;
     stripe_price_id?: (string | null);
+    subscription_tier?: 'free' | 'pro' | 'max' | 'admin';
 };
 
 export type UserRegister = {

--- a/src/components/Admin/columns.tsx
+++ b/src/components/Admin/columns.tsx
@@ -44,8 +44,8 @@ function formatSubscriptionStatus(value: string | null | undefined): string {
 function formatSubscriptionTier(
   value: UserPublic["subscription_tier"] | undefined,
 ): string {
-  if (!value) return "Free"
-  return value.charAt(0).toUpperCase() + value.slice(1)
+  const tier = value ?? "free"
+  return `${tier.charAt(0).toUpperCase() + tier.slice(1)} membership`
 }
 
 function getTierBadgeVariant(
@@ -97,7 +97,7 @@ export const columns: ColumnDef<UserTableData>[] = [
   },
   {
     accessorKey: "subscription_tier",
-    header: "Tier",
+    header: "Membership",
     cell: ({ row }) => {
       const status = row.original.stripe_subscription_status
       const cancelsAtPeriodEnd =

--- a/src/components/Admin/columns.tsx
+++ b/src/components/Admin/columns.tsx
@@ -41,14 +41,19 @@ function formatSubscriptionStatus(value: string | null | undefined): string {
     .join(" ")
 }
 
-function getBillingBadgeVariant(
-  value: string | null | undefined,
-): "success" | "destructive" | "secondary" | "outline" {
-  if (value === "active" || value === "trialing") return "success"
-  if (value === "past_due" || value === "unpaid") return "destructive"
-  if (!value || value === "canceled" || value === "incomplete_expired") {
-    return "secondary"
-  }
+function formatSubscriptionTier(
+  value: UserPublic["subscription_tier"] | undefined,
+): string {
+  if (!value) return "Free"
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+function getTierBadgeVariant(
+  value: UserPublic["subscription_tier"] | undefined,
+): "default" | "success" | "secondary" | "outline" {
+  if (value === "admin") return "default"
+  if (value === "pro" || value === "max") return "success"
+  if (value === "free" || !value) return "secondary"
   return "outline"
 }
 
@@ -91,26 +96,31 @@ export const columns: ColumnDef<UserTableData>[] = [
     ),
   },
   {
-    accessorKey: "stripe_subscription_status",
-    header: "Billing",
+    accessorKey: "subscription_tier",
+    header: "Tier",
     cell: ({ row }) => {
       const status = row.original.stripe_subscription_status
       const cancelsAtPeriodEnd =
         row.original.stripe_subscription_cancel_at_period_end
       const periodEnd = row.original.stripe_subscription_current_period_end
+      const tier = row.original.subscription_tier ?? "free"
 
       return (
         <div className="flex flex-col items-start gap-1">
-          <Badge variant={getBillingBadgeVariant(status)}>
-            {formatSubscriptionStatus(status)}
+          <Badge variant={getTierBadgeVariant(tier)}>
+            {formatSubscriptionTier(tier)}
           </Badge>
           {status ? (
             <span className="text-xs text-muted-foreground">
-              {cancelsAtPeriodEnd ? "Cancels" : "Renews"}{" "}
+              {formatSubscriptionStatus(status)}
+              {" - "}
+              {cancelsAtPeriodEnd ? "cancels" : "renews"}{" "}
               {formatBillingPeriodEnd(periodEnd)}
             </span>
           ) : (
-            <span className="text-xs text-muted-foreground">Not paid</span>
+            <span className="text-xs text-muted-foreground">
+              No Stripe plan
+            </span>
           )}
         </div>
       )

--- a/src/components/UserSettings/Billing.tsx
+++ b/src/components/UserSettings/Billing.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { CreditCard, ExternalLink, RefreshCw } from "lucide-react"
 
 import {
+  type BillingStatusPublic,
   createBillingPortalSession,
   createCheckoutSession,
   readBillingStatus,
@@ -37,6 +38,13 @@ function formatStatus(value: string | null): string {
     .join(" ")
 }
 
+function formatTier(
+  value: BillingStatusPublic["subscription_tier"] | undefined,
+) {
+  if (!value) return "Free"
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
 const Billing = () => {
   const queryClient = useQueryClient()
   const { showErrorToast } = useCustomToast()
@@ -62,7 +70,8 @@ const Billing = () => {
   })
 
   const billingStatus = billingStatusQuery.data
-  const isSubscribed = billingStatus?.is_subscription_active ?? false
+  const tier = billingStatus?.subscription_tier ?? "free"
+  const isPaidTier = tier === "pro" || tier === "max" || tier === "admin"
   const hasCustomer = billingStatus?.has_customer ?? false
 
   return (
@@ -97,12 +106,18 @@ const Billing = () => {
                   renewal events.
                 </p>
               </div>
-              <Badge variant={isSubscribed ? "success" : "secondary"}>
-                {formatStatus(billingStatus?.subscription_status ?? null)}
+              <Badge variant={isPaidTier ? "success" : "secondary"}>
+                {formatTier(tier)}
               </Badge>
             </div>
 
             <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
+              <div>
+                <dt className="text-muted-foreground">Stripe status</dt>
+                <dd className="font-medium">
+                  {formatStatus(billingStatus?.subscription_status ?? null)}
+                </dd>
+              </div>
               <div>
                 <dt className="text-muted-foreground">Current period ends</dt>
                 <dd className="font-medium">
@@ -116,7 +131,7 @@ const Billing = () => {
                 <dd className="font-medium">
                   {billingStatus?.subscription_cancel_at_period_end
                     ? "Cancels at period end"
-                    : isSubscribed
+                    : billingStatus?.is_subscription_active
                       ? "Renews automatically"
                       : "Not active"}
                 </dd>
@@ -136,11 +151,11 @@ const Billing = () => {
             <LoadingButton
               type="button"
               loading={checkoutMutation.isPending}
-              disabled={isSubscribed}
+              disabled={isPaidTier}
               onClick={() => checkoutMutation.mutate()}
             >
               <ExternalLink className="h-4 w-4" />
-              {isSubscribed ? "Subscribed" : "Subscribe"}
+              {isPaidTier ? `${formatTier(tier)} tier` : "Subscribe"}
             </LoadingButton>
 
             <LoadingButton

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -70,8 +70,8 @@ const upgradeItem: TaskforceNavItem = {
   path: "/v2/pricing",
 }
 
-function hasActiveSubscription(user: UserPublic): boolean {
-  return ["active", "trialing"].includes(user.stripe_subscription_status ?? "")
+function hasPaidTier(user: UserPublic): boolean {
+  return ["pro", "max", "admin"].includes(user.subscription_tier ?? "free")
 }
 
 function TaskforceMark() {
@@ -94,7 +94,7 @@ function TaskforceNav({ currentUser }: TaskforceShellProps) {
   const currentPath = router.location.pathname
   const items = [
     ...taskforceItems,
-    ...(!hasActiveSubscription(currentUser) ? [upgradeItem] : []),
+    ...(!hasPaidTier(currentUser) ? [upgradeItem] : []),
     ...(currentUser.is_superuser
       ? [{ icon: Shield, title: "Admin", path: "/v2/admin" }]
       : []),


### PR DESCRIPTION
## Summary
- Adds frontend `subscription_tier` types for user, billing, and search eligibility payloads
- Uses tier-based Upgrade nav gating instead of raw Stripe active status
- Shows the current tier in Billing settings
- Shows tier in the admin users table while keeping Stripe status details as secondary text

## Jira
- TF-149

## Depends on
- Backend PR: https://github.com/al-exe/EnderAI/pull/54

## Validation
- `npx biome check --write src/client/types.gen.ts src/api/v2Search.ts src/api/billing.ts src/components/V2/TaskforceShell.tsx src/components/UserSettings/Billing.tsx src/components/Admin/columns.tsx`
- `npm run build`
- `git diff --check`

Note: build passes with the existing Node 18.19.1 warning from Vite requesting Node 20.19+ or 22.12+.