### PR TITLE
TF-173: Add organization invite status badges

### DIFF
--- a/src/components/UserSettings/Organization.tsx
+++ b/src/components/UserSettings/Organization.tsx
@@ -2,11 +2,14 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   Building2,
   Check,
+  CircleCheck,
+  Clock,
   MailPlus,
   RefreshCw,
   Shield,
   Trash2,
   Users,
+  XCircle,
 } from "lucide-react"
 import { type FormEvent, useEffect, useState } from "react"
 
@@ -75,6 +78,37 @@ function RoleBadge({ role }: { role: OrganizationRole }) {
     <Badge variant={role === "admin" ? "default" : "secondary"}>
       {role === "admin" && <Shield className="size-3" />}
       {roleLabel(role)}
+    </Badge>
+  )
+}
+
+function InvitationStatusBadge({
+  invitation,
+}: {
+  invitation: OrganizationInvitationPublic
+}) {
+  if (invitation.revoked_at !== null) {
+    return (
+      <Badge variant="destructive">
+        <XCircle className="size-3" />
+        Revoked
+      </Badge>
+    )
+  }
+
+  if (invitation.accepted_at !== null) {
+    return (
+      <Badge variant="success">
+        <CircleCheck className="size-3" />
+        Accepted
+      </Badge>
+    )
+  }
+
+  return (
+    <Badge variant="outline">
+      <Clock className="size-3" />
+      Pending
     </Badge>
   )
 }
@@ -391,8 +425,11 @@ function IncomingInvitations({
             className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
           >
             <div className="min-w-0">
-              <div className="truncate font-medium">
-                {invitation.organization_name ?? "Organization invitation"}
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <span className="truncate font-medium">
+                  {invitation.organization_name ?? "Organization invitation"}
+                </span>
+                <InvitationStatusBadge invitation={invitation} />
               </div>
               <div className="text-sm text-muted-foreground">
                 Sent {formatDate(invitation.created_at)}
@@ -533,17 +570,21 @@ function PendingInvitations({
         <TableHeader>
           <TableRow>
             <TableHead>Email</TableHead>
+            <TableHead>Status</TableHead>
             <TableHead>Sent</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {invitations.length === 0 && (
-            <EmptyRow colSpan={2}>No pending invitations.</EmptyRow>
+            <EmptyRow colSpan={3}>No pending invitations.</EmptyRow>
           )}
           {invitations.map((invitation) => (
             <TableRow key={invitation.id}>
               <TableCell className="max-w-[20rem] truncate">
                 {invitation.invited_email}
+              </TableCell>
+              <TableCell>
+                <InvitationStatusBadge invitation={invitation} />
               </TableCell>
               <TableCell>{formatDate(invitation.created_at)}</TableCell>
             </TableRow>

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -218,6 +218,15 @@ test.describe("Organization", () => {
     await expect(page.getByText("Partner Organization")).toBeVisible()
     await expect(page.getByText("member@example.com")).toBeVisible()
     await expect(page.getByText("pending@example.com")).toBeVisible()
+    await expect(
+      page
+        .locator('[data-slot="card-content"]')
+        .filter({ hasText: "Partner Organization" })
+        .filter({ hasText: "Pending" }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole("row", { name: /pending@example\.com.*Pending/ }),
+    ).toBeVisible()
 
     await page.getByLabel("Organization name").fill("Renamed Organization")
     await page.getByRole("button", { name: "Save name" }).click()


### PR DESCRIPTION
## Summary
- add explicit Pending, Accepted, and Revoked badges for organization invitations
- show invitation status on incoming invitation cards and outgoing invitation rows
- cover pending invite badges in the organization settings Playwright test

## Validation
- bun run build
- FIRST_SUPERUSER=admin@example.com FIRST_SUPERUSER_PASSWORD=password npx playwright test tests/user-settings.spec.ts --project=chromium --no-deps -g "Organization tab shows members"
- bunx biome check --no-errors-on-unmatched --files-ignore-unknown=true ./ (passes with existing src/index.css noImportantStyles warning)

Jira: TF-173