### PR TITLE
TF-156: Polish metrics frontend

### DIFF
--- a/src/components/V2/Metrics/MetricBreakdown.tsx
+++ b/src/components/V2/Metrics/MetricBreakdown.tsx
@@ -1,23 +1,47 @@
+import { Info } from "lucide-react"
 import type { MetricBreakdownEntry } from "@/api/v2Metrics"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { formatMetricValue } from "./formatters"
 
 type Props = {
   title: string
   rows: MetricBreakdownEntry[]
   format?: "compact-int" | "usd"
+  info?: string
 }
 
 export function MetricBreakdown({
   title,
   rows,
   format = "compact-int",
+  info,
 }: Props) {
   const total = rows.reduce((acc, row) => acc + row.tokens, 0)
   return (
     <div className="rounded-lg border border-border bg-background p-4 shadow-sm">
-      <h3 className="mb-3 text-sm font-medium text-muted-foreground">
-        {title}
-      </h3>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
+        {info && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label={`${title} information`}
+              >
+                <Info className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" align="end" className="max-w-64">
+              {info}
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
       {rows.length === 0 ? (
         <p className="text-sm text-muted-foreground">No data yet.</p>
       ) : (

--- a/src/components/V2/Metrics/MetricCard.tsx
+++ b/src/components/V2/Metrics/MetricCard.tsx
@@ -30,8 +30,14 @@ export function MetricCard({ definition, value }: Props) {
             delta.sign === "flat" && "text-muted-foreground",
           )}
         >
-          {delta.sign === "up" ? "▲ " : delta.sign === "down" ? "▼ " : ""}
-          {delta.label} vs prev
+          {delta.sign === "flat" ? (
+            "No change from previous period"
+          ) : (
+            <>
+              {delta.sign === "up" ? "▲ " : "▼ "}
+              {delta.label} from previous period
+            </>
+          )}
         </div>
       )}
       <p className="mt-3 text-xs text-muted-foreground">

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -19,11 +19,49 @@ type Props = {
 }
 
 const PRIMARY_METRICS = ["tokens_saved", "usd_saved", "reuse_rate"]
-const SECONDARY_METRICS = [
-  "tokens_consumed",
-  "usd_consumed",
-  "documents_touched",
-]
+const SECONDARY_METRICS = ["tokens_consumed", "usd_consumed"]
+
+const METRIC_PRESENTATION_OVERRIDES: Record<
+  string,
+  Partial<Pick<MetricDefinitionPublic, "display_name" | "description">>
+> = {
+  tokens_saved: {
+    description:
+      "Estimated tokens not sent to model provided thanks to Taskforce's information rediscovery.",
+  },
+  usd_saved: {
+    display_name: "USD Offset",
+  },
+  reuse_rate: {
+    description:
+      "How often Taskforce found useful existing work instead of starting from scratch.",
+  },
+  tokens_consumed: {
+    description: "Total input and output tokens consumed by Taskforce.",
+  },
+  documents_touched: {
+    description: "Documents Taskforce created, reused, updated, or finished.",
+  },
+}
+
+const USD_NET_SAVED_DEFINITION: MetricDefinitionPublic = {
+  name: "usd_net_saved",
+  display_name: "USD Saved",
+  unit: "usd",
+  description: "USD offset minus USD spent.",
+  presentation: {
+    format: "usd",
+    trend: false,
+    icon: null,
+  },
+}
+
+function toMetricNumber(value: string | number | null | undefined) {
+  if (value == null) return 0
+  if (typeof value === "number") return value
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
 
 // Org-scope toggle is intentionally deferred. The backend supports
 // scope=organization on /v2/metrics (admin-gated), but the generated
@@ -49,7 +87,7 @@ export function MetricsPage({ currentUser: _currentUser }: Props) {
   const definitionsByName = useMemo(() => {
     const out: Record<string, MetricDefinitionPublic> = {}
     for (const d of definitionsQuery.data?.data ?? []) {
-      out[d.name] = d
+      out[d.name] = { ...d, ...METRIC_PRESENTATION_OVERRIDES[d.name] }
     }
     return out
   }, [definitionsQuery.data])
@@ -57,6 +95,15 @@ export function MetricsPage({ currentUser: _currentUser }: Props) {
   const metrics = metricsQuery.data?.metrics ?? {}
   const tokensSaved = metrics.tokens_saved
   const tokensConsumed = metrics.tokens_consumed
+  const usdOffset = toMetricNumber(metrics.usd_saved?.total)
+  const usdSpent = toMetricNumber(metrics.usd_consumed?.total)
+  const usdNetSaved = {
+    total: String(usdOffset - usdSpent),
+    delta_vs_prev_window: null,
+    series: [],
+    breakdown_by_source: null,
+    top_models: null,
+  }
   const isEmpty =
     metricsQuery.isSuccess &&
     Object.values(metrics).every((m) => {
@@ -65,13 +112,10 @@ export function MetricsPage({ currentUser: _currentUser }: Props) {
     })
 
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold">Metrics</h1>
-          <p className="text-sm text-muted-foreground">
-            Tokens and dollars saved by Taskforce, plus what was consumed.
-          </p>
         </div>
         <div className="flex flex-wrap items-center gap-3">
           <MetricsTimeRange value={window} onChange={setWindow} />
@@ -111,6 +155,7 @@ export function MetricsPage({ currentUser: _currentUser }: Props) {
         <MetricBreakdown
           title="Savings by source"
           rows={tokensSaved?.breakdown_by_source ?? []}
+          info="Shows where Taskforce avoided rework: cache reuse, reading summaries instead of full details, and reconnecting to existing documents."
         />
       </section>
 
@@ -122,6 +167,7 @@ export function MetricsPage({ currentUser: _currentUser }: Props) {
             <MetricCard key={name} definition={def} value={metrics[name]} />
           )
         })}
+        <MetricCard definition={USD_NET_SAVED_DEFINITION} value={usdNetSaved} />
       </section>
 
       <section>

--- a/src/components/V2/Metrics/formatters.ts
+++ b/src/components/V2/Metrics/formatters.ts
@@ -67,7 +67,7 @@ export function formatDelta(
   if (!Number.isFinite(n)) return null
   const sign = n > 0 ? "up" : n < 0 ? "down" : "flat"
   if (format === "ratio") {
-    return { label: `${deltaAbs.format(n * 100)} pp`, sign }
+    return { label: `${deltaAbs.format(n * 100)} percentage points`, sign }
   }
   return { label: deltaPct.format(n), sign }
 }

--- a/src/components/V2/Metrics/methodology.md
+++ b/src/components/V2/Metrics/methodology.md
@@ -1,12 +1,10 @@
 # How we calculate savings
 
-Tokens Saved and USD Saved come from three **attributable** sources. Anything we can't attribute cleanly is not counted — keeping the dollar figure defensible matters more than making it look bigger.
+Tokens Saved and USD Offset come from three **attributable** sources. Anything we can't attribute cleanly is not counted — keeping the dollar figure defensible matters more than making it look bigger.
 
 ## What "actually used" means
 
 We count tokens the API call **billed**, not the byte size of the document. Cache reads count at the cache-read rate. Tokens prepared in a tool result but never returned to the model don't count. Raw Details markdown sitting on the doc but not loaded into the turn doesn't count.
-
-Every metrics event that carries a USD figure is priced against the model-pricing row that was effective at the moment the event occurred. Historical figures stay reproducible across price changes.
 
 ## The three sources
 


### PR DESCRIPTION
## Summary
- Handles METRICS tickets TF-156, TF-157, TF-158, TF-159, TF-160, TF-161, TF-162, TF-163, TF-164, TF-165, and TF-169.
- Removes the metrics page subtitle and historical reproducibility copy.
- Overrides metrics labels/descriptions client-side for customer-facing language, including USD Offset and total USD Saved.
- Adds the Savings by source info tooltip and makes metrics deltas less internal.
- Makes the metrics page vertically scrollable in constrained browser heights.

## Validation
- npx biome check --write src/components/V2/Metrics/MetricsPage.tsx src/components/V2/Metrics/MetricBreakdown.tsx src/components/V2/Metrics/MetricCard.tsx src/components/V2/Metrics/formatters.ts src/components/V2/Metrics/methodology.md
- npx @tanstack/router-cli generate
- git diff --check
- npm run build

Build note: Vite emitted the existing Node 18.19.1 warning, but the build completed successfully.