### PR TITLE
Add membership upgrade and organization controls

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -40,6 +40,10 @@ export interface OrganizationInvitationCreate {
   email: string
 }
 
+export interface OrganizationUpdate {
+  name: string
+}
+
 export interface OrganizationMemberUpdate {
   organization_role: OrganizationRole
 }
@@ -48,6 +52,16 @@ export function readMyOrganization(): CancelablePromise<OrganizationMePublic> {
   return request(OpenAPI, {
     method: "GET",
     url: "/api/v1/organizations/me",
+  })
+}
+
+export function updateMyOrganization(
+  body: OrganizationUpdate,
+): CancelablePromise<OrganizationMePublic> {
+  return request(OpenAPI, {
+    method: "PATCH",
+    url: "/api/v1/organizations/me",
+    body,
   })
 }
 
@@ -91,5 +105,17 @@ export function updateOrganizationMember(
       user_id: userId,
     },
     body,
+  })
+}
+
+export function removeOrganizationMember(
+  userId: string,
+): CancelablePromise<void> {
+  return request(OpenAPI, {
+    method: "DELETE",
+    url: "/api/v1/organizations/members/{user_id}",
+    path: {
+      user_id: userId,
+    },
   })
 }

--- a/src/components/UserSettings/Organization.tsx
+++ b/src/components/UserSettings/Organization.tsx
@@ -5,9 +5,10 @@ import {
   MailPlus,
   RefreshCw,
   Shield,
+  Trash2,
   Users,
 } from "lucide-react"
-import { type FormEvent, useState } from "react"
+import { type FormEvent, useEffect, useState } from "react"
 
 import {
   acceptOrganizationInvitation,
@@ -17,6 +18,8 @@ import {
   type OrganizationRole,
   readMyOrganization,
   readMyOrganizationInvitations,
+  removeOrganizationMember,
+  updateMyOrganization,
   updateOrganizationMember,
 } from "@/api/organizations"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -97,6 +100,7 @@ function OrganizationSettings() {
   const { user: currentUser } = useAuth()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const [inviteEmail, setInviteEmail] = useState("")
+  const [organizationName, setOrganizationName] = useState("")
 
   const organizationQuery = useQuery({
     queryKey: organizationQueryKey,
@@ -146,15 +150,51 @@ function OrganizationSettings() {
     onError: handleError.bind(showErrorToast),
   })
 
+  const removeMemberMutation = useMutation({
+    mutationFn: removeOrganizationMember,
+    onSuccess: () => {
+      showSuccessToast("Member removed")
+      void queryClient.invalidateQueries({ queryKey: organizationQueryKey })
+    },
+    onError: handleError.bind(showErrorToast),
+  })
+
   const organization = organizationQuery.data
   const incomingInvitations = incomingInvitationsQuery.data?.data ?? []
   const isAdmin = organization?.organization_role === "admin"
+  const trimmedOrganizationName = organizationName.trim()
+  const organizationNameChanged =
+    organization !== undefined && trimmedOrganizationName !== organization.name
+  const canUpdateOrganizationName =
+    isAdmin && trimmedOrganizationName.length > 0 && organizationNameChanged
+
+  const organizationMutation = useMutation({
+    mutationFn: (name: string) => updateMyOrganization({ name }),
+    onSuccess: (updatedOrganization) => {
+      setOrganizationName(updatedOrganization.name)
+      showSuccessToast("Organization name updated")
+      void queryClient.invalidateQueries({ queryKey: organizationQueryKey })
+    },
+    onError: handleError.bind(showErrorToast),
+  })
+
+  useEffect(() => {
+    if (organization) {
+      setOrganizationName(organization.name)
+    }
+  }, [organization])
 
   const submitInvitation = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const email = inviteEmail.trim()
     if (!email) return
     inviteMutation.mutate(email)
+  }
+
+  const submitOrganizationName = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!canUpdateOrganizationName) return
+    organizationMutation.mutate(trimmedOrganizationName)
   }
 
   const refresh = () => {
@@ -241,6 +281,37 @@ function OrganizationSettings() {
 
           {isAdmin && (
             <form
+              className="grid gap-2 rounded-md border p-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+              onSubmit={submitOrganizationName}
+            >
+              <div className="space-y-1">
+                <label
+                  htmlFor="organization-name"
+                  className="text-sm font-medium"
+                >
+                  Organization name
+                </label>
+                <Input
+                  id="organization-name"
+                  value={organizationName}
+                  onChange={(event) => setOrganizationName(event.target.value)}
+                  placeholder="Organization name"
+                  aria-label="Organization name"
+                />
+              </div>
+              <LoadingButton
+                type="submit"
+                className="self-end"
+                loading={organizationMutation.isPending}
+                disabled={!canUpdateOrganizationName}
+              >
+                Save name
+              </LoadingButton>
+            </form>
+          )}
+
+          {isAdmin && (
+            <form
               className="flex flex-col gap-2 sm:flex-row"
               onSubmit={submitInvitation}
             >
@@ -271,10 +342,16 @@ function OrganizationSettings() {
                 ? roleMutation.variables?.userId
                 : undefined
             }
+            removingMemberId={
+              removeMemberMutation.isPending
+                ? removeMemberMutation.variables
+                : undefined
+            }
             onRoleChange={(member, role) => {
               if (member.organization_role === role) return
               roleMutation.mutate({ userId: member.id, role })
             }}
+            onRemove={(member) => removeMemberMutation.mutate(member.id)}
           />
 
           <PendingInvitations invitations={organization.invitations} />
@@ -342,16 +419,20 @@ function MembersTable({
   currentUserId,
   isAdmin,
   pendingMemberId,
+  removingMemberId,
   onRoleChange,
+  onRemove,
 }: {
   members: OrganizationMemberPublic[]
   currentUserId?: string
   isAdmin: boolean
   pendingMemberId?: string
+  removingMemberId?: string
   onRoleChange: (
     member: OrganizationMemberPublic,
     role: OrganizationRole,
   ) => void
+  onRemove: (member: OrganizationMemberPublic) => void
 }) {
   return (
     <section className="space-y-3">
@@ -365,16 +446,24 @@ function MembersTable({
             <TableHead>Name</TableHead>
             <TableHead>Email</TableHead>
             <TableHead>Role</TableHead>
+            {isAdmin && (
+              <TableHead className="text-right">
+                <span className="sr-only">Actions</span>
+              </TableHead>
+            )}
           </TableRow>
         </TableHeader>
         <TableBody>
           {members.length === 0 && (
-            <EmptyRow colSpan={3}>No members found.</EmptyRow>
+            <EmptyRow colSpan={isAdmin ? 4 : 3}>No members found.</EmptyRow>
           )}
           {members.map((member) => {
             const isCurrentUser = member.id === currentUserId
             const roleControlDisabled =
-              !isAdmin || isCurrentUser || pendingMemberId === member.id
+              !isAdmin ||
+              isCurrentUser ||
+              pendingMemberId === member.id ||
+              removingMemberId === member.id
 
             return (
               <TableRow key={member.id}>
@@ -405,6 +494,21 @@ function MembersTable({
                     <RoleBadge role={member.organization_role} />
                   )}
                 </TableCell>
+                {isAdmin && (
+                  <TableCell className="text-right">
+                    <LoadingButton
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      loading={removingMemberId === member.id}
+                      disabled={isCurrentUser}
+                      onClick={() => onRemove(member)}
+                    >
+                      <Trash2 className="size-4" />
+                      Remove
+                    </LoadingButton>
+                  </TableCell>
+                )}
               </TableRow>
             )
           })}

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -8,10 +8,10 @@ import {
 import {
   BarChart3,
   BookOpenText,
+  Bot,
   ChevronDown,
   ChevronUp,
   Component,
-  Cpu,
   GripHorizontal,
   MessageCircle,
   Rocket,
@@ -64,21 +64,12 @@ type TaskforceNavItem = {
 const taskforceItems: TaskforceNavItem[] = [
   { icon: Search, title: "Search", path: "/v2/search" },
   { icon: BookOpenText, title: "Library", path: "/v2/library" },
-  { icon: Cpu, title: "Agents", path: "/v2/agents" },
+  { icon: Bot, title: "Agents", path: "/v2/agents" },
   { icon: BarChart3, title: "Metrics", path: "/v2/metrics" },
+  { icon: Rocket, title: "Upgrade", path: "/v2/pricing" },
 ]
 
-const upgradeItem: TaskforceNavItem = {
-  icon: Rocket,
-  title: "Upgrade",
-  path: "/v2/pricing",
-}
-
 const TASKFORCE_DISCORD_URL = ""
-
-function hasPaidTier(user: UserPublic): boolean {
-  return ["pro", "max", "admin"].includes(user.subscription_tier ?? "free")
-}
 
 function TaskforceMark() {
   return (
@@ -100,7 +91,6 @@ function TaskforceNav({ currentUser }: TaskforceShellProps) {
   const currentPath = router.location.pathname
   const items = [
     ...taskforceItems,
-    ...(!hasPaidTier(currentUser) ? [upgradeItem] : []),
     ...(currentUser.is_superuser
       ? [{ icon: Shield, title: "Admin", path: "/v2/admin" }]
       : []),

--- a/src/routes/_layout/settings.tsx
+++ b/src/routes/_layout/settings.tsx
@@ -69,7 +69,6 @@ function UserSettings() {
     <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden">
       <div className="shrink-0">
         <h1 className="text-2xl font-bold tracking-tight">Settings</h1>
-        <p className="text-muted-foreground">Account and local setup.</p>
       </div>
 
       <Tabs

--- a/src/routes/v2/pricing.tsx
+++ b/src/routes/v2/pricing.tsx
@@ -1,24 +1,118 @@
 import { useMutation } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
-import { Check, ExternalLink } from "lucide-react"
+import { Check, Circle, ExternalLink, Sparkles } from "lucide-react"
+import { useState } from "react"
 
 import { createCheckoutSession } from "@/api/billing"
+import type { UserPublic } from "@/client"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { LoadingButton } from "@/components/ui/loading-button"
 import useCustomToast from "@/hooks/useCustomToast"
+import { cn } from "@/lib/utils"
 import { handleError } from "@/utils"
 
+type MembershipTier = "free" | "pro" | "max"
+
+type MembershipPlan = {
+  tier: MembershipTier
+  name: string
+  eyebrow: string
+  price: string
+  priceDetail: string
+  description: string
+  benefits: string[]
+  cta: string
+  disabled?: boolean
+  highlighted?: boolean
+}
+
+const membershipPlans: MembershipPlan[] = [
+  {
+    tier: "free",
+    name: "Free",
+    eyebrow: "Start here",
+    price: "$0",
+    priceDetail: "/ month",
+    description:
+      "A lightweight workspace for trying Taskforce and keeping basic agent context organized.",
+    benefits: [
+      "Placeholder benefit for personal document memory",
+      "Placeholder benefit for basic search and library access",
+      "Placeholder benefit for getting started with agent handoffs",
+    ],
+    cta: "Included",
+  },
+  {
+    tier: "pro",
+    name: "Pro",
+    eyebrow: "Early adopter special",
+    price: "$4.99",
+    priceDetail: "/ month for the first 3 months",
+    description:
+      "A focused membership for individual builders who want stronger Taskforce workflows.",
+    benefits: [
+      "Placeholder benefit for richer project memory",
+      "Placeholder benefit for Pro search workflows with your own key",
+      "Placeholder benefit for early adopter product access",
+    ],
+    cta: "Select this tier",
+    highlighted: true,
+  },
+  {
+    tier: "max",
+    name: "Max",
+    eyebrow: "Coming soon",
+    price: "TBD",
+    priceDetail: "",
+    description:
+      "A higher ceiling for heavier usage, managed model costs, and larger context operations.",
+    benefits: [
+      "Placeholder benefit for covered LLM usage",
+      "Placeholder benefit for expanded workspace limits",
+      "Placeholder benefit for priority Taskforce capabilities",
+    ],
+    cta: "Coming soon",
+    disabled: true,
+  },
+]
+
 export const Route = createFileRoute("/v2/pricing")({
-  component: TaskforcePricing,
+  component: TaskforcePricingRoute,
   head: () => ({
     meta: [
       {
-        title: "Taskforce Pro",
+        title: "Taskforce Membership",
       },
     ],
   }),
 })
 
-function TaskforcePricing() {
+function isMembershipTier(
+  value: UserPublic["subscription_tier"],
+): value is MembershipTier {
+  return value === "free" || value === "pro" || value === "max"
+}
+
+function TaskforcePricingRoute() {
+  const { currentUser } = Route.useRouteContext()
+
+  return <TaskforcePricing currentUser={currentUser} />
+}
+
+function TaskforcePricing({ currentUser }: { currentUser: UserPublic }) {
+  const currentTier = isMembershipTier(currentUser.subscription_tier)
+    ? currentUser.subscription_tier
+    : "free"
+  const [selectedTier, setSelectedTier] = useState<MembershipTier>(currentTier)
   const { showErrorToast } = useCustomToast()
   const checkoutMutation = useMutation({
     mutationFn: createCheckoutSession,
@@ -28,63 +122,129 @@ function TaskforcePricing() {
     onError: handleError.bind(showErrorToast),
   })
 
+  const selectedPlan = membershipPlans.find(
+    (plan) => plan.tier === selectedTier,
+  )
+
   return (
     <section className="flex min-h-0 flex-1 overflow-y-auto">
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 py-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 py-8">
         <div className="space-y-3">
           <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
-            Taskforce Pro
+            Taskforce Membership
           </p>
           <h1 className="text-3xl font-semibold tracking-tight">
-            Early adopter access for Taskforce.
+            Choose the membership tier for how you use Taskforce.
           </h1>
-          <p className="max-w-2xl text-base leading-7 text-muted-foreground">
-            A focused plan for the first users shaping the product. More plan
-            details can be added here as the Pro offering settles.
+          <p className="max-w-3xl text-base leading-7 text-muted-foreground">
+            Free, Pro, and Max are sketched here with placeholder benefit copy
+            until the final tier details are locked. Pro keeps the existing
+            early adopter $4.99 discount.
           </p>
         </div>
 
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-          <div className="border bg-card p-6 text-card-foreground">
-            <h2 className="text-lg font-semibold">What is included</h2>
-            <ul className="mt-5 grid gap-3 text-sm text-muted-foreground">
-              {[
-                "First 3 months of Taskforce usage",
-                "Access to current Taskforce Pro workflows",
-                "Early adopter pricing while the plan is finalized",
-              ].map((item) => (
-                <li key={item} className="flex items-start gap-3">
-                  <Check className="mt-0.5 size-4 shrink-0 text-emerald-600" />
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
+        <div className="grid gap-4 lg:grid-cols-3">
+          {membershipPlans.map((plan) => {
+            const isCurrent = plan.tier === currentTier
+            const isSelected = plan.tier === selectedTier
 
-          <div className="border bg-card p-6 text-card-foreground">
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-muted-foreground">
-                Early adopter special
-              </p>
-              <div className="flex items-baseline gap-2">
-                <span className="text-4xl font-semibold">$4.99</span>
-                <span className="text-sm text-muted-foreground">/ month</span>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Covers the first 3 months of Taskforce usage.
-              </p>
-            </div>
+            return (
+              <Card
+                key={plan.tier}
+                data-testid={`membership-plan-${plan.tier}`}
+                className={cn(
+                  "relative flex cursor-pointer flex-col border bg-card transition hover:border-primary/60 hover:shadow-sm",
+                  isSelected && "border-primary ring-2 ring-primary/20",
+                  plan.highlighted && "bg-primary/[0.03]",
+                )}
+                onClick={() => setSelectedTier(plan.tier)}
+              >
+                <CardHeader className="gap-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        {plan.eyebrow}
+                      </p>
+                      <CardTitle className="text-2xl">{plan.name}</CardTitle>
+                    </div>
+                    <div className="flex flex-col items-end gap-2">
+                      {isCurrent && (
+                        <Badge variant="secondary">
+                          You already have this tier
+                        </Badge>
+                      )}
+                      {isSelected && (
+                        <Badge data-testid="membership-selected-indicator">
+                          <Sparkles className="size-3" />
+                          Selected
+                        </Badge>
+                      )}
+                    </div>
+                  </div>
+                  <CardDescription>{plan.description}</CardDescription>
+                </CardHeader>
 
-            <LoadingButton
-              type="button"
-              className="mt-6 w-full"
-              loading={checkoutMutation.isPending}
-              onClick={() => checkoutMutation.mutate()}
-            >
-              <ExternalLink className="size-4" />
-              Complete checkout
-            </LoadingButton>
-          </div>
+                <CardContent className="flex flex-1 flex-col gap-5">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-4xl font-semibold">{plan.price}</span>
+                    {plan.priceDetail && (
+                      <span className="text-sm text-muted-foreground">
+                        {plan.priceDetail}
+                      </span>
+                    )}
+                  </div>
+
+                  <ul className="grid gap-3 text-sm text-muted-foreground">
+                    {plan.benefits.map((benefit) => (
+                      <li key={benefit} className="flex items-start gap-3">
+                        <Check className="mt-0.5 size-4 shrink-0 text-emerald-600" />
+                        <span>{benefit}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+
+                <CardFooter className="flex flex-col items-stretch gap-2">
+                  {plan.tier === "pro" && !isCurrent ? (
+                    <LoadingButton
+                      type="button"
+                      loading={checkoutMutation.isPending}
+                      disabled={!isSelected}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        checkoutMutation.mutate()
+                      }}
+                    >
+                      <ExternalLink className="size-4" />
+                      {isSelected ? plan.cta : "Select Pro"}
+                    </LoadingButton>
+                  ) : (
+                    <Button
+                      type="button"
+                      variant={isCurrent ? "secondary" : "outline"}
+                      disabled={isCurrent || plan.disabled}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        setSelectedTier(plan.tier)
+                      }}
+                    >
+                      {isCurrent && <Circle className="size-4 fill-current" />}
+                      {isCurrent ? "Current tier" : plan.cta}
+                    </Button>
+                  )}
+                </CardFooter>
+              </Card>
+            )
+          })}
+        </div>
+
+        <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+          Selected:{" "}
+          <span className="font-medium text-foreground">
+            {selectedPlan?.name ?? "Free"}
+          </span>
+          . Final copy, limits, and entitlement details can replace these
+          placeholders when the tiers are finalized.
         </div>
       </div>
     </section>

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -10,6 +10,7 @@ const currentUser = {
   full_name: "Alex Lee",
   created_at: "2026-03-24T00:00:00Z",
   v2: true,
+  subscription_tier: "free",
 }
 
 test.use({
@@ -82,6 +83,37 @@ test("Taskforce v2 Admin link stays inside the v2 shell", async ({ page }) => {
     page.getByText("Manage user accounts and permissions"),
   ).toBeVisible()
   await expect(page.getByText("Taskforce").first()).toBeVisible()
+})
+
+test("Community Upgrade link opens membership tiers with current and selected indicators", async ({
+  page,
+}) => {
+  await mockTaskforceAuth(page)
+  await mockV2Documents(page)
+
+  await page.goto("/v2/home")
+  await page.getByRole("link", { name: "Upgrade" }).click()
+
+  await expect(page).toHaveURL(/\/v2\/pricing$/)
+  await expect(
+    page.getByRole("heading", {
+      name: "Choose the membership tier for how you use Taskforce.",
+    }),
+  ).toBeVisible()
+  await expect(page.getByTestId("membership-plan-free")).toContainText(
+    "You already have this tier",
+  )
+  await expect(page.getByTestId("membership-plan-free")).toContainText(
+    "Selected",
+  )
+  await expect(page.getByTestId("membership-plan-pro")).toContainText("$4.99")
+  await expect(page.getByTestId("membership-plan-max")).toContainText("TBD")
+
+  await page.getByTestId("membership-plan-pro").click()
+  await expect(page.getByTestId("membership-plan-pro")).toContainText(
+    "Selected",
+  )
+  await expect(page.getByText("Selected: Pro")).toBeVisible()
 })
 
 test("Taskforce v2 wordmark links to v2 home", async ({ page }) => {

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -88,6 +88,22 @@ test.describe("Organization", () => {
     })
 
     await page.route("**/api/v1/organizations/me", async (route) => {
+      if (route.request().method() === "PATCH") {
+        const body = JSON.parse(route.request().postData() ?? "{}") as {
+          name?: string
+        }
+        organization = {
+          ...organization,
+          name: body.name ?? organization.name,
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(organization),
+        })
+        return
+      }
+
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -159,6 +175,17 @@ test.describe("Organization", () => {
     await page.route(
       "**/api/v1/organizations/members/user-2",
       async (route) => {
+        if (route.request().method() === "DELETE") {
+          organization = {
+            ...organization,
+            members: organization.members.filter(
+              (member) => member.id !== "user-2",
+            ),
+          }
+          await route.fulfill({ status: 204 })
+          return
+        }
+
         organization = {
           ...organization,
           members: organization.members.map((member) =>
@@ -187,6 +214,11 @@ test.describe("Organization", () => {
     await expect(page.getByText("member@example.com")).toBeVisible()
     await expect(page.getByText("pending@example.com")).toBeVisible()
 
+    await page.getByLabel("Organization name").fill("Renamed Organization")
+    await page.getByRole("button", { name: "Save name" }).click()
+    await expect(page.getByText("Organization name updated")).toBeVisible()
+    await expect(page.getByText("Renamed Organization")).toBeVisible()
+
     await page.getByLabel("Invitation email").fill("new@example.com")
     await page.getByRole("button", { name: "Invite" }).click()
     await expect(page.getByText("Invitation sent")).toBeVisible()
@@ -198,6 +230,13 @@ test.describe("Organization", () => {
       .click()
     await page.getByRole("option", { name: "Admin" }).click()
     await expect(page.getByText("Member role updated")).toBeVisible()
+
+    await page
+      .getByRole("row", { name: /Member User/ })
+      .getByRole("button", { name: "Remove" })
+      .click()
+    await expect(page.getByText("Member removed")).toBeVisible()
+    await expect(page.getByText("member@example.com")).toHaveCount(0)
 
     await page.getByRole("button", { name: "Accept" }).click()
     await expect(page.getByText("Invitation accepted")).toBeVisible()


### PR DESCRIPTION
## Summary
- Keep Upgrade in the main Taskforce sidebar under Metrics and above Admin, using the Bot icon for Agents
- Expand /v2/pricing into Free, Pro, and Max membership cards with selected/current-tier indicators
- Preserve Pro early-adopter $4.99 pricing and change the Pro CTA to "Select this tier"
- Remove the Settings subtitle "Account and local setup."
- Add frontend Organization admin controls for renaming the org and removing members

## Backend dependency
- Requires/paired with https://github.com/al-exe/EnderAI/pull/62

## Validation
- `npx biome check --write --unsafe src/api/organizations.ts src/components/UserSettings/Organization.tsx src/components/V2/TaskforceShell.tsx src/routes/_layout/settings.tsx src/routes/v2/pricing.tsx tests/taskforce-shell.spec.ts tests/user-settings.spec.ts`
- `npm run build`
- `FIRST_SUPERUSER=admin@example.com FIRST_SUPERUSER_PASSWORD=password npx playwright test tests/taskforce-shell.spec.ts tests/user-settings.spec.ts --grep "Upgrade|Organization tab shows" --project=chromium --no-deps` with Vite started manually using dummy Firebase VITE_* test env

Note: Vite still reports the existing Node 18.19.1 warning; build completed successfully.
