### PR TITLE
Wire Taskforce pricing checkout

### DIFF
--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -8,12 +8,14 @@ export interface BillingStatusPublic {
   subscription_cancel_at_period_end: boolean
   price_id: string | null
   is_subscription_active: boolean
-  subscription_tier: "free" | "pro" | "max" | "admin"
+  subscription_tier: "free" | "pro" | "max"
 }
 
 export interface BillingSessionPublic {
   url: string
 }
+
+export type CheckoutTier = "pro" | "max"
 
 export function readBillingStatus(): CancelablePromise<BillingStatusPublic> {
   return request(OpenAPI, {
@@ -22,10 +24,14 @@ export function readBillingStatus(): CancelablePromise<BillingStatusPublic> {
   })
 }
 
-export function createCheckoutSession(): CancelablePromise<BillingSessionPublic> {
+export function createCheckoutSession(
+  tier: CheckoutTier,
+): CancelablePromise<BillingSessionPublic> {
   return request(OpenAPI, {
     method: "POST",
     url: "/api/v1/billing/checkout-session",
+    body: { tier },
+    mediaType: "application/json",
   })
 }
 

--- a/src/api/v2Search.ts
+++ b/src/api/v2Search.ts
@@ -1,7 +1,7 @@
 import { type CancelablePromise, OpenAPI } from "@/client"
 import { request } from "@/client/core/request"
 
-export type SearchTier = "free" | "pro" | "max" | "admin"
+export type SearchTier = "free" | "pro" | "max"
 export type SearchRoute = "managed" | "byok:anthropic" | "byok:openai"
 export type SearchReason = "upgrade_required" | "byok_required"
 export type ByokProvider = "anthropic" | "openai"

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -66,7 +66,7 @@ export type UserPublic = {
     stripe_subscription_current_period_end?: (string | null);
     stripe_subscription_cancel_at_period_end?: boolean;
     stripe_price_id?: (string | null);
-    subscription_tier?: 'free' | 'pro' | 'max' | 'admin';
+    subscription_tier?: 'free' | 'pro' | 'max';
 };
 
 export type UserRegister = {

--- a/src/components/Admin/columns.tsx
+++ b/src/components/Admin/columns.tsx
@@ -51,7 +51,6 @@ function formatSubscriptionTier(
 function getTierBadgeVariant(
   value: UserPublic["subscription_tier"] | undefined,
 ): "default" | "success" | "secondary" | "outline" {
-  if (value === "admin") return "default"
   if (value === "pro" || value === "max") return "success"
   if (value === "free" || !value) return "secondary"
   return "outline"

--- a/src/components/UserSettings/Billing.tsx
+++ b/src/components/UserSettings/Billing.tsx
@@ -54,7 +54,7 @@ const Billing = () => {
   })
 
   const checkoutMutation = useMutation({
-    mutationFn: createCheckoutSession,
+    mutationFn: () => createCheckoutSession("pro"),
     onSuccess: (result) => {
       window.location.assign(result.url)
     },
@@ -71,7 +71,7 @@ const Billing = () => {
 
   const billingStatus = billingStatusQuery.data
   const tier = billingStatus?.subscription_tier ?? "free"
-  const isPaidTier = tier === "pro" || tier === "max" || tier === "admin"
+  const isPaidTier = tier === "pro" || tier === "max"
   const hasCustomer = billingStatus?.has_customer ?? false
 
   return (

--- a/src/routes/v2/pricing.tsx
+++ b/src/routes/v2/pricing.tsx
@@ -70,8 +70,8 @@ const membershipPlans: MembershipPlan[] = [
   {
     tier: "max",
     name: "Max",
-    eyebrow: "Coming soon",
-    price: "TBD",
+    eyebrow: "Managed usage",
+    price: "Monthly",
     priceDetail: "",
     description:
       "A higher ceiling for heavier usage, managed model costs, and larger context operations.",
@@ -80,8 +80,7 @@ const membershipPlans: MembershipPlan[] = [
       "Placeholder benefit for expanded workspace limits",
       "Placeholder benefit for priority Taskforce capabilities",
     ],
-    cta: "Coming soon",
-    disabled: true,
+    cta: "Select this tier",
   },
 ]
 
@@ -205,18 +204,21 @@ function TaskforcePricing({ currentUser }: { currentUser: UserPublic }) {
                 </CardContent>
 
                 <CardFooter className="flex flex-col items-stretch gap-2">
-                  {plan.tier === "pro" && !isCurrent ? (
+                  {(plan.tier === "pro" || plan.tier === "max") &&
+                  !isCurrent ? (
                     <LoadingButton
                       type="button"
                       loading={checkoutMutation.isPending}
                       disabled={!isSelected}
                       onClick={(event) => {
                         event.stopPropagation()
-                        checkoutMutation.mutate()
+                        checkoutMutation.mutate(
+                          plan.tier === "max" ? "max" : "pro",
+                        )
                       }}
                     >
                       <ExternalLink className="size-4" />
-                      {isSelected ? plan.cta : "Select Pro"}
+                      {isSelected ? plan.cta : `Select ${plan.name}`}
                     </LoadingButton>
                   ) : (
                     <Button

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -107,13 +107,27 @@ test("Community Upgrade link opens membership tiers with current and selected in
     "Selected",
   )
   await expect(page.getByTestId("membership-plan-pro")).toContainText("$4.99")
-  await expect(page.getByTestId("membership-plan-max")).toContainText("TBD")
+  await expect(page.getByTestId("membership-plan-max")).toContainText("Monthly")
 
   await page.getByTestId("membership-plan-pro").click()
   await expect(page.getByTestId("membership-plan-pro")).toContainText(
     "Selected",
   )
   await expect(page.getByText("Selected: Pro")).toBeVisible()
+
+  let checkoutBody: unknown
+  await page.route("**/api/v1/billing/checkout-session", async (route) => {
+    checkoutBody = route.request().postDataJSON()
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ url: "https://checkout.stripe.test/max" }),
+    })
+  })
+
+  await page.getByTestId("membership-plan-max").click()
+  await page.getByRole("button", { name: "Select this tier" }).click()
+  await expect.poll(() => checkoutBody).toEqual({ tier: "max" })
 })
 
 test("Taskforce v2 wordmark links to v2 home", async ({ page }) => {

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -277,6 +277,7 @@ test.describe("Billing", () => {
           subscription_cancel_at_period_end: false,
           price_id: "price_test",
           is_subscription_active: true,
+          subscription_tier: "pro",
         }),
       })
     })
@@ -288,9 +289,7 @@ test.describe("Billing", () => {
     ).toBeVisible()
     await expect(page.getByText("Active")).toBeVisible()
     await expect(page.getByText("Renews automatically")).toBeVisible()
-    await expect(
-      page.getByRole("button", { name: "Subscribed" }),
-    ).toBeDisabled()
+    await expect(page.getByRole("button", { name: "Pro tier" })).toBeDisabled()
     await expect(
       page.getByRole("button", { name: "Manage billing" }),
     ).toBeEnabled()


### PR DESCRIPTION
## Summary
- Send the selected public paid tier (`pro` or `max`) to the checkout API.
- Enable the Max pricing card for checkout instead of leaving it as coming soon.
- Keep admin tier out of public frontend subscription tier typings and billing UI logic.
- Update pricing and billing tests for tier-specific checkout behavior.

## Validation
- `bunx tsc -p tsconfig.build.json --noEmit`
- `bunx biome check --no-errors-on-unmatched --files-ignore-unknown=true src/api/billing.ts src/api/v2Search.ts src/client/types.gen.ts src/components/Admin/columns.tsx src/components/UserSettings/Billing.tsx src/routes/v2/pricing.tsx tests/taskforce-shell.spec.ts tests/user-settings.spec.ts`

## Notes
- Focused Playwright was attempted earlier, but this worktree's no-deps setup timed out before the pricing assertions because the existing `/v2/home` test path did not find the Upgrade link.
