### PR TITLE
Fix organization invite badge placement

### DIFF
--- a/src/components/Common/PendingInvitationBadge.tsx
+++ b/src/components/Common/PendingInvitationBadge.tsx
@@ -1,0 +1,33 @@
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+
+type PendingInvitationBadgeProps = {
+  count: number
+  className?: string
+  testId?: string
+}
+
+export function PendingInvitationBadge({
+  count,
+  className,
+  testId = "organization-invite-badge",
+}: PendingInvitationBadgeProps) {
+  if (count <= 0) return null
+
+  const visibleCount = count > 9 ? "9+" : count.toString()
+  const title = `${count} pending organization invitation${count === 1 ? "" : "s"}`
+
+  return (
+    <Badge
+      variant="destructive"
+      className={cn(
+        "flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[10px] font-semibold leading-none text-white",
+        className,
+      )}
+      data-testid={testId}
+      title={title}
+    >
+      {visibleCount}
+    </Badge>
+  )
+}

--- a/src/components/Sidebar/User.tsx
+++ b/src/components/Sidebar/User.tsx
@@ -3,6 +3,7 @@ import { Link as RouterLink } from "@tanstack/react-router"
 import { ChevronsUpDown, LogOut, Settings } from "lucide-react"
 
 import { readMyOrganizationInvitations } from "@/api/organizations"
+import { PendingInvitationBadge } from "@/components/Common/PendingInvitationBadge"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import {
   DropdownMenu,
@@ -32,9 +33,6 @@ function UserInfo({
   email,
   pendingInvitationCount = 0,
 }: UserInfoProps) {
-  const visibleInvitationCount =
-    pendingInvitationCount > 9 ? "9+" : pendingInvitationCount.toString()
-
   return (
     <div className="flex items-center gap-2.5 w-full min-w-0 group-data-[collapsible=icon]:w-auto group-data-[collapsible=icon]:gap-0">
       <div className="relative shrink-0">
@@ -43,15 +41,10 @@ function UserInfo({
             {getInitials(fullName || "User")}
           </AvatarFallback>
         </Avatar>
-        {pendingInvitationCount > 0 && (
-          <span
-            className="-right-1 -top-1 absolute flex h-4 min-w-4 items-center justify-center rounded-full bg-red-600 px-1 text-[10px] font-semibold leading-none text-white ring-2 ring-sidebar"
-            data-testid="organization-invite-badge"
-            title={`${pendingInvitationCount} pending organization invitation${pendingInvitationCount === 1 ? "" : "s"}`}
-          >
-            {visibleInvitationCount}
-          </span>
-        )}
+        <PendingInvitationBadge
+          count={pendingInvitationCount}
+          className="-right-1 -top-1 absolute h-4 min-w-4 ring-2 ring-sidebar"
+        />
       </div>
       <div className="flex flex-col items-start min-w-0 group-data-[collapsible=icon]:hidden">
         <p className="text-sm font-medium truncate w-full">{fullName}</p>
@@ -120,7 +113,12 @@ export function User({ user }: { user: any }) {
             <RouterLink to="/v2/settings" onClick={handleMenuClick}>
               <DropdownMenuItem>
                 <Settings />
-                User Settings
+                <span>User Settings</span>
+                <PendingInvitationBadge
+                  count={pendingInvitationCount}
+                  className="ml-auto"
+                  testId="user-settings-invite-badge"
+                />
               </DropdownMenuItem>
             </RouterLink>
             <DropdownMenuItem onClick={handleLogout}>

--- a/src/components/UserSettings/UserSettingsPage.tsx
+++ b/src/components/UserSettings/UserSettingsPage.tsx
@@ -1,5 +1,8 @@
+import { useQuery } from "@tanstack/react-query"
 import type { ComponentType } from "react"
 
+import { readMyOrganizationInvitations } from "@/api/organizations"
+import { PendingInvitationBadge } from "@/components/Common/PendingInvitationBadge"
 import AppearanceSettings from "@/components/UserSettings/Appearance"
 import Billing from "@/components/UserSettings/Billing"
 import ChangePassword from "@/components/UserSettings/ChangePassword"
@@ -46,10 +49,19 @@ export function UserSettingsPage({
   onTabChange,
 }: UserSettingsPageProps) {
   const { user: currentUser } = useAuth()
+  const invitationsQuery = useQuery({
+    queryKey: ["my-organization-invitations"],
+    queryFn: readMyOrganizationInvitations,
+    enabled: Boolean(currentUser),
+    staleTime: 30_000,
+  })
 
   if (!currentUser) {
     return null
   }
+
+  const pendingInvitationCount =
+    invitationsQuery.data?.count ?? invitationsQuery.data?.data.length ?? 0
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden">
@@ -65,7 +77,13 @@ export function UserSettingsPage({
         <TabsList className="max-w-full shrink-0 justify-start overflow-x-auto">
           {tabsConfig.map((tab) => (
             <TabsTrigger key={tab.value} value={tab.value}>
-              {tab.title}
+              <span>{tab.title}</span>
+              {tab.value === "organization" && (
+                <PendingInvitationBadge
+                  count={pendingInvitationCount}
+                  testId="organization-tab-invite-badge"
+                />
+              )}
             </TabsTrigger>
           ))}
         </TabsList>

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -103,8 +103,18 @@ test("Taskforce v2 sidebar shows pending organization invite badge on the accoun
     "2 pending organization invitations",
   )
 
+  await page.getByTestId("user-menu").click()
+  const settingsInviteBadge = page.getByTestId("user-settings-invite-badge")
+  await expect(settingsInviteBadge).toBeVisible()
+  await expect(settingsInviteBadge).toHaveText("2")
+  await expect(settingsInviteBadge).toHaveAttribute(
+    "title",
+    "2 pending organization invitations",
+  )
+
+  await page.keyboard.press("Escape")
   await page.getByTestId("sidebar-collapse-toggle").click()
-  await expect(inviteBadge).toBeVisible()
+  await expect(inviteBadge.first()).toBeVisible()
 })
 
 test("Taskforce v2 Admin link stays inside the v2 shell", async ({ page }) => {

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -209,6 +209,15 @@ test.describe("Organization", () => {
 
     await page.goto("/v2/settings?tab=organization")
 
+    const organizationTabInviteBadge = page.getByTestId(
+      "organization-tab-invite-badge",
+    )
+    await expect(organizationTabInviteBadge).toBeVisible()
+    await expect(organizationTabInviteBadge).toHaveText("1")
+    await expect(organizationTabInviteBadge).toHaveAttribute(
+      "title",
+      "1 pending organization invitation",
+    )
     await expect(
       page
         .locator('[data-slot="card-title"]')


### PR DESCRIPTION
## Summary
- add a reusable pending organization invitation badge component
- keep the existing avatar badge but reuse the shared badge component
- show the pending invite badge on the User Settings dropdown item
- show the pending invite badge on the Organization settings tab trigger

## Validation
- bun run build
- FIRST_SUPERUSER=admin@example.com FIRST_SUPERUSER_PASSWORD=password npx playwright test tests/taskforce-shell.spec.ts tests/user-settings.spec.ts --project=chromium --no-deps -g "pending organization invite badge|Organization tab shows members" (2 passed)
- bunx biome check --no-errors-on-unmatched --files-ignore-unknown=true ./ (passes with existing src/index.css noImportantStyles warning)