### PR TITLE
TF-192: Frontend metrics session filter

### DIFF
--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -1,0 +1,65 @@
+import { type CancelablePromise, OpenAPI } from "@/client"
+import { request } from "@/client/core/request"
+
+export interface TaskforceSessionSavingsResponse {
+  session_id: string
+  doc_count: number
+  net_saved_tokens: number
+  usd_saved: string
+  pricing_model_id: string
+  occurred_at_first: string | null
+  occurred_at_last: string | null
+}
+
+export interface TaskforceSessionLogEntry {
+  document_id: string
+  title: string
+  score: number
+  confidence_band: "high" | "medium" | "low"
+  match_reasons: string[]
+  summary_markdown: string
+  occurred_at: string
+  query_id: string
+  net_saved_tokens: number
+}
+
+export interface TaskforceSessionLogResponse {
+  session_id: string
+  entries: TaskforceSessionLogEntry[]
+}
+
+export interface ReadTaskforceSessionSavingsArgs {
+  sessionId: string
+  pricingModelId?: string
+}
+
+export function readTaskforceSessionSavings(
+  args: ReadTaskforceSessionSavingsArgs,
+): CancelablePromise<TaskforceSessionSavingsResponse> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/taskforce/session-savings",
+    query: {
+      session_id: args.sessionId,
+      ...(args.pricingModelId ? { pricing_model_id: args.pricingModelId } : {}),
+    },
+  })
+}
+
+export interface ReadTaskforceSessionLogArgs {
+  sessionId: string
+  limit?: number
+}
+
+export function readTaskforceSessionLog(
+  args: ReadTaskforceSessionLogArgs,
+): CancelablePromise<TaskforceSessionLogResponse> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/taskforce/session-log",
+    query: {
+      session_id: args.sessionId,
+      limit: args.limit ?? 50,
+    },
+  })
+}

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -1,13 +1,30 @@
 import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
 import { useMemo, useState } from "react"
 import {
   type MetricDefinitionPublic,
   type MetricsWindow,
+  type MetricValuePublic,
   readMetricDefinitions,
   readMetrics,
 } from "@/api/v2Metrics"
+import {
+  readTaskforceSessionLog,
+  readTaskforceSessionSavings,
+  type TaskforceSessionLogEntry,
+  type TaskforceSessionSavingsResponse,
+} from "@/api/v2Taskforce"
 import type { UserPublic } from "@/client"
 import { useDemoMode } from "@/components/demo-mode-provider"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 import { usePersistentState } from "@/hooks/usePersistentState"
 import { MethodologyLink } from "./MethodologyLink"
 import { MetricBreakdown } from "./MetricBreakdown"
@@ -17,10 +34,17 @@ import { MetricTrendChart } from "./MetricTrendChart"
 
 type Props = {
   currentUser: UserPublic
+  sessionId?: string
 }
 
 const PRIMARY_METRICS = ["tokens_saved", "usd_saved", "reuse_rate"]
 const SECONDARY_METRICS = ["tokens_consumed", "usd_consumed"]
+const SESSION_PRICING_MODEL_ID = "claude-opus-4-7"
+const SESSION_PRIMARY_METRICS = [
+  "tokens_saved",
+  "usd_saved",
+  "documents_consulted",
+]
 
 const METRIC_PRESENTATION_OVERRIDES: Record<
   string,
@@ -57,6 +81,42 @@ const USD_NET_SAVED_DEFINITION: MetricDefinitionPublic = {
   },
 }
 
+const SESSION_METRIC_DEFINITIONS: Record<string, MetricDefinitionPublic> = {
+  tokens_saved: {
+    name: "tokens_saved",
+    display_name: "Tokens Saved",
+    unit: "tokens",
+    description: "Net tokens saved by this Taskforce session.",
+    presentation: {
+      format: "compact-int",
+      trend: false,
+      icon: null,
+    },
+  },
+  usd_saved: {
+    name: "usd_saved",
+    display_name: "USD Saved",
+    unit: "usd",
+    description: `Approximate USD saved using ${SESSION_PRICING_MODEL_ID} pricing.`,
+    presentation: {
+      format: "usd",
+      trend: false,
+      icon: null,
+    },
+  },
+  documents_consulted: {
+    name: "documents_consulted",
+    display_name: "Documents Consulted",
+    unit: "count",
+    description: "Documents Taskforce consulted for this session.",
+    presentation: {
+      format: "count",
+      trend: false,
+      icon: null,
+    },
+  },
+}
+
 function toMetricNumber(value: string | number | null | undefined) {
   if (value == null) return 0
   if (typeof value === "number") return value
@@ -64,14 +124,68 @@ function toMetricNumber(value: string | number | null | undefined) {
   return Number.isFinite(parsed) ? parsed : 0
 }
 
+function metricValue(total: string | number): MetricValuePublic {
+  return {
+    total: String(total),
+    delta_vs_prev_window: null,
+    series: [],
+    breakdown_by_source: null,
+    top_models: null,
+  }
+}
+
+function buildFallbackSessionSavings(
+  sessionId: string,
+  entries: TaskforceSessionLogEntry[],
+): TaskforceSessionSavingsResponse {
+  const occurredAtValues = entries
+    .map((entry) => entry.occurred_at)
+    .filter(Boolean)
+    .sort()
+  const documentIds = new Set(entries.map((entry) => entry.document_id))
+  return {
+    session_id: sessionId,
+    doc_count: documentIds.size,
+    net_saved_tokens: entries.reduce(
+      (total, entry) => total + entry.net_saved_tokens,
+      0,
+    ),
+    usd_saved: "0",
+    pricing_model_id: SESSION_PRICING_MODEL_ID,
+    occurred_at_first: occurredAtValues[0] ?? null,
+    occurred_at_last: occurredAtValues[occurredAtValues.length - 1] ?? null,
+  }
+}
+
+function formatSessionDate(value: string): string {
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  }).format(parsed)
+}
+
+function formatScore(score: number): string {
+  if (!Number.isFinite(score)) return "0%"
+  return `${Math.round(score * 100)}%`
+}
+
 // Org-scope toggle is intentionally deferred. The backend supports
 // scope=organization on /v2/metrics (admin-gated), but the generated
 // OpenAPI client doesn't yet expose organization_id / organization_role
 // on UserPublic in this repo. When the client is regenerated, restore
 // the MetricsScopeToggle import and the `scope` state below.
-export function MetricsPage({ currentUser: _currentUser }: Props) {
+export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
   const { isDemoMode } = useDemoMode()
   const [window, setWindow] = useState<MetricsWindow>("7d")
+  const scopedSessionId = sessionId?.trim() || undefined
+  const sessionShortId = scopedSessionId?.slice(0, 8)
   // TF-177 / Phase 3 feature flag. When enabled, surface the
   // Avoided Rediscovery card driven by document.consulted events.
   // Toggle by setting `localStorage["taskforce.flags.savings_v2"] = "true"`
@@ -90,6 +204,29 @@ export function MetricsPage({ currentUser: _currentUser }: Props) {
     staleTime: 30 * 1000,
   })
 
+  const sessionSavingsQuery = useQuery({
+    queryKey: [
+      "v2-taskforce-session-savings",
+      { sessionId: scopedSessionId, pricingModelId: SESSION_PRICING_MODEL_ID },
+    ],
+    queryFn: () =>
+      readTaskforceSessionSavings({
+        sessionId: scopedSessionId ?? "",
+        pricingModelId: SESSION_PRICING_MODEL_ID,
+      }),
+    enabled: Boolean(scopedSessionId),
+    retry: false,
+    staleTime: 30 * 1000,
+  })
+
+  const sessionLogQuery = useQuery({
+    queryKey: ["v2-taskforce-session-log", { sessionId: scopedSessionId }],
+    queryFn: () =>
+      readTaskforceSessionLog({ sessionId: scopedSessionId ?? "", limit: 50 }),
+    enabled: Boolean(scopedSessionId),
+    staleTime: 30 * 1000,
+  })
+
   const definitionsByName = useMemo(() => {
     const out: Record<string, MetricDefinitionPublic> = {}
     for (const d of definitionsQuery.data?.data ?? []) {
@@ -99,6 +236,19 @@ export function MetricsPage({ currentUser: _currentUser }: Props) {
   }, [definitionsQuery.data])
 
   const metrics = metricsQuery.data?.metrics ?? {}
+  const sessionLogEntries = sessionLogQuery.data?.entries ?? []
+  const fallbackSessionSavings =
+    scopedSessionId && sessionLogQuery.isSuccess
+      ? buildFallbackSessionSavings(scopedSessionId, sessionLogEntries)
+      : null
+  const sessionSavings = sessionSavingsQuery.data ?? fallbackSessionSavings
+  const sessionMetricValues: Record<string, MetricValuePublic> = {
+    tokens_saved: metricValue(sessionSavings?.net_saved_tokens ?? 0),
+    usd_saved: metricValue(sessionSavings?.usd_saved ?? "0"),
+    documents_consulted: metricValue(
+      sessionSavings?.doc_count ?? sessionLogEntries.length,
+    ),
+  }
   const tokensSaved = metrics.tokens_saved
   const tokensConsumed = metrics.tokens_consumed
   const usdOffset = toMetricNumber(metrics.usd_saved?.total)
@@ -128,6 +278,27 @@ export function MetricsPage({ currentUser: _currentUser }: Props) {
         </div>
       </div>
 
+      {scopedSessionId && (
+        <div
+          data-testid="metrics-session-filter-banner"
+          className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-950 dark:border-blue-900/70 dark:bg-blue-950/40 dark:text-blue-100"
+        >
+          <span>
+            Showing savings for session{" "}
+            <code className="rounded bg-white/70 px-1.5 py-0.5 font-mono text-xs dark:bg-white/10">
+              {sessionShortId}
+            </code>
+          </span>
+          <Link
+            to="/v2/metrics"
+            search={{}}
+            className="font-medium underline-offset-4 hover:underline"
+          >
+            view all metrics →
+          </Link>
+        </div>
+      )}
+
       {metricsQuery.isError && (
         <div className="rounded border border-destructive bg-destructive/10 p-3 text-sm">
           Failed to load metrics. Try again in a moment.
@@ -142,16 +313,29 @@ export function MetricsPage({ currentUser: _currentUser }: Props) {
       )}
 
       <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        {PRIMARY_METRICS.map((name) => {
-          const def = definitionsByName[name]
-          if (!def) return null
-          return (
-            <MetricCard key={name} definition={def} value={metrics[name]} />
-          )
-        })}
+        {(scopedSessionId ? SESSION_PRIMARY_METRICS : PRIMARY_METRICS).map(
+          (name) => {
+            const def = scopedSessionId
+              ? SESSION_METRIC_DEFINITIONS[name]
+              : definitionsByName[name]
+            const value = scopedSessionId
+              ? sessionMetricValues[name]
+              : metrics[name]
+            if (!def) return null
+            return <MetricCard key={name} definition={def} value={value} />
+          },
+        )}
       </section>
 
-      {savingsV2Flag && (
+      {scopedSessionId && (
+        <SessionLogTable
+          entries={sessionLogEntries}
+          isError={sessionLogQuery.isError}
+          isLoading={sessionLogQuery.isLoading}
+        />
+      )}
+
+      {savingsV2Flag && !scopedSessionId && (
         <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
           {[
             "avoided_rediscovery",
@@ -199,5 +383,74 @@ export function MetricsPage({ currentUser: _currentUser }: Props) {
         />
       </section>
     </div>
+  )
+}
+
+function SessionLogTable({
+  entries,
+  isError,
+  isLoading,
+}: {
+  entries: TaskforceSessionLogEntry[]
+  isError: boolean
+  isLoading: boolean
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-background p-4 shadow-sm">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-medium text-muted-foreground">
+            Session Consult Log
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Documents Taskforce consulted while calculating this session's
+            savings.
+          </p>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading session log…</p>
+      ) : isError ? (
+        <p className="text-sm text-destructive">
+          Failed to load the session log.
+        </p>
+      ) : entries.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No consulted documents were recorded for this session.
+        </p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Document</TableHead>
+              <TableHead>Score</TableHead>
+              <TableHead>Band</TableHead>
+              <TableHead className="text-right">Net Tokens</TableHead>
+              <TableHead>Occurred</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {entries.map((entry) => (
+              <TableRow key={`${entry.query_id}-${entry.document_id}`}>
+                <TableCell className="max-w-72 truncate font-medium">
+                  {entry.title}
+                </TableCell>
+                <TableCell className="tabular-nums">
+                  {formatScore(entry.score)}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline">{entry.confidence_band}</Badge>
+                </TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {entry.net_saved_tokens.toLocaleString()}
+                </TableCell>
+                <TableCell>{formatSessionDate(entry.occurred_at)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </section>
   )
 }

--- a/src/routes/v2/metrics.tsx
+++ b/src/routes/v2/metrics.tsx
@@ -1,9 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
 
 import { MetricsPage } from "@/components/V2/Metrics/MetricsPage"
 
+const searchSchema = z.object({
+  session_id: z.string().optional(),
+})
+
 export const Route = createFileRoute("/v2/metrics")({
   component: TaskforceMetrics,
+  validateSearch: searchSchema,
   head: () => ({
     meta: [
       {
@@ -15,5 +21,6 @@ export const Route = createFileRoute("/v2/metrics")({
 
 function TaskforceMetrics() {
   const { currentUser } = Route.useRouteContext()
-  return <MetricsPage currentUser={currentUser} />
+  const { session_id: sessionId } = Route.useSearch()
+  return <MetricsPage currentUser={currentUser} sessionId={sessionId} />
 }

--- a/tests/v2-metrics-session.spec.ts
+++ b/tests/v2-metrics-session.spec.ts
@@ -1,0 +1,222 @@
+import { expect, type Page, test } from "@playwright/test"
+
+import { mockV2Documents } from "./fixtures/v2-documents"
+
+const sessionId = "123e4567-e89b-12d3-a456-426614174000"
+
+const currentUser = {
+  id: "user-1",
+  email: "alex@example.com",
+  is_active: true,
+  is_superuser: true,
+  full_name: "Alex Lee",
+  created_at: "2026-03-24T00:00:00Z",
+  v2: true,
+  subscription_tier: "free",
+}
+
+test.use({
+  storageState: {
+    cookies: [],
+    origins: [],
+  },
+})
+
+function metricDefinition(
+  name: string,
+  displayName: string,
+  format: "compact-int" | "usd" | "ratio" | "count",
+  unit: "tokens" | "usd" | "ratio" | "count",
+) {
+  return {
+    name,
+    display_name: displayName,
+    unit,
+    description: `${displayName} description`,
+    presentation: { format, trend: false, icon: null },
+  }
+}
+
+function metricValue(total: string) {
+  return {
+    total,
+    delta_vs_prev_window: null,
+    series: [{ day: "2026-05-24", value: total }],
+    breakdown_by_source: [
+      { key: "reuse", label: "Reuse", tokens: Number(total) || 0, usd: "0" },
+    ],
+    top_models: [
+      { key: "claude-opus-4-7", label: "Claude Opus", tokens: 100, usd: "0" },
+    ],
+  }
+}
+
+async function mockMetricsPage(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "test-token")
+  })
+
+  await page.route("**/api/v1/users/**", async (route) => {
+    const url = new URL(route.request().url())
+
+    if (url.pathname === "/api/v1/users/me") {
+      await route.fulfill({ json: currentUser })
+      return
+    }
+
+    if (url.pathname === "/api/v1/users/") {
+      await route.fulfill({ json: { data: [currentUser], count: 1 } })
+      return
+    }
+
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+
+  await page.route("**/api/v1/organizations/invitations", async (route) => {
+    await route.fulfill({ json: { data: [], count: 0 } })
+  })
+
+  await page.route("**/api/v1/v2/metrics/definitions", async (route) => {
+    await route.fulfill({
+      json: {
+        data: [
+          metricDefinition(
+            "tokens_saved",
+            "Tokens Saved",
+            "compact-int",
+            "tokens",
+          ),
+          metricDefinition("usd_saved", "USD Saved", "usd", "usd"),
+          metricDefinition("reuse_rate", "Reuse Rate", "ratio", "ratio"),
+          metricDefinition(
+            "tokens_consumed",
+            "Tokens Consumed",
+            "compact-int",
+            "tokens",
+          ),
+          metricDefinition("usd_consumed", "USD Consumed", "usd", "usd"),
+        ],
+      },
+    })
+  })
+
+  await page.route("**/api/v1/v2/metrics?*", async (route) => {
+    await route.fulfill({
+      json: {
+        window: "7d",
+        from: "2026-05-18T00:00:00Z",
+        to: "2026-05-24T00:00:00Z",
+        scope: "personal",
+        is_demo: false,
+        metrics: {
+          tokens_saved: metricValue("1000"),
+          usd_saved: metricValue("1.23"),
+          reuse_rate: metricValue("0.5"),
+          tokens_consumed: metricValue("2000"),
+          usd_consumed: metricValue("0.25"),
+        },
+      },
+    })
+  })
+
+  await page.route("**/api/v1/v2/taskforce/session-log?*", async (route) => {
+    await route.fulfill({
+      json: {
+        session_id: sessionId,
+        entries: [
+          {
+            document_id: "doc-1",
+            title: "Bridge incident investigation",
+            score: 0.92,
+            confidence_band: "high",
+            match_reasons: ["Title overlap"],
+            summary_markdown: "Bridge summary",
+            occurred_at: "2026-05-23T19:00:00Z",
+            query_id: "query-1",
+            net_saved_tokens: 2500,
+          },
+          {
+            document_id: "doc-2",
+            title: "Metrics polish follow-up",
+            score: 0.64,
+            confidence_band: "medium",
+            match_reasons: ["Prompt overlap"],
+            summary_markdown: "Metrics summary",
+            occurred_at: "2026-05-23T19:04:00Z",
+            query_id: "query-2",
+            net_saved_tokens: 1718,
+          },
+        ],
+      },
+    })
+  })
+
+  await mockV2Documents(page)
+}
+
+test("metrics page shows session-scoped savings when session_id is present", async ({
+  page,
+}) => {
+  await mockMetricsPage(page)
+
+  await page.route(
+    "**/api/v1/v2/taskforce/session-savings?*",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          session_id: sessionId,
+          doc_count: 2,
+          net_saved_tokens: 4218,
+          usd_saved: "0.42",
+          pricing_model_id: "claude-opus-4-7",
+          occurred_at_first: "2026-05-23T19:00:00Z",
+          occurred_at_last: "2026-05-23T19:04:00Z",
+        },
+      })
+    },
+  )
+
+  await page.goto(`/v2/metrics?session_id=${sessionId}`)
+
+  await expect(page.getByTestId("metrics-session-filter-banner")).toContainText(
+    "123e4567",
+  )
+  await expect(
+    page.getByText("Tokens Saved", { exact: true }).first(),
+  ).toBeVisible()
+  await expect(page.getByText("4.2K", { exact: true }).first()).toBeVisible()
+  await expect(
+    page.getByText("USD Saved", { exact: true }).first(),
+  ).toBeVisible()
+  await expect(page.getByText("$0.42", { exact: true }).first()).toBeVisible()
+  await expect(
+    page.getByText("Documents Consulted", { exact: true }),
+  ).toBeVisible()
+  await expect(page.getByText("Bridge incident investigation")).toBeVisible()
+  await expect(page.getByText("2,500")).toBeVisible()
+
+  await page.getByRole("link", { name: /view all metrics/i }).click()
+  await expect(page).toHaveURL(/\/v2\/metrics$/)
+})
+
+test("metrics page keeps aggregate dashboard without session_id", async ({
+  page,
+}) => {
+  let sessionSavingsRequests = 0
+  await mockMetricsPage(page)
+  await page.route(
+    "**/api/v1/v2/taskforce/session-savings?*",
+    async (route) => {
+      sessionSavingsRequests += 1
+      await route.fulfill({ status: 500, json: { detail: "Unexpected call" } })
+    },
+  )
+
+  await page.goto("/v2/metrics")
+
+  await expect(page.getByTestId("metrics-session-filter-banner")).toHaveCount(0)
+  await expect(page.getByText("Reuse Rate", { exact: true })).toBeVisible()
+  await expect(page.getByText("1K", { exact: true }).first()).toBeVisible()
+  await expect(page.getByText("$1.23", { exact: true }).first()).toBeVisible()
+  expect(sessionSavingsRequests).toBe(0)
+})


### PR DESCRIPTION
## Summary
- Add typed Taskforce API clients for `/session-savings` and `/session-log`.
- Parse `session_id` on `/v2/metrics` and show a session filter banner with a `view all metrics` link.
- Replace headline cards with session Tokens Saved / USD Saved / Documents Consulted values and render a session consult-log table.
- Keep the no-query-param aggregate metrics page unchanged. Since TF-187 is not merged yet, the UI falls back to summing `session-log` net tokens and uses `$0.00` USD until `/session-savings` is available.

## Validation
- `npx biome check src/api/v2Taskforce.ts src/components/V2/Metrics/MetricsPage.tsx src/routes/v2/metrics.tsx tests/v2-metrics-session.spec.ts`
- `npx tsc --noEmit`
- `env VITE_API_URL=http://127.0.0.1:8000 VITE_FIREBASE_API_KEY=test-api-key VITE_FIREBASE_AUTH_DOMAIN=test.firebaseapp.com VITE_FIREBASE_PROJECT_ID=test-project VITE_FIREBASE_MESSAGING_SENDER_ID=123456 VITE_FIREBASE_APP_ID=1:123456:web:test npx playwright test tests/v2-metrics-session.spec.ts --project=chromium --no-deps`

Notes:
- `bun install --frozen-lockfile` fails on current `main` because `bun.lock` is already out of sync; no dependency files were changed.
- Local Playwright required the existing workaround of starting Vite via `bun --bun node_modules/vite/bin/vite.js` plus transient optional `@tailwindcss/oxide-linux-x64-gnu` install due npm optional dependency resolution.

Jira: TF-192