### PR TITLE
Use light Taskforce logo in all themes

### DIFF
--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -106,11 +106,7 @@ function TaskforceMark() {
       to="/v2/library"
       className="flex min-w-0 items-center gap-3 px-1 text-sidebar-foreground group-data-[collapsible=icon]:px-0"
     >
-      <picture className="grid size-8 shrink-0 place-items-center overflow-hidden border border-sidebar-border bg-sidebar-accent group-data-[collapsible=icon]:size-7">
-        <source
-          srcSet="/assets/brand/tf-icon-filled-dark.svg"
-          media="(prefers-color-scheme: dark)"
-        />
+      <picture className="grid size-8 shrink-0 place-items-center overflow-hidden group-data-[collapsible=icon]:size-7">
         <img
           src="/assets/brand/tf-icon-filled.svg"
           alt=""

--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -44,10 +44,6 @@ function LandingMinimal() {
           className="inline-flex items-center gap-2 text-sm font-semibold"
         >
           <picture className="grid size-6 place-items-center overflow-hidden">
-            <source
-              srcSet="/assets/brand/tf-icon-filled-dark.svg"
-              media="(prefers-color-scheme: dark)"
-            />
             <img src="/assets/brand/tf-icon-filled.svg" alt="" />
           </picture>
           Taskforce


### PR DESCRIPTION
## Summary
- Remove the gray sidebar border/background around the Taskforce mark in the shell.
- Use the light `tf-icon-filled.svg` logo in both light and dark mode (shell and landing page).

## Test plan
- [ ] Open the app in light mode and confirm the sidebar logo has no gray border.
- [ ] Switch to dark mode and confirm the same light logo is shown (no dark variant swap).
- [ ] Check the landing page nav logo in both themes.


Made with [Cursor](https://cursor.com)