### PR TITLE
TF-146/147/148/171: Folder tree UX polish

### DIFF
--- a/src/components/V2/Library/FolderControls.tsx
+++ b/src/components/V2/Library/FolderControls.tsx
@@ -223,11 +223,13 @@ export function FolderCreateDialog({
 
 export function FolderActionsMenu({
   folder,
+  folders = [],
   demo,
   onDeleted,
   align = "end",
 }: {
   folder: V2DocumentFolderPublic
+  folders?: V2DocumentFolderPublic[]
   demo: boolean
   onDeleted?: (folderId: string) => void
   align?: "start" | "center" | "end"
@@ -236,6 +238,7 @@ export function FolderActionsMenu({
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const [renameOpen, setRenameOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
+  const [subfolderOpen, setSubfolderOpen] = useState(false)
   const [name, setName] = useState(folder.name)
 
   const invalidateLibraryQueries = () => {
@@ -285,14 +288,26 @@ export function FolderActionsMenu({
             size="icon-sm"
             disabled={demo}
             aria-label={`Open options for ${folder.name}`}
+            className="cursor-pointer"
             onClick={(event) => event.stopPropagation()}
             onDragStart={(event) => event.preventDefault()}
           >
             <MoreHorizontal className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align={align} className="w-44">
+        <DropdownMenuContent align={align} className="w-48">
           <DropdownMenuItem
+            className="cursor-pointer"
+            onSelect={(event) => {
+              event.preventDefault()
+              setSubfolderOpen(true)
+            }}
+          >
+            <FolderPlus className="size-4" />
+            Create sub-folder
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer"
             onSelect={(event) => {
               event.preventDefault()
               setName(folder.name)
@@ -302,8 +317,10 @@ export function FolderActionsMenu({
             <Pencil className="size-4" />
             Rename
           </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem
             variant="destructive"
+            className="cursor-pointer"
             onSelect={(event) => {
               event.preventDefault()
               setDeleteOpen(true)
@@ -314,6 +331,14 @@ export function FolderActionsMenu({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <FolderCreateDialog
+        open={subfolderOpen}
+        onOpenChange={setSubfolderOpen}
+        demo={demo}
+        folders={folders}
+        initialParentFolderId={folder.id}
+      />
 
       <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
         <DialogContent className="sm:max-w-md">
@@ -453,7 +478,7 @@ export function FolderPickerDropdown({
           variant="outline"
           size="sm"
           disabled={disabled}
-          className="max-w-full justify-start"
+          className="max-w-full cursor-pointer justify-start"
         >
           <Folder className="size-4" />
           <span className="truncate">
@@ -478,7 +503,7 @@ export function FolderPickerDropdown({
               event.preventDefault()
               selectFolder(null)
             }}
-            className="gap-2"
+            className="cursor-pointer gap-2"
           >
             <Folder className="size-4" />
             <span className="min-w-0 flex-1 truncate">Unfiled</span>
@@ -491,7 +516,7 @@ export function FolderPickerDropdown({
                 event.preventDefault()
                 selectFolder(folder.id)
               }}
-              className="gap-2"
+              className="cursor-pointer gap-2"
             >
               <Folder className="size-4" />
               <span
@@ -519,7 +544,7 @@ export function FolderPickerDropdown({
           type="button"
           variant="ghost"
           size="sm"
-          className={cn("w-full justify-start")}
+          className={cn("w-full cursor-pointer justify-start")}
           onClick={() => {
             setOpen(false)
             setQuery("")

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -875,23 +875,16 @@ function FolderDirectory({
   const unfiledDocuments = documentsByFolder.get("unfiled") ?? []
 
   return (
-    <div className="min-w-0 border bg-card text-card-foreground">
-      <button
-        type="button"
-        className={cn(
-          "flex h-10 w-full items-center gap-2 border-b px-3 text-left text-sm hover:bg-muted",
-          dragOverFolderId === "root" && "bg-muted/70",
-        )}
-        onDragOver={(event) => onFolderDragOver(event, "root")}
-        onDrop={onRootFolderDrop}
-        onDragLeave={onFolderDragLeave}
-      >
-        <Folder className="size-4 shrink-0 text-muted-foreground" />
-        <span className="min-w-0 flex-1 truncate font-medium">Top level</span>
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {folderTree.length}
-        </span>
-      </button>
+    <section
+      aria-label="Library contents"
+      className={cn(
+        "min-w-0 border bg-card text-card-foreground",
+        dragOverFolderId === "root" && "bg-muted/40",
+      )}
+      onDragOver={(event) => onFolderDragOver(event, "root")}
+      onDrop={onRootFolderDrop}
+      onDragLeave={onFolderDragLeave}
+    >
       <DirectoryUnfiled
         label="Favorites"
         icon={<Star className="size-4 shrink-0 text-muted-foreground" />}
@@ -943,7 +936,7 @@ function FolderDirectory({
         onFolderDragLeave={onFolderDragLeave}
         onFolderDeleted={onFolderDeleted}
       />
-    </div>
+    </section>
   )
 }
 
@@ -1234,7 +1227,7 @@ function DirectoryFolder({
           {itemCount === 0 && (
             <div
               className="px-3 py-2 text-sm text-muted-foreground"
-              style={{ marginLeft: `${40 + depth * 24}px` }}
+              style={{ marginLeft: `${24 + depth * 24}px` }}
             >
               Empty folder
             </div>
@@ -1290,7 +1283,7 @@ function DirectoryDocumentRow({
           "grid min-h-10 min-w-0 flex-1 grid-cols-[minmax(0,1fr)_160px_130px] items-center gap-3 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring max-md:grid-cols-[minmax(0,1fr)]",
           draggable && "cursor-grab active:cursor-grabbing",
         )}
-        style={{ marginLeft: `${40 + depth * 24}px` }}
+        style={{ marginLeft: `${24 + depth * 24}px` }}
       >
         <span className="flex min-w-0 items-center gap-2">
           <FileText className="size-4 shrink-0 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- **TF-146**: Aligns file rows with their sibling folder icon column inside a folder so File B lines up under Folder A.
- **TF-147**: Adds "Create sub-folder" to the folder options dropdown, opening the create dialog pre-seeded with the parent folder.
- **TF-148**: Cursor-pointer on folder option triggers, dropdown items, and the folder picker.
- **TF-171**: Removes the "Top level" header; the surrounding directory section still receives drop events for moving folders to the root.

## Validation
- `npx biome check --write src/routes/v2/library.tsx src/components/V2/Library/FolderControls.tsx`
- `npm run build`

## Jira
- TF-146, TF-147, TF-148, TF-171

🤖 Generated with [Claude Code](https://claude.com/claude-code)