### PR TITLE
Show organization invite badge on account menu

### DIFF
--- a/src/components/Sidebar/User.tsx
+++ b/src/components/Sidebar/User.tsx
@@ -1,6 +1,8 @@
+import { useQuery } from "@tanstack/react-query"
 import { Link as RouterLink } from "@tanstack/react-router"
 import { ChevronsUpDown, LogOut, Settings } from "lucide-react"
 
+import { readMyOrganizationInvitations } from "@/api/organizations"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import {
   DropdownMenu,
@@ -22,16 +24,35 @@ import { getInitials } from "@/utils"
 interface UserInfoProps {
   fullName?: string
   email?: string
+  pendingInvitationCount?: number
 }
 
-function UserInfo({ fullName, email }: UserInfoProps) {
+function UserInfo({
+  fullName,
+  email,
+  pendingInvitationCount = 0,
+}: UserInfoProps) {
+  const visibleInvitationCount =
+    pendingInvitationCount > 9 ? "9+" : pendingInvitationCount.toString()
+
   return (
     <div className="flex items-center gap-2.5 w-full min-w-0 group-data-[collapsible=icon]:w-auto group-data-[collapsible=icon]:gap-0">
-      <Avatar className="size-8 group-data-[collapsible=icon]:size-10">
-        <AvatarFallback className="bg-zinc-600 text-white">
-          {getInitials(fullName || "User")}
-        </AvatarFallback>
-      </Avatar>
+      <div className="relative shrink-0">
+        <Avatar className="size-8 group-data-[collapsible=icon]:size-10">
+          <AvatarFallback className="bg-zinc-600 text-white">
+            {getInitials(fullName || "User")}
+          </AvatarFallback>
+        </Avatar>
+        {pendingInvitationCount > 0 && (
+          <span
+            className="-right-1 -top-1 absolute flex h-4 min-w-4 items-center justify-center rounded-full bg-red-600 px-1 text-[10px] font-semibold leading-none text-white ring-2 ring-sidebar"
+            data-testid="organization-invite-badge"
+            title={`${pendingInvitationCount} pending organization invitation${pendingInvitationCount === 1 ? "" : "s"}`}
+          >
+            {visibleInvitationCount}
+          </span>
+        )}
+      </div>
       <div className="flex flex-col items-start min-w-0 group-data-[collapsible=icon]:hidden">
         <p className="text-sm font-medium truncate w-full">{fullName}</p>
         <p className="text-xs text-muted-foreground truncate w-full">{email}</p>
@@ -43,8 +64,17 @@ function UserInfo({ fullName, email }: UserInfoProps) {
 export function User({ user }: { user: any }) {
   const { logout } = useAuth()
   const { isMobile, setOpenMobile } = useSidebar()
+  const invitationsQuery = useQuery({
+    queryKey: ["my-organization-invitations"],
+    queryFn: readMyOrganizationInvitations,
+    enabled: Boolean(user),
+    staleTime: 30_000,
+  })
 
   if (!user) return null
+
+  const pendingInvitationCount =
+    invitationsQuery.data?.count ?? invitationsQuery.data?.data.length ?? 0
 
   const handleMenuClick = () => {
     if (isMobile) {
@@ -65,7 +95,11 @@ export function User({ user }: { user: any }) {
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
               data-testid="user-menu"
             >
-              <UserInfo fullName={user?.full_name} email={user?.email} />
+              <UserInfo
+                fullName={user?.full_name}
+                email={user?.email}
+                pendingInvitationCount={pendingInvitationCount}
+              />
               <ChevronsUpDown className="ml-auto size-[18px] text-muted-foreground group-data-[collapsible=icon]:hidden" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
@@ -76,7 +110,11 @@ export function User({ user }: { user: any }) {
             sideOffset={4}
           >
             <DropdownMenuLabel className="p-0 font-normal">
-              <UserInfo fullName={user?.full_name} email={user?.email} />
+              <UserInfo
+                fullName={user?.full_name}
+                email={user?.email}
+                pendingInvitationCount={pendingInvitationCount}
+              />
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
             <RouterLink to="/v2/settings" onClick={handleMenuClick}>

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -20,7 +20,10 @@ test.use({
   },
 })
 
-async function mockTaskforceAuth(page: Page) {
+async function mockTaskforceAuth(
+  page: Page,
+  { incomingInvitationCount = 0 }: { incomingInvitationCount?: number } = {},
+) {
   await page.addInitScript(() => {
     window.localStorage.setItem("access_token", "test-token")
   })
@@ -39,6 +42,24 @@ async function mockTaskforceAuth(page: Page) {
     }
 
     await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+
+  await page.route("**/api/v1/organizations/invitations", async (route) => {
+    const data = Array.from(
+      { length: incomingInvitationCount },
+      (_, index) => ({
+        id: `invite-${index + 1}`,
+        organization_id: `org-${index + 1}`,
+        organization_name: `Partner Organization ${index + 1}`,
+        invited_email: currentUser.email,
+        invited_by_user_id: `partner-admin-${index + 1}`,
+        created_at: "2026-03-17T20:00:00Z",
+        accepted_at: null,
+        revoked_at: null,
+      }),
+    )
+
+    await route.fulfill({ json: { data, count: data.length } })
   })
 }
 
@@ -64,6 +85,26 @@ test("Taskforce v2 sidebar includes collapse and document search controls", asyn
 
   await collapseToggle.click()
   await expect(collapseToggle).toBeVisible()
+})
+
+test("Taskforce v2 sidebar shows pending organization invite badge on the account button", async ({
+  page,
+}) => {
+  await mockTaskforceAuth(page, { incomingInvitationCount: 2 })
+  await mockV2Documents(page)
+
+  await page.goto("/v2/library")
+
+  const inviteBadge = page.getByTestId("organization-invite-badge")
+  await expect(inviteBadge).toBeVisible()
+  await expect(inviteBadge).toHaveText("2")
+  await expect(inviteBadge).toHaveAttribute(
+    "title",
+    "2 pending organization invitations",
+  )
+
+  await page.getByTestId("sidebar-collapse-toggle").click()
+  await expect(inviteBadge).toBeVisible()
 })
 
 test("Taskforce v2 Admin link stays inside the v2 shell", async ({ page }) => {


### PR DESCRIPTION
## Summary
- fetch incoming organization invitations from the shared sidebar user menu
- show a red numeric badge on the lower-left account avatar when pending invitations exist
- keep the badge visible when the Taskforce sidebar is collapsed
- add Taskforce shell Playwright coverage for the invite badge

## Validation
- bun run build
- FIRST_SUPERUSER=admin@example.com FIRST_SUPERUSER_PASSWORD=password npx playwright test tests/taskforce-shell.spec.ts --project=chromium --no-deps
- bunx biome check --no-errors-on-unmatched --files-ignore-unknown=true ./ (passes with existing src/index.css noImportantStyles warning)