### PR TITLE
TF-185: Scroll doc viewer to URL hash

### DIFF
--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -18,7 +18,14 @@ import {
   Strikethrough,
   X,
 } from "lucide-react"
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 
 import {
   type OrganizationMemberPublic,
@@ -493,6 +500,7 @@ function TaskforceDocumentDetail() {
   const [accessOpen, setAccessOpen] = useState(false)
   const [shareDraft, setShareDraft] = useState<ShareDraft>({})
   const [createFolderOpen, setCreateFolderOpen] = useState(false)
+  const handledHashScrollRef = useRef<string | null>(null)
 
   const documentQuery = useQuery({
     queryKey: ["v2-document", documentId, { demo: isDemoMode }],
@@ -614,7 +622,7 @@ function TaskforceDocumentDetail() {
   const summaryVisible = viewMode === "summary" || isSplit
   const detailsVisible = viewMode === "details" || isSplit
 
-  const showEvidence = (anchorId: string) => {
+  const showEvidence = useCallback((anchorId: string) => {
     setActiveEvidenceAnchorId(anchorId)
     setViewMode("split")
     window.setTimeout(() => {
@@ -622,7 +630,32 @@ function TaskforceDocumentDetail() {
         .getElementById(anchorId)
         ?.scrollIntoView({ block: "start", behavior: "smooth" })
     }, 0)
-  }
+  }, [])
+
+  useEffect(() => {
+    if (!document) return
+
+    const rawHash = window.location.hash.slice(1)
+    if (!rawHash) return
+
+    let anchorId = rawHash
+    try {
+      anchorId = decodeURIComponent(rawHash)
+    } catch {
+      anchorId = rawHash
+    }
+
+    const scrollKey = `${document.id}:${anchorId}`
+    if (handledHashScrollRef.current === scrollKey) return
+
+    const hasMatchingSection = document.details_markdown_sections.some(
+      (section) => section.anchor_id === anchorId,
+    )
+    if (!hasMatchingSection) return
+
+    handledHashScrollRef.current = scrollKey
+    showEvidence(anchorId)
+  }, [document, showEvidence])
 
   const closeSplit = () => {
     setViewMode("summary")

--- a/tests/v2-document-hash.spec.ts
+++ b/tests/v2-document-hash.spec.ts
@@ -1,0 +1,136 @@
+import { expect, type Page, test } from "@playwright/test"
+
+import { mockV2Documents } from "./fixtures/v2-documents"
+
+const bridgeDocumentId = "8c9b0f48-2f3f-4e8d-9f7d-b4f0607d6a32"
+
+const currentUser = {
+  id: "user-1",
+  email: "alex@example.com",
+  is_active: true,
+  is_superuser: true,
+  full_name: "Alex Lee",
+  created_at: "2026-03-24T00:00:00Z",
+  v2: true,
+  subscription_tier: "free",
+}
+
+test.use({
+  storageState: {
+    cookies: [],
+    origins: [],
+  },
+})
+
+async function mockTaskforceDocumentPage(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "test-token")
+    window.localStorage.setItem("taskforce-demo-mode", "true")
+
+    const win = window as typeof window & { __scrollIntoViewCalls: string[] }
+    win.__scrollIntoViewCalls = []
+    Element.prototype.scrollIntoView = function () {
+      win.__scrollIntoViewCalls.push((this as HTMLElement).id)
+    }
+  })
+
+  await page.route("**/api/v1/users/**", async (route) => {
+    const url = new URL(route.request().url())
+
+    if (url.pathname === "/api/v1/users/me") {
+      await route.fulfill({ json: currentUser })
+      return
+    }
+
+    if (url.pathname === "/api/v1/users/") {
+      await route.fulfill({ json: { data: [currentUser], count: 1 } })
+      return
+    }
+
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+
+  await page.route("**/api/v1/organizations/invitations", async (route) => {
+    await route.fulfill({ json: { data: [], count: 0 } })
+  })
+
+  await mockV2Documents(page)
+}
+
+test("V2 document viewer opens and scrolls to matching URL hash anchor", async ({
+  page,
+}) => {
+  await mockTaskforceDocumentPage(page)
+
+  await page.goto(`/v2/library/${bridgeDocumentId}#affected-users`)
+
+  await expect(page.getByRole("tab", { name: "Split" })).toHaveAttribute(
+    "data-state",
+    "active",
+  )
+  await expect(page.getByTestId("ai-evidence-affected-users")).toHaveAttribute(
+    "data-active-evidence",
+    "true",
+  )
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { __scrollIntoViewCalls: string[] })
+            .__scrollIntoViewCalls,
+      ),
+    )
+    .toEqual(["affected-users"])
+})
+
+test("V2 document viewer leaves summary mode unchanged without URL hash", async ({
+  page,
+}) => {
+  await mockTaskforceDocumentPage(page)
+
+  await page.goto(`/v2/library/${bridgeDocumentId}`)
+
+  await expect(page.getByRole("tab", { name: "Summary" })).toHaveAttribute(
+    "data-state",
+    "active",
+  )
+  await expect(page.getByRole("tab", { name: "Split" })).toHaveAttribute(
+    "data-state",
+    "inactive",
+  )
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { __scrollIntoViewCalls: string[] })
+            .__scrollIntoViewCalls,
+      ),
+    )
+    .toEqual([])
+})
+
+test("V2 document viewer ignores unknown URL hash anchors", async ({
+  page,
+}) => {
+  await mockTaskforceDocumentPage(page)
+
+  await page.goto(`/v2/library/${bridgeDocumentId}#unknown-anchor`)
+
+  await expect(page.getByRole("tab", { name: "Summary" })).toHaveAttribute(
+    "data-state",
+    "active",
+  )
+  await expect(page.getByRole("tab", { name: "Split" })).toHaveAttribute(
+    "data-state",
+    "inactive",
+  )
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { __scrollIntoViewCalls: string[] })
+            .__scrollIntoViewCalls,
+      ),
+    )
+    .toEqual([])
+})


### PR DESCRIPTION
## Summary

Implements TF-185 by making the V2 document viewer honor URL hash anchors on initial load.

## Changes

- Reads `window.location.hash` after the document is loaded.
- Verifies the hash matches an existing `details_markdown_sections[].anchor_id` before acting.
- Reuses the existing `showEvidence(anchorId)` flow so the page switches to split mode, marks the active evidence section, and scrolls to the details anchor.
- Guards with a `docId:anchorId` ref so rerenders do not repeatedly scroll the same document/hash pair.
- Adds focused Playwright coverage for matching hash, no hash, and unknown hash cases.

## Validation

- `npx biome check src/routes/v2/library.$documentId.tsx tests/v2-document-hash.spec.ts`
- `npx tsc --noEmit`
- `npx playwright test tests/v2-document-hash.spec.ts --project=chromium --no-deps`

Local validation notes:
- This worktree had no installed dependencies. `bun install --frozen-lockfile` reported the existing `bun.lock` is out of sync, so I did not modify it.
- I installed transient `node_modules` with `npm install --no-package-lock` for validation only. No dependency files were changed.
- The local dev server was started with non-secret test Firebase Vite env vars for the Playwright run.

Jira: TF-185