### PR TITLE
TF-197: Add agents grid and detail pages

### DIFF
--- a/src/api/v2Agents.ts
+++ b/src/api/v2Agents.ts
@@ -1,0 +1,93 @@
+import { type CancelablePromise, OpenAPI } from "@/client"
+import { request } from "@/client/core/request"
+
+export type AgentSpecialistStatus = "active" | "draft" | "archived"
+
+export interface AgentSpecialistSummary {
+  id: string
+  slug: string
+  name: string
+  role: string
+  short_description: string
+  domain_tags: string[]
+  status: AgentSpecialistStatus
+  linked_docs_count: number
+  invocations_count: number
+  tokens_saved: number
+  last_invoked_at: string | null
+}
+
+export interface AgentsListResponse {
+  items: AgentSpecialistSummary[]
+}
+
+export interface AgentSpecialistLinkedDoc {
+  document_id: string
+  title: string
+  description: string
+  anchor_id: string | null
+  href: string
+  reason: string | null
+}
+
+export interface AgentSpecialistInvocationSummary {
+  id: string
+  prompt: string
+  summary: string | null
+  session_id: string | null
+  repo: string | null
+  branch: string | null
+  documents_consulted_count: number
+  tokens_saved: number
+  created_at: string
+}
+
+export interface AgentSpecialistStats {
+  invocations_count: number
+  linked_docs_count: number
+  tokens_saved: number
+  usd_saved: string
+}
+
+export interface AgentSpecialistDetail {
+  id: string
+  slug: string
+  name: string
+  role: string
+  description: string
+  domain_tags: string[]
+  routing_triggers: string[]
+  negative_triggers: string[]
+  instructions: string[]
+  linked_knowledge: AgentSpecialistLinkedDoc[]
+  recent_invocations: AgentSpecialistInvocationSummary[]
+  stats: AgentSpecialistStats
+}
+
+export function listAgents(
+  options: { demo?: boolean } = {},
+): CancelablePromise<AgentsListResponse> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/agents",
+    query: {
+      demo: options.demo || undefined,
+    },
+  })
+}
+
+export function getAgent(
+  slug: string,
+  options: { demo?: boolean } = {},
+): CancelablePromise<AgentSpecialistDetail> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/agents/{slug}",
+    path: {
+      slug,
+    },
+    query: {
+      demo: options.demo || undefined,
+    },
+  })
+}

--- a/src/components/V2/Agents/AgentCard.tsx
+++ b/src/components/V2/Agents/AgentCard.tsx
@@ -1,0 +1,82 @@
+import { Link } from "@tanstack/react-router"
+import { ArrowRight, BookOpen, Clock3, Sparkles } from "lucide-react"
+
+import type { AgentSpecialistSummary } from "@/api/v2Agents"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { formatCompactNumber, formatRelativeTime } from "./formatters"
+
+type Props = {
+  agent: AgentSpecialistSummary
+}
+
+export function AgentCard({ agent }: Props) {
+  return (
+    <Card className="group relative overflow-hidden border-border/80 bg-background/95 transition-all hover:-translate-y-1 hover:border-primary/30 hover:shadow-xl">
+      <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-amber-400 via-emerald-400 to-sky-500 opacity-80" />
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="mb-3 flex size-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <Sparkles className="size-5" />
+            </div>
+            <CardTitle className="text-2xl">{agent.name}</CardTitle>
+            <p className="mt-1 text-sm font-medium text-muted-foreground">
+              {agent.role}
+            </p>
+          </div>
+          <Badge variant="outline">{agent.status}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-5">
+        <p className="min-h-12 text-sm leading-6 text-muted-foreground">
+          {agent.short_description}
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {agent.domain_tags.slice(0, 4).map((tag) => (
+            <Badge key={tag} variant="secondary" className="normal-case">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+        <div className="grid grid-cols-3 gap-2 rounded-2xl bg-muted/50 p-3 text-sm">
+          <div>
+            <div className="font-semibold tabular-nums">
+              {formatCompactNumber(agent.tokens_saved)}
+            </div>
+            <div className="text-xs text-muted-foreground">saved</div>
+          </div>
+          <div>
+            <div className="font-semibold tabular-nums">
+              {agent.invocations_count}
+            </div>
+            <div className="text-xs text-muted-foreground">runs</div>
+          </div>
+          <div>
+            <div className="font-semibold tabular-nums">
+              {agent.linked_docs_count}
+            </div>
+            <div className="text-xs text-muted-foreground">docs</div>
+          </div>
+        </div>
+        <div className="mt-auto flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            {agent.last_invoked_at ? (
+              <Clock3 className="size-3.5" />
+            ) : (
+              <BookOpen className="size-3.5" />
+            )}
+            <span>{formatRelativeTime(agent.last_invoked_at)}</span>
+          </div>
+          <Button asChild size="sm" variant="outline">
+            <Link to="/v2/agents/$slug" params={{ slug: agent.slug }}>
+              View specialist
+              <ArrowRight className="size-4" />
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/V2/Agents/AgentHero.tsx
+++ b/src/components/V2/Agents/AgentHero.tsx
@@ -1,0 +1,64 @@
+import { BadgeCheck, Sparkles } from "lucide-react"
+
+import type { AgentSpecialistDetail } from "@/api/v2Agents"
+import { Badge } from "@/components/ui/badge"
+import { formatCompactNumber } from "./formatters"
+
+type Props = {
+  agent: AgentSpecialistDetail
+}
+
+export function AgentHero({ agent }: Props) {
+  return (
+    <section className="relative overflow-hidden rounded-[2rem] border bg-[radial-gradient(circle_at_top_left,rgba(251,191,36,0.28),transparent_32%),linear-gradient(135deg,rgba(15,23,42,0.96),rgba(6,78,59,0.88))] p-8 text-white shadow-2xl">
+      <div className="absolute right-8 top-8 hidden size-28 rounded-full border border-white/15 bg-white/10 blur-sm md:block" />
+      <div className="relative max-w-4xl">
+        <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-sm text-white/80">
+          <Sparkles className="size-4" />
+          Taskforce specialist
+        </div>
+        <h1 className="text-4xl font-semibold tracking-tight md:text-6xl">
+          {agent.name}
+        </h1>
+        <p className="mt-3 text-lg font-medium text-emerald-100">
+          {agent.role}
+        </p>
+        <p className="mt-5 max-w-3xl text-base leading-7 text-white/78">
+          {agent.description}
+        </p>
+        <div className="mt-7 flex flex-wrap gap-2">
+          {agent.domain_tags.map((tag) => (
+            <Badge
+              key={tag}
+              className="border-white/20 bg-white/12 text-white hover:bg-white/18"
+              variant="outline"
+            >
+              {tag}
+            </Badge>
+          ))}
+        </div>
+        <div className="mt-8 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-2xl border border-white/15 bg-white/10 p-4">
+            <div className="text-2xl font-semibold tabular-nums">
+              {formatCompactNumber(agent.stats.tokens_saved)}
+            </div>
+            <div className="text-sm text-white/65">tokens saved</div>
+          </div>
+          <div className="rounded-2xl border border-white/15 bg-white/10 p-4">
+            <div className="text-2xl font-semibold tabular-nums">
+              {agent.stats.invocations_count}
+            </div>
+            <div className="text-sm text-white/65">invocations</div>
+          </div>
+          <div className="rounded-2xl border border-white/15 bg-white/10 p-4">
+            <div className="flex items-center gap-2 text-2xl font-semibold tabular-nums">
+              <BadgeCheck className="size-5 text-emerald-200" />
+              {agent.stats.linked_docs_count}
+            </div>
+            <div className="text-sm text-white/65">linked docs</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/V2/Agents/AgentInstructions.tsx
+++ b/src/components/V2/Agents/AgentInstructions.tsx
@@ -1,0 +1,23 @@
+import { CheckCircle2 } from "lucide-react"
+
+type Props = {
+  instructions: string[]
+}
+
+export function AgentInstructions({ instructions }: Props) {
+  return (
+    <section className="rounded-3xl border bg-background p-6 shadow-sm">
+      <h2 className="text-xl font-semibold">Operating instructions</h2>
+      <div className="mt-5 space-y-3">
+        {instructions.map((instruction) => (
+          <div key={instruction} className="flex gap-3">
+            <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-emerald-500" />
+            <p className="text-sm leading-6 text-muted-foreground">
+              {instruction}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/V2/Agents/AgentInvocations.tsx
+++ b/src/components/V2/Agents/AgentInvocations.tsx
@@ -1,0 +1,63 @@
+import { Link } from "@tanstack/react-router"
+import { BarChart3, GitBranch } from "lucide-react"
+
+import type { AgentSpecialistInvocationSummary } from "@/api/v2Agents"
+import { formatCompactNumber, formatRelativeTime } from "./formatters"
+
+type Props = {
+  invocations: AgentSpecialistInvocationSummary[]
+}
+
+export function AgentInvocations({ invocations }: Props) {
+  return (
+    <section className="rounded-3xl border bg-background p-6 shadow-sm">
+      <h2 className="text-xl font-semibold">Recent invocations</h2>
+      <div className="mt-5 overflow-hidden rounded-2xl border">
+        {invocations.map((invocation) => {
+          const row = (
+            <div
+              key={`${invocation.id}-row`}
+              className="grid gap-2 border-b p-4 last:border-b-0 hover:bg-muted/40 md:grid-cols-[1fr_auto]"
+            >
+              <div>
+                <p className="font-medium">{invocation.prompt}</p>
+                <div className="mt-2 flex flex-wrap gap-3 text-xs text-muted-foreground">
+                  <span>{formatRelativeTime(invocation.created_at)}</span>
+                  {invocation.branch && (
+                    <span className="inline-flex items-center gap-1">
+                      <GitBranch className="size-3" />
+                      {invocation.branch}
+                    </span>
+                  )}
+                  <span>{invocation.documents_consulted_count} docs</span>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 text-sm font-medium tabular-nums">
+                <BarChart3 className="size-4 text-primary" />
+                {formatCompactNumber(invocation.tokens_saved)} saved
+              </div>
+            </div>
+          )
+
+          return invocation.session_id ? (
+            <Link
+              key={invocation.id}
+              to="/v2/metrics"
+              search={{ session_id: invocation.session_id }}
+              className="block"
+            >
+              {row}
+            </Link>
+          ) : (
+            <div key={invocation.id}>{row}</div>
+          )
+        })}
+        {invocations.length === 0 && (
+          <p className="p-6 text-sm text-muted-foreground">
+            No invocation history yet.
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/V2/Agents/AgentLinkedKnowledge.tsx
+++ b/src/components/V2/Agents/AgentLinkedKnowledge.tsx
@@ -1,0 +1,49 @@
+import { ArrowUpRight, FileText } from "lucide-react"
+
+import type { AgentSpecialistLinkedDoc } from "@/api/v2Agents"
+
+type Props = {
+  documents: AgentSpecialistLinkedDoc[]
+}
+
+export function AgentLinkedKnowledge({ documents }: Props) {
+  return (
+    <section className="rounded-3xl border bg-background p-6 shadow-sm">
+      <h2 className="text-xl font-semibold">Linked knowledge</h2>
+      <div className="mt-5 grid gap-3">
+        {documents.map((document) => (
+          <a
+            key={`${document.document_id}-${document.anchor_id ?? "summary"}`}
+            href={document.href}
+            className="group rounded-2xl border bg-muted/30 p-4 transition hover:border-primary/40 hover:bg-muted/60"
+          >
+            <div className="flex items-start gap-3">
+              <div className="rounded-xl bg-background p-2 text-primary">
+                <FileText className="size-4" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="font-medium">{document.title}</h3>
+                  <ArrowUpRight className="size-4 shrink-0 text-muted-foreground transition group-hover:text-primary" />
+                </div>
+                <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                  {document.description}
+                </p>
+                {document.reason && (
+                  <p className="mt-2 text-xs font-medium text-primary">
+                    {document.reason}
+                  </p>
+                )}
+              </div>
+            </div>
+          </a>
+        ))}
+        {documents.length === 0 && (
+          <p className="rounded-2xl border border-dashed p-6 text-sm text-muted-foreground">
+            No linked knowledge yet.
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/V2/Agents/AgentStatsRail.tsx
+++ b/src/components/V2/Agents/AgentStatsRail.tsx
@@ -1,0 +1,29 @@
+import type { AgentSpecialistStats } from "@/api/v2Agents"
+import { formatCompactNumber, formatUsd } from "./formatters"
+
+type Props = {
+  stats: AgentSpecialistStats
+}
+
+export function AgentStatsRail({ stats }: Props) {
+  const rows = [
+    ["Tokens saved", formatCompactNumber(stats.tokens_saved)],
+    ["USD saved", formatUsd(stats.usd_saved)],
+    ["Invocations", stats.invocations_count.toLocaleString()],
+    ["Linked docs", stats.linked_docs_count.toLocaleString()],
+  ]
+
+  return (
+    <aside className="rounded-3xl border bg-background p-6 shadow-sm">
+      <h2 className="text-lg font-semibold">Specialist impact</h2>
+      <div className="mt-5 space-y-4">
+        {rows.map(([label, value]) => (
+          <div key={label} className="rounded-2xl bg-muted/40 p-4">
+            <div className="text-2xl font-semibold tabular-nums">{value}</div>
+            <div className="text-sm text-muted-foreground">{label}</div>
+          </div>
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/src/components/V2/Agents/RoutingSignals.tsx
+++ b/src/components/V2/Agents/RoutingSignals.tsx
@@ -1,0 +1,40 @@
+import { Badge } from "@/components/ui/badge"
+
+type Props = {
+  routingTriggers: string[]
+  negativeTriggers: string[]
+}
+
+export function RoutingSignals({ routingTriggers, negativeTriggers }: Props) {
+  return (
+    <section className="rounded-3xl border bg-background p-6 shadow-sm">
+      <h2 className="text-xl font-semibold">Routing signals</h2>
+      <div className="mt-5 grid gap-5 md:grid-cols-2">
+        <div>
+          <div className="text-sm font-medium text-muted-foreground">
+            Send here when the ask includes
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {routingTriggers.map((trigger) => (
+              <Badge key={trigger} className="normal-case">
+                {trigger}
+              </Badge>
+            ))}
+          </div>
+        </div>
+        <div>
+          <div className="text-sm font-medium text-muted-foreground">
+            Avoid routing for
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {negativeTriggers.map((trigger) => (
+              <Badge key={trigger} variant="outline" className="normal-case">
+                {trigger}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/V2/Agents/formatters.ts
+++ b/src/components/V2/Agents/formatters.ts
@@ -1,0 +1,33 @@
+export function formatCompactNumber(value: number) {
+  return new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value)
+}
+
+export function formatUsd(value: string | number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(Number(value) || 0)
+}
+
+export function formatRelativeTime(value: string | null) {
+  if (!value) return "Never used"
+
+  const diffMs = new Date(value).getTime() - Date.now()
+  const absMs = Math.abs(diffMs)
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ["day", 86_400_000],
+    ["hour", 3_600_000],
+    ["minute", 60_000],
+  ]
+  const formatter = new Intl.RelativeTimeFormat("en-US", { numeric: "auto" })
+  for (const [unit, ms] of units) {
+    if (absMs >= ms) {
+      return formatter.format(Math.round(diffMs / ms), unit)
+    }
+  }
+  return "Just now"
+}

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -8,7 +8,6 @@ import {
 import {
   BarChart3,
   BookOpenText,
-  Bot,
   ChevronDown,
   ChevronUp,
   Component,
@@ -17,6 +16,7 @@ import {
   Rocket,
   Search,
   Shield,
+  Sparkles,
 } from "lucide-react"
 import {
   Fragment,
@@ -63,14 +63,13 @@ type TaskforceNavItem = {
 const taskforceItems: TaskforceNavItem[] = [
   { icon: Search, title: "Search", path: "/v2/search" },
   { icon: BookOpenText, title: "Library", path: "/v2/library" },
-  { icon: Bot, title: "Agents", path: "/v2/agents" },
+  { icon: Sparkles, title: "Agents", path: "/v2/agents" },
   { icon: BarChart3, title: "Metrics", path: "/v2/metrics" },
   { icon: Rocket, title: "Upgrade", path: "/v2/pricing" },
 ]
 
 const TASKFORCE_DISCORD_URL = ""
-const EXTRAS_DRAWER_COLLAPSED_STORAGE_KEY =
-  "taskforce.sidebar.extras.collapsed"
+const EXTRAS_DRAWER_COLLAPSED_STORAGE_KEY = "taskforce.sidebar.extras.collapsed"
 
 function readStoredExtrasDrawerCollapsed() {
   if (typeof window === "undefined") return null
@@ -139,7 +138,8 @@ function TaskforceNav({ currentUser }: TaskforceShellProps) {
         const isActive =
           currentPath === item.path ||
           (item.path === "/v2/library" &&
-            currentPath.startsWith("/v2/library/"))
+            currentPath.startsWith("/v2/library/")) ||
+          (item.path === "/v2/agents" && currentPath.startsWith("/v2/agents/"))
 
         return (
           <SidebarMenuItem key={item.title}>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as LayoutCasesRouteImport } from './routes/_layout/cases'
 import { Route as LayoutAdminRouteImport } from './routes/_layout/admin'
 import { Route as V2MetricsMethodologyRouteImport } from './routes/v2/metrics.methodology'
 import { Route as V2LibraryDocumentIdRouteImport } from './routes/v2/library.$documentId'
+import { Route as V2AgentsSlugRouteImport } from './routes/v2/agents.$slug'
 
 const V2Route = V2RouteImport.update({
   id: '/v2',
@@ -153,6 +154,11 @@ const V2LibraryDocumentIdRoute = V2LibraryDocumentIdRouteImport.update({
   path: '/$documentId',
   getParentRoute: () => V2LibraryRoute,
 } as any)
+const V2AgentsSlugRoute = V2AgentsSlugRouteImport.update({
+  id: '/$slug',
+  path: '/$slug',
+  getParentRoute: () => V2AgentsRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -168,7 +174,7 @@ export interface FileRoutesByFullPath {
   '/skills': typeof LayoutSkillsRoute
   '/topics': typeof LayoutTopicsRoute
   '/v2/admin': typeof V2AdminRoute
-  '/v2/agents': typeof V2AgentsRoute
+  '/v2/agents': typeof V2AgentsRouteWithChildren
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
@@ -176,6 +182,7 @@ export interface FileRoutesByFullPath {
   '/v2/search': typeof V2SearchRoute
   '/v2/settings': typeof V2SettingsRoute
   '/v2/': typeof V2IndexRoute
+  '/v2/agents/$slug': typeof V2AgentsSlugRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
 }
@@ -192,7 +199,7 @@ export interface FileRoutesByTo {
   '/skills': typeof LayoutSkillsRoute
   '/topics': typeof LayoutTopicsRoute
   '/v2/admin': typeof V2AdminRoute
-  '/v2/agents': typeof V2AgentsRoute
+  '/v2/agents': typeof V2AgentsRouteWithChildren
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
@@ -200,6 +207,7 @@ export interface FileRoutesByTo {
   '/v2/search': typeof V2SearchRoute
   '/v2/settings': typeof V2SettingsRoute
   '/v2': typeof V2IndexRoute
+  '/v2/agents/$slug': typeof V2AgentsSlugRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
 }
@@ -219,7 +227,7 @@ export interface FileRoutesById {
   '/_layout/skills': typeof LayoutSkillsRoute
   '/_layout/topics': typeof LayoutTopicsRoute
   '/v2/admin': typeof V2AdminRoute
-  '/v2/agents': typeof V2AgentsRoute
+  '/v2/agents': typeof V2AgentsRouteWithChildren
   '/v2/home': typeof V2HomeRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
@@ -227,6 +235,7 @@ export interface FileRoutesById {
   '/v2/search': typeof V2SearchRoute
   '/v2/settings': typeof V2SettingsRoute
   '/v2/': typeof V2IndexRoute
+  '/v2/agents/$slug': typeof V2AgentsSlugRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
 }
@@ -254,6 +263,7 @@ export interface FileRouteTypes {
     | '/v2/search'
     | '/v2/settings'
     | '/v2/'
+    | '/v2/agents/$slug'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
   fileRoutesByTo: FileRoutesByTo
@@ -278,6 +288,7 @@ export interface FileRouteTypes {
     | '/v2/search'
     | '/v2/settings'
     | '/v2'
+    | '/v2/agents/$slug'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
   id:
@@ -304,6 +315,7 @@ export interface FileRouteTypes {
     | '/v2/search'
     | '/v2/settings'
     | '/v2/'
+    | '/v2/agents/$slug'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
   fileRoutesById: FileRoutesById
@@ -488,6 +500,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof V2LibraryDocumentIdRouteImport
       parentRoute: typeof V2LibraryRoute
     }
+    '/v2/agents/$slug': {
+      id: '/v2/agents/$slug'
+      path: '/$slug'
+      fullPath: '/v2/agents/$slug'
+      preLoaderRoute: typeof V2AgentsSlugRouteImport
+      parentRoute: typeof V2AgentsRoute
+    }
   }
 }
 
@@ -511,6 +530,18 @@ const LayoutRouteChildren: LayoutRouteChildren = {
 
 const LayoutRouteWithChildren =
   LayoutRoute._addFileChildren(LayoutRouteChildren)
+
+interface V2AgentsRouteChildren {
+  V2AgentsSlugRoute: typeof V2AgentsSlugRoute
+}
+
+const V2AgentsRouteChildren: V2AgentsRouteChildren = {
+  V2AgentsSlugRoute: V2AgentsSlugRoute,
+}
+
+const V2AgentsRouteWithChildren = V2AgentsRoute._addFileChildren(
+  V2AgentsRouteChildren,
+)
 
 interface V2LibraryRouteChildren {
   V2LibraryDocumentIdRoute: typeof V2LibraryDocumentIdRoute
@@ -538,7 +569,7 @@ const V2MetricsRouteWithChildren = V2MetricsRoute._addFileChildren(
 
 interface V2RouteChildren {
   V2AdminRoute: typeof V2AdminRoute
-  V2AgentsRoute: typeof V2AgentsRoute
+  V2AgentsRoute: typeof V2AgentsRouteWithChildren
   V2HomeRoute: typeof V2HomeRoute
   V2LibraryRoute: typeof V2LibraryRouteWithChildren
   V2MetricsRoute: typeof V2MetricsRouteWithChildren
@@ -550,7 +581,7 @@ interface V2RouteChildren {
 
 const V2RouteChildren: V2RouteChildren = {
   V2AdminRoute: V2AdminRoute,
-  V2AgentsRoute: V2AgentsRoute,
+  V2AgentsRoute: V2AgentsRouteWithChildren,
   V2HomeRoute: V2HomeRoute,
   V2LibraryRoute: V2LibraryRouteWithChildren,
   V2MetricsRoute: V2MetricsRouteWithChildren,

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -1,0 +1,87 @@
+import { useQuery } from "@tanstack/react-query"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { ArrowLeft } from "lucide-react"
+
+import { getAgent } from "@/api/v2Agents"
+import { useDemoMode } from "@/components/demo-mode-provider"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { AgentHero } from "@/components/V2/Agents/AgentHero"
+import { AgentInstructions } from "@/components/V2/Agents/AgentInstructions"
+import { AgentInvocations } from "@/components/V2/Agents/AgentInvocations"
+import { AgentLinkedKnowledge } from "@/components/V2/Agents/AgentLinkedKnowledge"
+import { AgentStatsRail } from "@/components/V2/Agents/AgentStatsRail"
+import { RoutingSignals } from "@/components/V2/Agents/RoutingSignals"
+
+export const Route = createFileRoute("/v2/agents/$slug")({
+  component: AgentDetailPage,
+  head: () => ({
+    meta: [
+      {
+        title: "Taskforce | Agent Specialist",
+      },
+    ],
+  }),
+})
+
+function AgentDetailPage() {
+  const { slug } = Route.useParams()
+  const { isDemoMode } = useDemoMode()
+  const agentQuery = useQuery({
+    queryKey: ["v2-agent", slug, isDemoMode],
+    queryFn: () => getAgent(slug, { demo: isDemoMode }),
+  })
+  const agent = agentQuery.data
+
+  if (agentQuery.isLoading) {
+    return (
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-5 py-8 md:px-8">
+        <Skeleton className="h-80 rounded-[2rem]" />
+        <div className="grid gap-6 lg:grid-cols-[1fr_18rem]">
+          <Skeleton className="h-96 rounded-3xl" />
+          <Skeleton className="h-96 rounded-3xl" />
+        </div>
+      </main>
+    )
+  }
+
+  if (!agent) {
+    return (
+      <main className="mx-auto w-full max-w-3xl px-5 py-16 text-center">
+        <h1 className="text-3xl font-semibold">Specialist not found</h1>
+        <p className="mt-3 text-muted-foreground">
+          This specialist is unavailable or you do not have access.
+        </p>
+        <Button asChild className="mt-6">
+          <Link to="/v2/agents">Back to agents</Link>
+        </Button>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_right,rgba(16,185,129,0.10),transparent_30rem)]">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-5 py-8 md:px-8">
+        <Button asChild variant="ghost" className="w-fit">
+          <Link to="/v2/agents">
+            <ArrowLeft className="size-4" />
+            Back to agents
+          </Link>
+        </Button>
+        <AgentHero agent={agent} />
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+          <div className="space-y-6">
+            <AgentInstructions instructions={agent.instructions} />
+            <RoutingSignals
+              routingTriggers={agent.routing_triggers}
+              negativeTriggers={agent.negative_triggers}
+            />
+            <AgentLinkedKnowledge documents={agent.linked_knowledge} />
+            <AgentInvocations invocations={agent.recent_invocations} />
+          </div>
+          <AgentStatsRail stats={agent.stats} />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -1,6 +1,10 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { createFileRoute, Outlet, useRouterState } from "@tanstack/react-router"
 
-import { TaskforcePlaceholder } from "@/components/V2/TaskforceShell"
+import { listAgents } from "@/api/v2Agents"
+import { useDemoMode } from "@/components/demo-mode-provider"
+import { Skeleton } from "@/components/ui/skeleton"
+import { AgentCard } from "@/components/V2/Agents/AgentCard"
 
 export const Route = createFileRoute("/v2/agents")({
   component: TaskforceAgents,
@@ -14,11 +18,64 @@ export const Route = createFileRoute("/v2/agents")({
 })
 
 function TaskforceAgents() {
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  })
+  return pathname === "/v2/agents" ? <AgentsIndex /> : <Outlet />
+}
+
+function AgentsIndex() {
+  const { isDemoMode } = useDemoMode()
+  const agentsQuery = useQuery({
+    queryKey: ["v2-agents", isDemoMode],
+    queryFn: () => listAgents({ demo: isDemoMode }),
+  })
+  const agents = agentsQuery.data?.items ?? []
+
   return (
-    <TaskforcePlaceholder
-      eyebrow="Taskforce"
-      title="Agents"
-      description="Agent workspace placeholder."
-    />
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(245,158,11,0.12),transparent_28rem),radial-gradient(circle_at_bottom_right,rgba(20,184,166,0.12),transparent_30rem)]">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-5 py-8 md:px-8">
+        <section className="overflow-hidden rounded-[2rem] border bg-background/85 p-8 shadow-sm backdrop-blur">
+          <div className="max-w-3xl">
+            <div className="text-sm font-semibold uppercase tracking-[0.24em] text-primary">
+              Taskforce command center
+            </div>
+            <h1 className="mt-4 text-4xl font-semibold tracking-tight md:text-6xl">
+              Reusable AI specialists
+            </h1>
+            <p className="mt-5 text-lg leading-8 text-muted-foreground">
+              Specialists package your best prior work into repeatable
+              expertise: routing triggers, operating instructions, linked
+              knowledge, and proof that reuse paid off.
+            </p>
+          </div>
+        </section>
+
+        {agentsQuery.isLoading ? (
+          <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <Skeleton key={index} className="h-80 rounded-xl" />
+            ))}
+          </div>
+        ) : agents.length > 0 ? (
+          <div
+            className="grid gap-5 md:grid-cols-2 xl:grid-cols-3"
+            data-testid="agents-grid"
+          >
+            {agents.map((agent) => (
+              <AgentCard key={agent.id} agent={agent} />
+            ))}
+          </div>
+        ) : (
+          <section className="rounded-[2rem] border border-dashed bg-background/80 p-10 text-center shadow-sm">
+            <h2 className="text-2xl font-semibold">No specialists yet</h2>
+            <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+              No specialists yet — Taskforce will create them as you accumulate
+              context.
+            </p>
+          </section>
+        )}
+      </div>
+    </main>
   )
 }

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -1,0 +1,192 @@
+import { expect, type Page, test } from "@playwright/test"
+
+import { mockV2Documents } from "./fixtures/v2-documents"
+
+const currentUser = {
+  id: "user-1",
+  email: "alex@example.com",
+  is_active: true,
+  is_superuser: false,
+  full_name: "Alex Lee",
+  created_at: "2026-03-24T00:00:00Z",
+  v2: true,
+  subscription_tier: "free",
+}
+
+const agents = [
+  {
+    id: "agent-1",
+    slug: "jensen",
+    name: "Jensen",
+    role: "Billing Reliability Specialist",
+    short_description:
+      "Stripe webhooks, subscriptions, and double-charge prevention.",
+    domain_tags: ["Stripe", "Billing", "Webhooks", "Reliability"],
+    status: "active",
+    linked_docs_count: 3,
+    invocations_count: 12,
+    tokens_saved: 42000,
+    last_invoked_at: "2026-05-24T12:00:00Z",
+  },
+  {
+    id: "agent-2",
+    slug: "mira",
+    name: "Mira",
+    role: "Search & Retrieval Specialist",
+    short_description:
+      "Indexer drift, pgvector retrieval, and citation anchors.",
+    domain_tags: ["Search", "Retrieval", "Citations"],
+    status: "active",
+    linked_docs_count: 2,
+    invocations_count: 4,
+    tokens_saved: 12000,
+    last_invoked_at: null,
+  },
+]
+
+const jensenDetail = {
+  id: "agent-1",
+  slug: "jensen",
+  name: "Jensen",
+  role: "Billing Reliability Specialist",
+  description:
+    "Helps debug Stripe billing, subscription upgrades, webhook retries, idempotency, duplicate invoices, and customer double-charge incidents.",
+  domain_tags: ["Stripe", "Billing", "Webhooks", "Reliability"],
+  routing_triggers: ["stripe", "webhook", "subscription", "plan upgrade"],
+  negative_triggers: ["pricing page copy", "frontend billing UI"],
+  instructions: [
+    "Check inbound webhook idempotency before changing fulfillment logic.",
+    "Prefer route-boundary WAL dedupe for Stripe retries.",
+  ],
+  linked_knowledge: [
+    {
+      document_id: "doc-1",
+      title: "Stripe webhook idempotency strategy",
+      description: "Decision record for route-boundary WAL dedupe.",
+      anchor_id: "decision-wal-table",
+      href: "/v2/library/doc-1#decision-wal-table",
+      reason: "Pinned decision record",
+    },
+  ],
+  recent_invocations: [
+    {
+      id: "event-1",
+      prompt: "Stripe is double-charging some users on plan upgrades.",
+      summary: "Fixed webhook replay ordering regression.",
+      session_id: "session-1",
+      repo: "taskforce-claude",
+      branch: "demo/stripe-double-charge",
+      documents_consulted_count: 2,
+      tokens_saved: 28432,
+      created_at: "2026-05-24T12:00:00Z",
+    },
+  ],
+  stats: {
+    invocations_count: 12,
+    linked_docs_count: 3,
+    tokens_saved: 42000,
+    usd_saved: "0.630000",
+  },
+}
+
+test.use({
+  storageState: {
+    cookies: [],
+    origins: [],
+  },
+})
+
+async function mockAgentsShell(page: Page, options: { empty?: boolean } = {}) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "test-token")
+  })
+
+  await page.route("**/api/v1/users/**", async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname === "/api/v1/users/me") {
+      await route.fulfill({ json: currentUser })
+      return
+    }
+    if (url.pathname === "/api/v1/users/") {
+      await route.fulfill({ json: { data: [currentUser], count: 1 } })
+      return
+    }
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+
+  await page.route("**/api/v1/organizations/invitations", async (route) => {
+    await route.fulfill({ json: { data: [], count: 0 } })
+  })
+
+  await page.route("**/api/v1/v2/agents**", async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname === "/api/v1/v2/agents") {
+      await route.fulfill({
+        json: { items: options.empty ? [] : agents },
+      })
+      return
+    }
+    if (url.pathname === "/api/v1/v2/agents/jensen") {
+      await route.fulfill({ json: jensenDetail })
+      return
+    }
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+
+  await page.route("**/api/v1/v2/metrics**", async (route) => {
+    await route.fulfill({ json: { metrics: {} } })
+  })
+
+  await mockV2Documents(page)
+}
+
+test("agents grid links to specialist detail and session metrics", async ({
+  page,
+}) => {
+  await mockAgentsShell(page)
+
+  await page.goto("/v2/agents")
+
+  await expect(page.getByText("Reusable AI specialists")).toBeVisible()
+  await expect(page.getByTestId("agents-grid")).toBeVisible()
+  await expect(page.getByText("Jensen")).toBeVisible()
+  await expect(page.getByText("Mira")).toBeVisible()
+
+  await page
+    .getByRole("link", { name: /view specialist/i })
+    .first()
+    .click()
+  await expect(page).toHaveURL(/\/v2\/agents\/jensen$/)
+  await expect(page.getByRole("heading", { name: "Jensen" })).toBeVisible()
+  await expect(page.getByText("Operating instructions")).toBeVisible()
+
+  const linkedKnowledge = page.getByRole("link", {
+    name: /Stripe webhook idempotency strategy/,
+  })
+  await expect(linkedKnowledge).toHaveAttribute(
+    "href",
+    "/v2/library/doc-1#decision-wal-table",
+  )
+
+  await page
+    .getByRole("link", {
+      name: /Stripe is double-charging some users on plan upgrades/,
+    })
+    .click()
+  await expect(page).toHaveURL(/\/v2\/metrics\?session_id=session-1$/)
+})
+
+test("agents grid shows empty state before specialists are seeded", async ({
+  page,
+}) => {
+  await mockAgentsShell(page, { empty: true })
+
+  await page.goto("/v2/agents")
+
+  await expect(
+    page.getByRole("heading", { name: "No specialists yet" }),
+  ).toBeVisible()
+  await expect(
+    page.getByText("Taskforce will create them as you accumulate context"),
+  ).toBeVisible()
+})


### PR DESCRIPTION
## Summary
- Replaces the `/v2/agents` placeholder with a specialist grid backed by `GET /v2/agents`.
- Adds `/v2/agents/{slug}` detail page with hero, operating instructions, routing signals, linked knowledge, invocation history, and stats rail.
- Adds typed `v2Agents` API client and focused V2 Agents components.
- Updates the sidebar icon to `Sparkles` and keeps Agents active on detail pages.
- Adds Playwright smoke coverage for populated and empty agents states, linked knowledge hrefs, and invocation click-through to `/v2/metrics?session_id=...`.

Jira: https://alexlee4190.atlassian.net/browse/TF-197

## Validation
- `npx biome check src/api/v2Agents.ts src/components/V2/Agents src/components/V2/TaskforceShell.tsx src/routes/v2/agents.tsx 'src/routes/v2/agents.$slug.tsx' src/routeTree.gen.ts tests/agents-routing.spec.ts`
- `npx tsc --noEmit`
- `env VITE_FIREBASE_API_KEY=AIzaSyDUMMYDUMMYDUMMYDUMMYDUMMYDUMMYDUM VITE_FIREBASE_AUTH_DOMAIN=example.firebaseapp.com VITE_FIREBASE_PROJECT_ID=demo-project VITE_FIREBASE_STORAGE_BUCKET=demo-project.appspot.com VITE_FIREBASE_MESSAGING_SENDER_ID=123456789 VITE_FIREBASE_APP_ID=1:123456789:web:abcdef npm run build`
- `npx vite preview --host 127.0.0.1 --port 5173` + `npx playwright test tests/agents-routing.spec.ts --project=chromium --no-deps`

## Notes
- Full `npx biome check src tests/agents-routing.spec.ts` is blocked by an existing `src/index.css` `!important` lint finding unrelated to this PR.
- Local Vite dev server cannot start under Node 18.19.1 because Vite 7 requires Node 20.19+ or 22.12+; production build completed despite the warning, and Playwright was run against `vite preview`.