### PR TITLE
TF-177: Avoided Rediscovery card (feature-flagged) + methodology

### DIFF
--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/api/v2Metrics"
 import type { UserPublic } from "@/client"
 import { useDemoMode } from "@/components/demo-mode-provider"
+import { usePersistentState } from "@/hooks/usePersistentState"
 import { MethodologyLink } from "./MethodologyLink"
 import { MetricBreakdown } from "./MetricBreakdown"
 import { MetricCard } from "./MetricCard"
@@ -71,6 +72,11 @@ function toMetricNumber(value: string | number | null | undefined) {
 export function MetricsPage({ currentUser: _currentUser }: Props) {
   const { isDemoMode } = useDemoMode()
   const [window, setWindow] = useState<MetricsWindow>("7d")
+  // TF-177 / Phase 3 feature flag. When enabled, surface the
+  // Avoided Rediscovery card driven by document.consulted events.
+  // Toggle by setting `localStorage["taskforce.flags.savings_v2"] = "true"`
+  // until a real settings UI lands.
+  const [savingsV2Flag] = usePersistentState<boolean>("flags.savings_v2", false)
 
   const definitionsQuery = useQuery({
     queryKey: ["v2-metrics-definitions"],
@@ -144,6 +150,22 @@ export function MetricsPage({ currentUser: _currentUser }: Props) {
           )
         })}
       </section>
+
+      {savingsV2Flag && (
+        <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {[
+            "avoided_rediscovery",
+            "avoided_rediscovery_usd",
+            "documents_consulted",
+          ].map((name) => {
+            const def = definitionsByName[name]
+            if (!def) return null
+            return (
+              <MetricCard key={name} definition={def} value={metrics[name]} />
+            )
+          })}
+        </section>
+      )}
 
       <MethodologyLink />
 

--- a/src/components/V2/Metrics/methodology.md
+++ b/src/components/V2/Metrics/methodology.md
@@ -33,3 +33,55 @@ These show up as observability (counts), not as dollars saved.
 ## Pricing
 
 We use the rates published at [platform.claude.com pricing](https://platform.claude.com/docs/en/about-claude/pricing). Each price change is recorded as a new effective-from row; events priced before the change keep pointing at their original snapshot. No retroactive rewriting.
+
+---
+
+## Avoided Rediscovery (Phase 3, TF-177) — *behind feature flag*
+
+A new savings model is rolling in alongside the three sources above. Once it's the default, the three sources collapse into one defensible card.
+
+### The story
+
+Every document carries a **rediscovery cost** — an estimate of "what would it take an agent to redo this investigation from scratch". When that doc gets surfaced to the agent (via the Taskforce hook on every user prompt — see TF-176), the savings for that consultation is the rediscovery cost minus what the consult actually cost in tokens.
+
+```
+net_saved_tokens = max(0, document.rediscovery_cost_tokens − summary_tokens_read)
+```
+
+### How we estimate rediscovery cost (v1)
+
+```
+rediscovery_cost_tokens =
+    1500 × commands
+  + 2500 × files inspected
+  +  500 × decisions
+  + 3000 × details sections
+  + 1000 × summary points
+```
+
+Capped at **50,000 tokens** per doc so a runaway formula never inflates the dashboard. Coefficients are deliberately round; we'll tune them quarterly from real consult-vs-redo data.
+
+Where the counts come from:
+- **Commands** — shell prompts (`$`/`>` lines) and fenced code blocks inside the doc's Details sections
+- **Files inspected** — distinct file paths referenced in details (`src/api/foo.py` etc.), with inline-backtick references and basename fallback
+- **Decisions** — lines with verbs like "decided to", "picked", "chose"
+- **Details sections** — `len(details_markdown_sections)`
+- **Summary points** — `len(main_body)` paragraphs
+
+### Worked example
+
+A document captures: 5 commands, 3 files inspected, 2 decisions, 3 details sections, 4 summary points.
+
+```
+rediscovery_cost = 5×1500 + 3×2500 + 2×500 + 3×3000 + 4×1000
+                = 7500 + 7500 + 1000 + 9000 + 4000
+                = 29,000 tokens
+```
+
+The hook later surfaces this doc with an 800-token summary. Net saved = `max(0, 29000 − 800)` = **28,200 tokens**, priced ≈ **$0.14** at opus rates. Taskforce's own cost to deliver that match: about **$0.002** in summarizer fees. ~70× recovered on a single consult.
+
+### Why this is better than the three-source model
+
+- **No agent self-report required.** The current `summary_only` source depends on the agent honestly setting `view_consulted: "summary"`. The new model derives savings from the doc's structure plus the consult fact itself.
+- **One number, one story.** "Taskforce avoided ~N tokens of rediscovery in this window" is something a CFO can quote.
+- **Defensible to skeptics.** The formula is mechanical and tunable. If someone pushes back on the multiplier, we point at the coefficients and the cap.


### PR DESCRIPTION
Frontend slice of TF-177. Backend bits (al-exe/EnderAI#69) merged separately.

- New row of cards under the primary headline, behind the \`taskforce.flags.savings_v2\` localStorage flag. Renders **Avoided Rediscovery** (tokens), **Avoided Rediscovery (USD)**, and **Documents Consulted**. With the flag off, the page is unchanged.
- Methodology page (methodology.md) gets a Phase-3 section: the story, the v1 formula with coefficients + cap, a worked example (29k tokens of rediscovery cost → ~\$0.14 net saved per consult at ~\$0.002 summarizer cost), and why this beats the three-source model.
- Reuses the \`usePersistentState\` hook for the flag.

To turn on locally: \`localStorage.setItem('taskforce.flags.savings_v2', 'true')\` and refresh /v2/metrics.

## Plan + epic
- Plan: \`~/dev/docs/claude-mcp-brainstorm.md\` §5, §7.3
- Epic: TF-174. Ticket: TF-177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)