### PR TITLE
Fix agents typography and remove mock header

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -115,6 +115,7 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    /* biome-ignore lint/complexity/noImportantStyles: design mockups require globally sharp corners over component utilities. */
     border-radius: 0 !important;
     -ms-overflow-style: none;
     scrollbar-width: none;
@@ -125,15 +126,28 @@
     height: 0;
     display: none;
   }
+  html,
+  body,
+  #root {
+    font-family: var(--font-sans);
+    font-feature-settings: "ss01", "cv11";
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-sans);
   }
   input,
   textarea,
   select,
   button {
     font-family: inherit;
+  }
+  code,
+  kbd,
+  samp,
+  pre {
+    font-family: var(--font-mono);
   }
   button,
   [role="button"] {

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -280,7 +280,7 @@ function AgentDetailPage() {
 
   if (agentQuery.isLoading) {
     return (
-      <main className="-m-6 min-h-0 flex-1 overflow-y-auto bg-white p-6 font-['Geist',sans-serif] md:-m-8 md:p-8 dark:bg-zinc-950">
+      <main className="-m-6 min-h-0 flex-1 overflow-y-auto bg-white p-6 font-sans md:-m-8 md:p-8 dark:bg-zinc-950">
         <div className="mx-auto w-full max-w-5xl">
           <Skeleton className="h-24 border bg-background" />
           <Skeleton className="mt-4 h-28 border bg-background" />
@@ -307,7 +307,7 @@ function AgentDetailPage() {
   }
 
   return (
-    <main className="-m-6 min-h-0 flex-1 overflow-y-auto bg-white font-['Geist',sans-serif] text-zinc-950 md:-m-8 dark:bg-zinc-950 dark:text-white">
+    <main className="-m-6 min-h-0 flex-1 overflow-y-auto bg-white font-sans text-zinc-950 md:-m-8 dark:bg-zinc-950 dark:text-white">
       <div className="mx-auto w-full max-w-5xl px-5 py-7 md:px-8">
         <header className="grid gap-4 border-b border-black/10 pb-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end dark:border-white/12">
           <div>

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -303,25 +303,7 @@ function TaskforceAgents() {
   const agents = agentsQuery.data?.items ?? []
 
   return (
-    <main className="-m-6 min-h-0 flex-1 overflow-y-auto bg-white font-['Geist',sans-serif] text-zinc-950 md:-m-8 dark:bg-zinc-950 dark:text-white">
-      <div className="border-b border-black/10 px-5 py-3 dark:border-white/10 md:px-8">
-        <div className="flex items-center justify-between gap-4">
-          <div className="inline-flex items-center gap-2 text-sm font-semibold">
-            <picture className="grid size-5 place-items-center overflow-hidden">
-              <source
-                srcSet="/assets/brand/tf-icon-filled-dark.svg"
-                media="(prefers-color-scheme: dark)"
-              />
-              <img src="/assets/brand/tf-icon-filled.svg" alt="" />
-            </picture>
-            Taskforce
-          </div>
-          <div className="hidden h-7 w-64 items-center border border-black/10 px-3 font-mono text-xs text-zinc-400 md:flex dark:border-white/12 dark:text-zinc-500">
-            / Search documents
-          </div>
-        </div>
-      </div>
-
+    <main className="-m-6 min-h-0 flex-1 overflow-y-auto bg-white font-sans text-zinc-950 md:-m-8 dark:bg-zinc-950 dark:text-white">
       <div className="mx-auto w-full max-w-7xl px-5 py-7 md:px-8">
         <header className="grid gap-5 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
           <div>


### PR DESCRIPTION
## Summary
- remove the mockup-only Taskforce/search bar from `/v2/agents`
- make the agents pages use the shared `font-sans` token instead of hardcoded arbitrary font classes
- apply the mockup typography settings globally: Geist body text, JetBrains Mono code/mono text, font feature settings, and smoothing

## Validation
- `npx biome check src/index.css src/routes/v2/agents.tsx 'src/routes/v2/agents.$slug.tsx'`\n- `npx tsc -p tsconfig.build.json --noEmit`\n- `npx vite build` (passes; repo still emits Node 18/Vite 7 version warning and large chunk warning)\n- `git diff --check`\n\n## Notes\n- Previous deep-link fix for `/v2/agents/jensen` is deployed and smoke-tested with HTTP 200.