### PR TITLE
Fix light Taskforce icon orientation

### DIFF
--- a/public/assets/brand/tf-icon-filled.svg
+++ b/public/assets/brand/tf-icon-filled.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Taskforce">
-  <rect width="100" height="100" fill="#8447ff"></rect>
-  <polygon fill="#ffffff" points="0,0 100,0 70,30 30,30 30,70 0,100"></polygon>
-  <polygon fill="#ffffff" points="70,30 70,70 30,70"></polygon>
+  <rect width="100" height="100" fill="#ffffff"></rect>
+  <polygon fill="#8447ff" points="0,0 100,0 70,30 30,30 30,70 0,100"></polygon>
+  <polygon fill="#8447ff" points="70,30 70,70 30,70"></polygon>
 </svg>


### PR DESCRIPTION
## Summary
- Correct `tf-icon-filled.svg` so purple is in the top-left and white is in the bottom-right.
- Matches the orientation used by the favicon and `tf-icon-filled-dark.svg`.

## Test plan
- [ ] Confirm sidebar logo matches favicon orientation in light mode.
- [ ] Confirm sidebar logo matches favicon orientation in dark mode.
- [ ] Check landing page nav logo.


Made with [Cursor](https://cursor.com)