### PR TITLE
TF-199: Enable demo-mode Library mutations

### DIFF
--- a/src/api/v2Documents.ts
+++ b/src/api/v2Documents.ts
@@ -152,10 +152,14 @@ export function readV2DocumentFolders(
 
 export function createV2DocumentFolder(
   body: V2DocumentFolderCreate,
+  options: { demo?: boolean } = {},
 ): CancelablePromise<V2DocumentFolderPublic> {
   return request(OpenAPI, {
     method: "POST",
     url: "/api/v1/v2/documents/folders/",
+    query: {
+      demo: options.demo || undefined,
+    },
     body,
   })
 }
@@ -163,6 +167,7 @@ export function createV2DocumentFolder(
 export function updateV2DocumentFolder(
   folderId: string,
   body: V2DocumentFolderUpdate,
+  options: { demo?: boolean } = {},
 ): CancelablePromise<V2DocumentFolderPublic> {
   return request(OpenAPI, {
     method: "PATCH",
@@ -170,18 +175,25 @@ export function updateV2DocumentFolder(
     path: {
       folder_id: folderId,
     },
+    query: {
+      demo: options.demo || undefined,
+    },
     body,
   })
 }
 
 export function deleteV2DocumentFolder(
   folderId: string,
+  options: { demo?: boolean } = {},
 ): CancelablePromise<void> {
   return request(OpenAPI, {
     method: "DELETE",
     url: "/api/v1/v2/documents/folders/{folder_id}",
     path: {
       folder_id: folderId,
+    },
+    query: {
+      demo: options.demo || undefined,
     },
   })
 }

--- a/src/components/V2/Library/FolderControls.tsx
+++ b/src/components/V2/Library/FolderControls.tsx
@@ -103,11 +103,14 @@ export function FolderCreateDialog({
 
   const createMutation = useMutation({
     mutationFn: () =>
-      createV2DocumentFolder({
-        name: name.trim(),
-        visibility,
-        parent_folder_id: parentFolderId,
-      }),
+      createV2DocumentFolder(
+        {
+          name: name.trim(),
+          visibility,
+          parent_folder_id: parentFolderId,
+        },
+        { demo },
+      ),
     onSuccess: (folder) => {
       setName("")
       setVisibility("private")
@@ -137,7 +140,7 @@ export function FolderCreateDialog({
           className="space-y-4"
           onSubmit={(event) => {
             event.preventDefault()
-            if (!name.trim() || demo) return
+            if (!name.trim()) return
             createMutation.mutate()
           }}
         >
@@ -168,7 +171,9 @@ export function FolderCreateDialog({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="private">Private</SelectItem>
-                <SelectItem value="organization">Organization</SelectItem>
+                {!demo && (
+                  <SelectItem value="organization">Organization</SelectItem>
+                )}
               </SelectContent>
             </Select>
           </div>
@@ -209,7 +214,7 @@ export function FolderCreateDialog({
             </Button>
             <Button
               type="submit"
-              disabled={!name.trim() || demo || createMutation.isPending}
+              disabled={!name.trim() || createMutation.isPending}
             >
               <FolderPlus className="size-4" />
               {createMutation.isPending ? "Creating" : "Create"}
@@ -252,9 +257,13 @@ export function FolderActionsMenu({
 
   const renameMutation = useMutation({
     mutationFn: () =>
-      updateV2DocumentFolder(folder.id, {
-        name: name.trim(),
-      }),
+      updateV2DocumentFolder(
+        folder.id,
+        {
+          name: name.trim(),
+        },
+        { demo },
+      ),
     onSuccess: () => {
       invalidateLibraryQueries()
       setRenameOpen(false)
@@ -266,7 +275,7 @@ export function FolderActionsMenu({
   })
 
   const deleteMutation = useMutation({
-    mutationFn: () => deleteV2DocumentFolder(folder.id),
+    mutationFn: () => deleteV2DocumentFolder(folder.id, { demo }),
     onSuccess: () => {
       invalidateLibraryQueries()
       setDeleteOpen(false)
@@ -286,7 +295,6 @@ export function FolderActionsMenu({
             type="button"
             variant="ghost"
             size="icon-sm"
-            disabled={demo}
             aria-label={`Open options for ${folder.name}`}
             className="cursor-pointer"
             onClick={(event) => event.stopPropagation()}
@@ -352,7 +360,7 @@ export function FolderActionsMenu({
             className="space-y-4"
             onSubmit={(event) => {
               event.preventDefault()
-              if (!name.trim() || demo) return
+              if (!name.trim()) return
               renameMutation.mutate()
             }}
           >
@@ -384,7 +392,6 @@ export function FolderActionsMenu({
                 disabled={
                   !name.trim() ||
                   name.trim() === folder.name ||
-                  demo ||
                   renameMutation.isPending
                 }
               >
@@ -416,7 +423,7 @@ export function FolderActionsMenu({
             <Button
               type="button"
               variant="destructive"
-              disabled={demo || deleteMutation.isPending}
+              disabled={deleteMutation.isPending}
               onClick={() => deleteMutation.mutate()}
             >
               {deleteMutation.isPending ? "Deleting" : "Delete folder"}

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -510,7 +510,12 @@ function TaskforceDocumentDetail() {
   const document = documentQuery.data
   const isOwner = Boolean(document && user?.id === document.owner_id)
   const canEditDocument = Boolean(document && document.user_access !== "viewer")
-  const canManageDocument = isOwner && !isDemoMode
+  const canManageDocument = isOwner
+  // Sharing demo docs to a real org would leak demo content into another
+  // user's live view, so keep the access/share affordance hidden when
+  // demo mode is on. Rename / move / dates / favorite / delete are safe
+  // because they only mutate the current user's own demo-scoped rows.
+  const canShareDocument = canManageDocument && !isDemoMode
 
   const foldersQuery = useQuery({
     queryKey: ["v2-document-folders", { demo: isDemoMode }],
@@ -588,7 +593,7 @@ function TaskforceDocumentDetail() {
   })
 
   const toggleFavorite = () => {
-    if (!document || isDemoMode || favoriteMutation.isPending) return
+    if (!document || favoriteMutation.isPending) return
     favoriteMutation.mutate(!document.is_favorite)
   }
 
@@ -976,7 +981,8 @@ function TaskforceDocumentDetail() {
           document={document}
           folders={foldersQuery.data?.data ?? []}
           canManageLibrary={canManageDocument}
-          canFavorite={!isDemoMode}
+          canShare={canShareDocument}
+          canFavorite={true}
           organizationMembers={organizationQuery.data?.members ?? []}
           shares={sharesQuery.data?.data ?? document.shared_with ?? []}
           ownerId={document.owner_id}
@@ -1055,6 +1061,7 @@ function DocumentMetadata({
   document,
   folders,
   canManageLibrary,
+  canShare,
   canFavorite,
   organizationMembers,
   shares,
@@ -1077,6 +1084,7 @@ function DocumentMetadata({
   document: V2DocumentPublic
   folders: V2DocumentFolderPublic[]
   canManageLibrary: boolean
+  canShare: boolean
   canFavorite: boolean
   organizationMembers: OrganizationMemberPublic[]
   shares: V2DocumentSharePublic[]
@@ -1131,7 +1139,7 @@ function DocumentMetadata({
         </span>
       )}
 
-      {canManageLibrary ? (
+      {canShare ? (
         <DocumentAccessDropdown
           open={accessOpen}
           onOpenChange={onAccessOpenChange}

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -304,7 +304,11 @@ function TaskforceLibrary() {
       folderId: string
       parentFolderId: string | null
     }) =>
-      updateV2DocumentFolder(folderId, { parent_folder_id: parentFolderId }),
+      updateV2DocumentFolder(
+        folderId,
+        { parent_folder_id: parentFolderId },
+        { demo: isDemoMode },
+      ),
     onMutate: async ({ folderId, parentFolderId }) => {
       await queryClient.cancelQueries({ queryKey: foldersQueryKey })
       const previousFolders =
@@ -514,7 +518,6 @@ function TaskforceLibrary() {
   const isFolderEmpty =
     !isLoading && documents.length > 0 && visibleDocuments.length === 0
   const canMutateLibrary =
-    !isDemoMode &&
     !moveDocumentMutation.isPending &&
     !moveFolderMutation.isPending &&
     !favoriteMutation.isPending
@@ -544,12 +547,7 @@ function TaskforceLibrary() {
   }
 
   const moveDocument = (documentId: string, folderId: string | null) => {
-    if (
-      isDemoMode ||
-      moveDocumentMutation.isPending ||
-      moveFolderMutation.isPending
-    )
-      return
+    if (moveDocumentMutation.isPending || moveFolderMutation.isPending) return
     const document = allDocuments.find((item) => item.id === documentId)
     if (!document || (document.folder_id ?? null) === folderId) {
       setDragOverFolderId(null)
@@ -559,12 +557,7 @@ function TaskforceLibrary() {
   }
 
   const moveFolder = (folderId: string, parentFolderId: string | null) => {
-    if (
-      isDemoMode ||
-      moveDocumentMutation.isPending ||
-      moveFolderMutation.isPending
-    )
-      return
+    if (moveDocumentMutation.isPending || moveFolderMutation.isPending) return
     const folder = folders.find((item) => item.id === folderId)
     if (
       !folder ||
@@ -582,7 +575,6 @@ function TaskforceLibrary() {
     event: DragEvent<HTMLElement>,
     folderId: DirectoryDropTargetId,
   ) => {
-    if (isDemoMode) return
     event.preventDefault()
     event.dataTransfer.dropEffect = "move"
     setDragOverFolderId(folderId)
@@ -627,7 +619,7 @@ function TaskforceLibrary() {
   }
 
   const toggleFavorite = (document: V2DocumentPublic) => {
-    if (isDemoMode || favoriteMutation.isPending) return
+    if (favoriteMutation.isPending) return
     favoriteMutation.mutate({
       documentId: document.id,
       favorite: !document.is_favorite,
@@ -635,7 +627,7 @@ function TaskforceLibrary() {
   }
 
   const requestDeleteDocument = (document: V2DocumentPublic) => {
-    if (isDemoMode || deleteDocumentMutation.isPending) return
+    if (deleteDocumentMutation.isPending) return
     setDeleteDocumentTarget(document)
   }
 
@@ -649,9 +641,7 @@ function TaskforceLibrary() {
     <DocumentDeleteContext.Provider
       value={{
         canDelete:
-          !isDemoMode &&
-          !deleteDocumentMutation.isPending &&
-          !moveDocumentMutation.isPending,
+          !deleteDocumentMutation.isPending && !moveDocumentMutation.isPending,
         onDelete: requestDeleteDocument,
       }}
     >
@@ -697,29 +687,25 @@ function TaskforceLibrary() {
                 onClick={() => setLibraryView("folders")}
               />
             </div>
-            {!isDemoMode && (
-              <>
-                <Button
-                  type="button"
-                  size="sm"
-                  className="w-fit"
-                  onClick={() => setCreateDocumentOpen(true)}
-                >
-                  <Plus className="size-4" />
-                  New document
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="w-fit"
-                  onClick={() => setCreateFolderOpen(true)}
-                >
-                  <FolderPlus className="size-4" />
-                  Create folder
-                </Button>
-              </>
-            )}
+            <Button
+              type="button"
+              size="sm"
+              className="w-fit"
+              onClick={() => setCreateDocumentOpen(true)}
+            >
+              <Plus className="size-4" />
+              New document
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="w-fit"
+              onClick={() => setCreateFolderOpen(true)}
+            >
+              <FolderPlus className="size-4" />
+              Create folder
+            </Button>
           </div>
         </div>
 
@@ -785,7 +771,7 @@ function TaskforceLibrary() {
               {!isFolderEmpty && (
                 <InfiniteDocumentGrid
                   documents={visibleDocuments}
-                  canFavorite={!isDemoMode && !favoriteMutation.isPending}
+                  canFavorite={!favoriteMutation.isPending}
                   onToggleFavorite={toggleFavorite}
                 />
               )}
@@ -803,7 +789,7 @@ function TaskforceLibrary() {
                 openFolderIds={openFolderIds}
                 dragOverFolderId={dragOverFolderId}
                 canMoveItems={canMutateLibrary}
-                canFavorite={!isDemoMode && !favoriteMutation.isPending}
+                canFavorite={!favoriteMutation.isPending}
                 currentUserId={currentUser.id}
                 demo={isDemoMode}
                 onToggleFolder={toggleFolderOpen}
@@ -1649,8 +1635,7 @@ function DocumentActionsMenu({
   const [renameValue, setRenameValue] = useState(document.title)
 
   const canRename =
-    !document.is_demo &&
-    (document.user_access === "owner" || document.user_access === "editor")
+    document.user_access === "owner" || document.user_access === "editor"
 
   const renameMutation = useMutation({
     mutationFn: (title: string) =>


### PR DESCRIPTION
## Summary

Library mutations (create document, create folder, rename, move, favorite, delete) were all hard-gated by `isDemoMode` in the frontend. With the backend now supporting demo-scoped folders (paired backend PR https://github.com/al-exe/EnderAI/pull/92), demo users can have a fully interactive Library without any risk of leaking demo content into live views.

## Changes

- `v2Documents.ts`: `createV2DocumentFolder`, `updateV2DocumentFolder`, `deleteV2DocumentFolder` accept `{ demo }`.
- `FolderControls.tsx`: pass `demo` to all three folder mutations, remove `disabled={demo}` gates on create/rename/delete buttons and submit handlers, hide `visibility=organization` in demo (backend rejects it with 422).
- `library.tsx`: remove `!isDemoMode` gates on the **New document** / **Create folder** header buttons, on `toggleFavorite` / `requestDelete` / `moveDocument` / `moveFolder` / `handleFolderDragOver`, on `canMutateLibrary`, `canFavorite`, `DocumentDeleteContext.canDelete`, and the per-document `canRename` check. Pass `demo` to the folder move mutation.
- `library.\$documentId.tsx`: `canManageDocument` no longer requires `!isDemoMode`; rename / move / dates / favorite all work for demo docs. A new `canShareDocument` flag keeps the Access dropdown hidden in demo mode because sharing demo docs to a real org would expose them in another user's live view (and the `/shares/` endpoint isn't demo-aware on the backend).

## Backend pairing

Requires PR https://github.com/al-exe/EnderAI/pull/92 (merged). Without it, creating a folder in demo mode would persist \`is_demo=false\` and the folder would silently appear in the user's live view.

## Test plan

- [ ] Vercel preview deploy succeeds.
- [ ] With Demo mode ON on the recording account:
  - [ ] **New document** button visible → creates a doc, appears in Unfiled, opens to editor.
  - [ ] **Create folder** button visible → creates a folder under \"All documents\" → \"Favorites\" → seeded folders. New folder is scoped to demo only.
  - [ ] Star icon toggles a demo doc as favorite, appears under Favorites.
  - [ ] Drag a demo doc from Unfiled into the new folder → moves.
  - [ ] Folder action menu (\`\\\`MoreHorizontal\`\\\`) shows Create sub-folder / Rename / Delete and all three work.
  - [ ] Document detail page: rename works, move-folder works, dates editable, Access dropdown is hidden.
- [ ] With Demo mode OFF, live folders still load and live mutations still work.

## Jira

TF-199 (frontend half).

Made with [Cursor](https://cursor.com)