### PR TITLE
Add superuser experimental mode gating

### DIFF
--- a/src/components/Home/HomePage.tsx
+++ b/src/components/Home/HomePage.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react"
 
 import type { UserPublic } from "@/client"
+import { useExperimentalMode } from "@/components/experimental-mode-provider"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -36,6 +37,7 @@ type HomePageProps = {
 
 export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
   const isPublic = mode === "public"
+  const { isExperimentalMode } = useExperimentalMode()
   const canUseApp = !isPublic || signedIn
   const firstName = user?.full_name?.trim().split(/\s+/)[0]
   const displayName = firstName || user?.email || "there"
@@ -70,14 +72,24 @@ export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
                 {isPublic ? (
                   <>
                     <Button asChild size="lg" className={styles.primaryCta}>
-                      <RouterLink to={signedIn ? "/v2/library" : "/signup"}>
+                      <RouterLink
+                        to={
+                          signedIn && isExperimentalMode
+                            ? "/v2/library"
+                            : signedIn
+                              ? "/home"
+                              : "/signup"
+                        }
+                      >
                         <Sparkles className={styles.icon} />
                         Try the demo
                       </RouterLink>
                     </Button>
                     <Button asChild variant="outline" size="lg">
                       {signedIn ? (
-                        <RouterLink to="/v2/library">
+                        <RouterLink
+                          to={isExperimentalMode ? "/v2/library" : "/home"}
+                        >
                           <LogIn className={styles.icon} />
                           Open Home
                         </RouterLink>
@@ -98,13 +110,23 @@ export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
                       </RouterLink>
                     </Button>
                     <Button asChild size="lg">
-                      <RouterLink
-                        to="/v2/settings"
-                        search={{ tab: "connect-agent" }}
-                        data-testid="home-connect-agent-link"
-                      >
-                        Connect agent
-                      </RouterLink>
+                      {isExperimentalMode ? (
+                        <RouterLink
+                          to="/v2/settings"
+                          search={{ tab: "connect-agent" }}
+                          data-testid="home-connect-agent-link"
+                        >
+                          Connect agent
+                        </RouterLink>
+                      ) : (
+                        <RouterLink
+                          to="/settings"
+                          search={{ tab: "connect-agent" }}
+                          data-testid="home-connect-agent-link"
+                        >
+                          Connect agent
+                        </RouterLink>
+                      )}
                     </Button>
                   </>
                 )}

--- a/src/components/Sidebar/AppSidebar.tsx
+++ b/src/components/Sidebar/AppSidebar.tsx
@@ -1,5 +1,6 @@
 import { Box, Boxes, Home, Sparkles, Users } from "lucide-react"
 
+import type { UserPublic } from "@/client"
 import { Logo } from "@/components/Common/Logo"
 import {
   Sidebar,
@@ -7,9 +8,8 @@ import {
   SidebarFooter,
   SidebarHeader,
 } from "@/components/ui/sidebar"
-import useAuth from "@/hooks/useAuth"
 import { type Item, Main } from "./Main"
-import { DemoModeToggle } from "./ModeSwitches"
+import { DemoModeToggle, ExperimentalModeToggle } from "./ModeSwitches"
 import { User } from "./User"
 
 const baseItems: Item[] = [
@@ -19,9 +19,11 @@ const baseItems: Item[] = [
   { icon: Sparkles, title: "Skills", path: "/skills" },
 ]
 
-export function AppSidebar() {
-  const { user: currentUser } = useAuth()
+type AppSidebarProps = {
+  currentUser: UserPublic | null
+}
 
+export function AppSidebar({ currentUser }: AppSidebarProps) {
   const items = currentUser?.is_superuser
     ? [...baseItems, { icon: Users, title: "Admin", path: "/admin" }]
     : baseItems
@@ -35,7 +37,12 @@ export function AppSidebar() {
         <Main items={items} />
       </SidebarContent>
       <SidebarFooter className="gap-1">
-        <DemoModeToggle />
+        {currentUser?.is_superuser && (
+          <>
+            <ExperimentalModeToggle />
+            <DemoModeToggle />
+          </>
+        )}
         <User user={currentUser} />
       </SidebarFooter>
     </Sidebar>

--- a/src/components/Sidebar/ModeSwitches.tsx
+++ b/src/components/Sidebar/ModeSwitches.tsx
@@ -1,48 +1,114 @@
-import { FlaskConical } from "lucide-react"
+import { useNavigate, useRouterState } from "@tanstack/react-router"
+import { FlaskConical, type LucideIcon, Rocket } from "lucide-react"
 
 import { useDemoMode } from "@/components/demo-mode-provider"
+import { useExperimentalMode } from "@/components/experimental-mode-provider"
 import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar"
+import {
+  getCurrentFrontendPath,
+  getExperimentalFrontendPath,
+} from "@/lib/experimentalMode"
 import { cn } from "@/lib/utils"
 
-export function DemoModeToggle() {
-  const { isDemoMode, toggleDemoMode } = useDemoMode()
+type ModeToggleProps = {
+  icon: LucideIcon
+  isActive: boolean
+  label: string
+  testId: string
+  tooltip: string
+  onClick: () => void
+}
 
+function ModeToggle({
+  icon: Icon,
+  isActive,
+  label,
+  testId,
+  tooltip,
+  onClick,
+}: ModeToggleProps) {
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
-        tooltip={isDemoMode ? "Disable demo mode" : "Enable demo mode"}
-        data-testid="demo-mode-toggle"
+        tooltip={tooltip}
+        data-testid={testId}
         role="switch"
-        aria-checked={isDemoMode}
-        isActive={isDemoMode}
+        aria-checked={isActive}
+        isActive={isActive}
         className="data-[active=true]:bg-sidebar-accent/80 data-[active=true]:text-sidebar-accent-foreground"
-        onClick={toggleDemoMode}
+        onClick={onClick}
       >
-        <FlaskConical
+        <Icon
           className={cn(
             "size-[18px] text-muted-foreground transition-colors",
-            isDemoMode && "text-sidebar-primary",
+            isActive && "text-sidebar-primary",
           )}
         />
-        <span>Demo mode</span>
+        <span>{label}</span>
         <div
           aria-hidden="true"
-          data-testid="demo-mode-toggle-track"
+          data-testid={`${testId}-track`}
           className={cn(
             "ml-auto hidden h-7 w-12 items-center rounded-full border border-sidebar-border/70 bg-muted/70 p-1 shadow-inner transition-colors group-data-[collapsible=icon]:hidden md:flex",
-            isDemoMode && "border-sidebar-primary/40 bg-sidebar-primary",
+            isActive && "border-sidebar-primary/40 bg-sidebar-primary",
           )}
         >
           <div
-            data-testid="demo-mode-toggle-thumb"
+            data-testid={`${testId}-thumb`}
             className={cn(
               "size-5 rounded-full bg-background shadow-sm ring-1 ring-black/5 transition-transform",
-              isDemoMode &&
+              isActive &&
                 "translate-x-5 bg-sidebar-primary-foreground ring-white/20",
             )}
           />
         </div>
       </SidebarMenuButton>
     </SidebarMenuItem>
+  )
+}
+
+export function ExperimentalModeToggle() {
+  const navigate = useNavigate()
+  const router = useRouterState()
+  const { isExperimentalMode, setExperimentalMode } = useExperimentalMode()
+
+  const handleClick = () => {
+    const nextEnabled = !isExperimentalMode
+    const nextPath = nextEnabled
+      ? getExperimentalFrontendPath(router.location.pathname)
+      : getCurrentFrontendPath(router.location.pathname)
+
+    setExperimentalMode(nextEnabled)
+    void navigate({ to: nextPath as never })
+  }
+
+  return (
+    <ModeToggle
+      icon={Rocket}
+      isActive={isExperimentalMode}
+      label="Experimental mode"
+      testId="experimental-mode-toggle"
+      tooltip={
+        isExperimentalMode
+          ? "Disable experimental mode"
+          : "Enable experimental mode"
+      }
+      onClick={handleClick}
+    />
+  )
+}
+
+export function DemoModeToggle() {
+  const { isDemoMode, toggleDemoMode } = useDemoMode()
+
+  return (
+    <ModeToggle
+      icon={FlaskConical}
+      isActive={isDemoMode}
+      label="Demo mode"
+      testId="demo-mode-toggle"
+      tooltip={isDemoMode ? "Disable demo mode" : "Enable demo mode"}
+      onClick={toggleDemoMode}
+    />
   )
 }

--- a/src/components/Sidebar/User.tsx
+++ b/src/components/Sidebar/User.tsx
@@ -4,6 +4,7 @@ import { ChevronsUpDown, LogOut, Settings } from "lucide-react"
 
 import { readMyOrganizationInvitations } from "@/api/organizations"
 import { PendingInvitationBadge } from "@/components/Common/PendingInvitationBadge"
+import { useExperimentalMode } from "@/components/experimental-mode-provider"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import {
   DropdownMenu,
@@ -56,6 +57,7 @@ function UserInfo({
 
 export function User({ user }: { user: any }) {
   const { logout } = useAuth()
+  const { isExperimentalMode } = useExperimentalMode()
   const { isMobile, setOpenMobile } = useSidebar()
   const invitationsQuery = useQuery({
     queryKey: ["my-organization-invitations"],
@@ -110,7 +112,10 @@ export function User({ user }: { user: any }) {
               />
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <RouterLink to="/v2/settings" onClick={handleMenuClick}>
+            <RouterLink
+              to={isExperimentalMode ? "/v2/settings" : "/settings"}
+              onClick={handleMenuClick}
+            >
               <DropdownMenuItem>
                 <Settings />
                 <span>User Settings</span>

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -30,7 +30,10 @@ import {
 import { readV2Documents, type V2DocumentPublic } from "@/api/v2Documents"
 import type { UserPublic } from "@/client"
 import { useDemoMode } from "@/components/demo-mode-provider"
-import { DemoModeToggle } from "@/components/Sidebar/ModeSwitches"
+import {
+  DemoModeToggle,
+  ExperimentalModeToggle,
+} from "@/components/Sidebar/ModeSwitches"
 import { User } from "@/components/Sidebar/User"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -199,7 +202,11 @@ function DiscordButton() {
   )
 }
 
-function SidebarUtilityDrawer() {
+function SidebarUtilityDrawer({
+  showInternalModes,
+}: {
+  showInternalModes: boolean
+}) {
   const [isCollapsed, setIsCollapsed] = useState(
     () => readStoredExtrasDrawerCollapsed() ?? false,
   )
@@ -268,7 +275,12 @@ function SidebarUtilityDrawer() {
       {!isCollapsed && (
         <SidebarMenu className="mt-1">
           <DiscordButton />
-          <DemoModeToggle />
+          {showInternalModes && (
+            <>
+              <ExperimentalModeToggle />
+              <DemoModeToggle />
+            </>
+          )}
         </SidebarMenu>
       )}
     </div>
@@ -580,7 +592,9 @@ export function TaskforceShell({ currentUser }: TaskforceShellProps) {
           <TaskforceNav currentUser={currentUser} />
         </SidebarContent>
         <SidebarFooter className="gap-1">
-          <SidebarUtilityDrawer />
+          <SidebarUtilityDrawer
+            showInternalModes={Boolean(currentUser.is_superuser)}
+          />
           <User user={currentUser} />
         </SidebarFooter>
       </Sidebar>

--- a/src/components/experimental-mode-provider.tsx
+++ b/src/components/experimental-mode-provider.tsx
@@ -1,0 +1,84 @@
+import {
+  createContext,
+  startTransition,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react"
+
+import {
+  EXPERIMENTAL_MODE_STORAGE_KEY,
+  readExperimentalModePreference,
+  writeExperimentalModePreference,
+} from "@/lib/experimentalMode"
+
+type ExperimentalModeProviderProps = {
+  children: React.ReactNode
+  storageKey?: string
+}
+
+type ExperimentalModeProviderState = {
+  isExperimentalMode: boolean
+  setExperimentalMode: (enabled: boolean) => void
+  toggleExperimentalMode: () => void
+}
+
+const initialState: ExperimentalModeProviderState = {
+  isExperimentalMode: false,
+  setExperimentalMode: () => null,
+  toggleExperimentalMode: () => null,
+}
+
+const ExperimentalModeProviderContext =
+  createContext<ExperimentalModeProviderState>(initialState)
+
+export function ExperimentalModeProvider({
+  children,
+  storageKey = EXPERIMENTAL_MODE_STORAGE_KEY,
+}: ExperimentalModeProviderProps) {
+  const [isExperimentalMode, setIsExperimentalMode] = useState<boolean>(() =>
+    readExperimentalModePreference(storageKey),
+  )
+
+  const setExperimentalMode = useCallback(
+    (enabled: boolean) => {
+      writeExperimentalModePreference(enabled, storageKey)
+      startTransition(() => {
+        setIsExperimentalMode(enabled)
+      })
+    },
+    [storageKey],
+  )
+
+  const toggleExperimentalMode = useCallback(() => {
+    setExperimentalMode(!isExperimentalMode)
+  }, [isExperimentalMode, setExperimentalMode])
+
+  const value = useMemo(
+    () => ({
+      isExperimentalMode,
+      setExperimentalMode,
+      toggleExperimentalMode,
+    }),
+    [isExperimentalMode, setExperimentalMode, toggleExperimentalMode],
+  )
+
+  return (
+    <ExperimentalModeProviderContext.Provider value={value}>
+      {children}
+    </ExperimentalModeProviderContext.Provider>
+  )
+}
+
+export const useExperimentalMode = () => {
+  const context = useContext(ExperimentalModeProviderContext)
+
+  if (context === undefined) {
+    throw new Error(
+      "useExperimentalMode must be used within an ExperimentalModeProvider",
+    )
+  }
+
+  return context
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -16,6 +16,7 @@ import {
   type UserRegister,
   UsersService,
 } from "@/client"
+import { getDefaultFrontendPath } from "@/lib/experimentalMode"
 import { firebaseAuth } from "@/lib/firebase"
 import { getAuthErrorMessage } from "@/lib/firebase-errors"
 import useCustomToast from "./useCustomToast"
@@ -57,7 +58,7 @@ const useAuth = () => {
       localStorage.setItem("access_token", response.access_token)
     },
     onSuccess: () => {
-      navigate({ to: "/v2/library" })
+      navigate({ to: getDefaultFrontendPath() as never })
     },
     onError: (error) => {
       showErrorToast(getAuthErrorMessage(error))
@@ -81,7 +82,7 @@ const useAuth = () => {
   const loginMutation = useMutation({
     mutationFn: login,
     onSuccess: () => {
-      navigate({ to: "/v2/library" })
+      navigate({ to: getDefaultFrontendPath() as never })
     },
     onError: async (error) => {
       const currentUser = firebaseAuth.currentUser
@@ -107,7 +108,7 @@ const useAuth = () => {
       localStorage.setItem("access_token", response.access_token)
     },
     onSuccess: () => {
-      navigate({ to: "/v2/library" })
+      navigate({ to: getDefaultFrontendPath() as never })
     },
     onError: (error) => {
       showErrorToast(getAuthErrorMessage(error))

--- a/src/lib/experimentalMode.ts
+++ b/src/lib/experimentalMode.ts
@@ -1,0 +1,56 @@
+export const EXPERIMENTAL_MODE_STORAGE_KEY = "taskforce-experimental-mode"
+
+export const CURRENT_FRONTEND_HOME = "/home"
+export const EXPERIMENTAL_FRONTEND_HOME = "/v2/library"
+
+const routePairs = [
+  { current: "/home", experimental: "/v2/library" },
+  { current: "/topics", experimental: "/v2/library" },
+  { current: "/cases", experimental: "/v2/library" },
+  { current: "/skills", experimental: "/v2/agents" },
+  { current: "/admin", experimental: "/v2/admin" },
+  { current: "/settings", experimental: "/v2/settings" },
+] as const
+
+export function readExperimentalModePreference(
+  storageKey = EXPERIMENTAL_MODE_STORAGE_KEY,
+) {
+  if (typeof window === "undefined") return false
+  return window.localStorage.getItem(storageKey) === "true"
+}
+
+export function writeExperimentalModePreference(
+  enabled: boolean,
+  storageKey = EXPERIMENTAL_MODE_STORAGE_KEY,
+) {
+  if (typeof window === "undefined") return
+  window.localStorage.setItem(storageKey, String(enabled))
+}
+
+export function getDefaultFrontendPath() {
+  return readExperimentalModePreference()
+    ? EXPERIMENTAL_FRONTEND_HOME
+    : CURRENT_FRONTEND_HOME
+}
+
+function matchesRoute(pathname: string, routePath: string) {
+  return pathname === routePath || pathname.startsWith(`${routePath}/`)
+}
+
+export function getExperimentalFrontendPath(pathname: string) {
+  if (pathname.startsWith("/v2")) return pathname
+
+  const match = routePairs.find(({ current }) =>
+    matchesRoute(pathname, current),
+  )
+  return match?.experimental ?? EXPERIMENTAL_FRONTEND_HOME
+}
+
+export function getCurrentFrontendPath(pathname: string) {
+  if (!pathname.startsWith("/v2")) return pathname
+
+  const match = routePairs.find(({ experimental }) =>
+    matchesRoute(pathname, experimental),
+  )
+  return match?.current ?? CURRENT_FRONTEND_HOME
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import { StrictMode } from "react"
 import ReactDOM from "react-dom/client"
 import { ApiError, OpenAPI } from "./client"
 import { DemoModeProvider } from "./components/demo-mode-provider"
+import { ExperimentalModeProvider } from "./components/experimental-mode-provider"
 import { ThemeProvider } from "./components/theme-provider"
 import { Toaster } from "./components/ui/sonner"
 import "./index.css"
@@ -63,10 +64,12 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
       <DemoModeProvider>
-        <QueryClientProvider client={queryClient}>
-          <RouterProvider router={router} />
-          <Toaster richColors closeButton />
-        </QueryClientProvider>
+        <ExperimentalModeProvider>
+          <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+            <Toaster richColors closeButton />
+          </QueryClientProvider>
+        </ExperimentalModeProvider>
       </DemoModeProvider>
     </ThemeProvider>
   </StrictMode>,

--- a/src/routes/_layout.tsx
+++ b/src/routes/_layout.tsx
@@ -1,25 +1,70 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
+import { useEffect } from "react"
 
+import { ApiError, type UserPublic, UsersService } from "@/client"
+import { useDemoMode } from "@/components/demo-mode-provider"
+import { useExperimentalMode } from "@/components/experimental-mode-provider"
 import { GlobalSearchBar } from "@/components/Search/GlobalSearchBar"
 import AppSidebar from "@/components/Sidebar/AppSidebar"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { isLoggedIn } from "@/hooks/useAuth"
+import {
+  getExperimentalFrontendPath,
+  readExperimentalModePreference,
+} from "@/lib/experimentalMode"
 
 export const Route = createFileRoute("/_layout")({
   component: Layout,
-  beforeLoad: async () => {
+  beforeLoad: async ({ location }) => {
     if (!isLoggedIn()) {
       throw redirect({
         to: "/login",
       })
     }
+
+    try {
+      const currentUser = await UsersService.readUserMe()
+
+      if (currentUser.is_superuser && readExperimentalModePreference()) {
+        throw redirect({
+          to: getExperimentalFrontendPath(location.pathname) as never,
+          search: location.search as never,
+          replace: true,
+        })
+      }
+
+      return { currentUser }
+    } catch (error) {
+      if (error instanceof ApiError && [401, 403].includes(error.status)) {
+        localStorage.removeItem("access_token")
+        throw redirect({ to: "/login" })
+      }
+
+      throw error
+    }
   },
 })
 
+function InternalModeAccessGate({ currentUser }: { currentUser: UserPublic }) {
+  const { setDemoMode } = useDemoMode()
+  const { setExperimentalMode } = useExperimentalMode()
+
+  useEffect(() => {
+    if (currentUser.is_superuser) return
+    setDemoMode(false)
+    setExperimentalMode(false)
+  }, [currentUser.is_superuser, setDemoMode, setExperimentalMode])
+
+  return null
+}
+
 function Layout() {
+  const { currentUser } = Route.useRouteContext()
+
   return (
     <SidebarProvider className="h-svh overflow-hidden">
-      <AppSidebar />
+      <InternalModeAccessGate currentUser={currentUser} />
+      <AppSidebar currentUser={currentUser} />
       <SidebarInset className="min-h-0 overflow-hidden">
         <header className="shrink-0 border-b bg-background px-6 md:px-8">
           <div className="flex h-16 items-center">

--- a/src/routes/_layout/admin.tsx
+++ b/src/routes/_layout/admin.tsx
@@ -9,11 +9,9 @@ export const Route = createFileRoute("/_layout/admin")({
     const user = await UsersService.readUserMe()
     if (!user.is_superuser) {
       throw redirect({
-        to: "/v2/library",
+        to: "/home",
       })
     }
-
-    throw redirect({ to: "/v2/admin" })
   },
   head: () => ({
     meta: [

--- a/src/routes/_layout/cases.tsx
+++ b/src/routes/_layout/cases.tsx
@@ -1,14 +1,26 @@
-import { createFileRoute, redirect } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
+
+import { CasesPage } from "@/components/Cases/CasesPage"
+
+const searchSchema = z.object({
+  caseId: z.string().optional(),
+})
 
 export const Route = createFileRoute("/_layout/cases")({
-  beforeLoad: () => {
-    throw redirect({ to: "/v2/library" })
-  },
+  component: Cases,
+  validateSearch: searchSchema,
   head: () => ({
     meta: [
       {
-        title: "Taskforce | Library",
+        title: "Cases",
       },
     ],
   }),
 })
+
+function Cases() {
+  const { caseId } = Route.useSearch()
+
+  return <CasesPage initialSelectedCaseId={caseId ?? null} />
+}

--- a/src/routes/_layout/home.tsx
+++ b/src/routes/_layout/home.tsx
@@ -1,14 +1,20 @@
-import { createFileRoute, redirect } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
+
+import { HomePage } from "@/components/Home/HomePage"
 
 export const Route = createFileRoute("/_layout/home")({
-  beforeLoad: () => {
-    throw redirect({ to: "/v2/library" })
-  },
+  component: Home,
   head: () => ({
     meta: [
       {
-        title: "Taskforce | Library",
+        title: "Home",
       },
     ],
   }),
 })
+
+function Home() {
+  const { currentUser } = Route.useRouteContext()
+
+  return <HomePage mode="app" signedIn user={currentUser} />
+}

--- a/src/routes/_layout/settings.tsx
+++ b/src/routes/_layout/settings.tsx
@@ -1,20 +1,19 @@
-import { createFileRoute, redirect } from "@tanstack/react-router"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { z } from "zod"
 
-import { settingsTabValues } from "@/components/UserSettings/UserSettingsPage"
+import {
+  type SettingsTab,
+  settingsTabValues,
+  UserSettingsPage,
+} from "@/components/UserSettings/UserSettingsPage"
 
 const searchSchema = z.object({
   tab: z.enum(settingsTabValues).optional(),
 })
 
 export const Route = createFileRoute("/_layout/settings")({
+  component: UserSettings,
   validateSearch: searchSchema,
-  beforeLoad: ({ search }) => {
-    throw redirect({
-      to: "/v2/settings",
-      search: { tab: search.tab },
-    })
-  },
   head: () => ({
     meta: [
       {
@@ -23,3 +22,22 @@ export const Route = createFileRoute("/_layout/settings")({
     ],
   }),
 })
+
+function UserSettings() {
+  const navigate = useNavigate()
+  const { tab } = Route.useSearch()
+  const activeTab = tab ?? "my-profile"
+
+  return (
+    <UserSettingsPage
+      activeTab={activeTab}
+      onTabChange={(nextTab: SettingsTab) => {
+        void navigate({
+          to: "/settings",
+          search: { tab: nextTab },
+          replace: true,
+        })
+      }}
+    />
+  )
+}

--- a/src/routes/_layout/skills.tsx
+++ b/src/routes/_layout/skills.tsx
@@ -1,14 +1,26 @@
-import { createFileRoute, redirect } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
+
+import { SkillsPage } from "@/components/Skills/SkillsPage"
+
+const searchSchema = z.object({
+  skillId: z.string().optional(),
+})
 
 export const Route = createFileRoute("/_layout/skills")({
-  beforeLoad: () => {
-    throw redirect({ to: "/v2/library" })
-  },
+  component: Skills,
+  validateSearch: searchSchema,
   head: () => ({
     meta: [
       {
-        title: "Taskforce | Library",
+        title: "Skills",
       },
     ],
   }),
 })
+
+function Skills() {
+  const { skillId } = Route.useSearch()
+
+  return <SkillsPage initialSelectedSkillId={skillId ?? null} />
+}

--- a/src/routes/_layout/topics.tsx
+++ b/src/routes/_layout/topics.tsx
@@ -1,14 +1,26 @@
-import { createFileRoute, redirect } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
+
+import { TopicsPage } from "@/components/Topics/TopicsPage"
+
+const searchSchema = z.object({
+  topicId: z.string().optional(),
+})
 
 export const Route = createFileRoute("/_layout/topics")({
-  beforeLoad: () => {
-    throw redirect({ to: "/v2/library" })
-  },
+  component: Topics,
+  validateSearch: searchSchema,
   head: () => ({
     meta: [
       {
-        title: "Taskforce | Library",
+        title: "Topics",
       },
     ],
   }),
 })
+
+function Topics() {
+  const { topicId } = Route.useSearch()
+
+  return <TopicsPage initialSelectedTopicId={topicId ?? null} />
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,12 +2,13 @@ import { createFileRoute, redirect } from "@tanstack/react-router"
 
 import { TaskforceLandingPage } from "@/components/V2/TaskforceLandingPage"
 import { isLoggedIn } from "@/hooks/useAuth"
+import { getDefaultFrontendPath } from "@/lib/experimentalMode"
 
 export const Route = createFileRoute("/")({
   component: Landing,
   beforeLoad: () => {
     if (isLoggedIn()) {
-      throw redirect({ to: "/v2/library" })
+      throw redirect({ to: getDefaultFrontendPath() as never })
     }
   },
   head: () => ({

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -22,6 +22,7 @@ import { Input } from "@/components/ui/input"
 import { LoadingButton } from "@/components/ui/loading-button"
 import { PasswordInput } from "@/components/ui/password-input"
 import useAuth, { isLoggedIn } from "@/hooks/useAuth"
+import { getDefaultFrontendPath } from "@/lib/experimentalMode"
 
 const formSchema = z.object({
   username: z.email(),
@@ -38,7 +39,7 @@ export const Route = createFileRoute("/login")({
   beforeLoad: async () => {
     if (isLoggedIn()) {
       throw redirect({
-        to: "/v2/library",
+        to: getDefaultFrontendPath() as never,
       })
     }
   },

--- a/src/routes/recover-password.tsx
+++ b/src/routes/recover-password.tsx
@@ -23,6 +23,7 @@ import { Input } from "@/components/ui/input"
 import { LoadingButton } from "@/components/ui/loading-button"
 import { isLoggedIn } from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
+import { getDefaultFrontendPath } from "@/lib/experimentalMode"
 import { firebaseAuth } from "@/lib/firebase"
 import {
   getAuthErrorMessage,
@@ -40,7 +41,7 @@ export const Route = createFileRoute("/recover-password")({
   beforeLoad: async () => {
     if (isLoggedIn()) {
       throw redirect({
-        to: "/v2/library",
+        to: getDefaultFrontendPath() as never,
       })
     }
   },

--- a/src/routes/reset-password.tsx
+++ b/src/routes/reset-password.tsx
@@ -23,6 +23,7 @@ import { LoadingButton } from "@/components/ui/loading-button"
 import { PasswordInput } from "@/components/ui/password-input"
 import { isLoggedIn } from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
+import { getDefaultFrontendPath } from "@/lib/experimentalMode"
 import { handleError } from "@/utils"
 
 const searchSchema = z.object({
@@ -51,7 +52,7 @@ export const Route = createFileRoute("/reset-password")({
   validateSearch: searchSchema,
   beforeLoad: async ({ search }) => {
     if (isLoggedIn()) {
-      throw redirect({ to: "/v2/library" })
+      throw redirect({ to: getDefaultFrontendPath() as never })
     }
     if (!search.token) {
       throw redirect({ to: "/login" })

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input"
 import { LoadingButton } from "@/components/ui/loading-button"
 import { PasswordInput } from "@/components/ui/password-input"
 import useAuth, { isLoggedIn } from "@/hooks/useAuth"
+import { getDefaultFrontendPath } from "@/lib/experimentalMode"
 
 const formSchema = z
   .object({
@@ -45,7 +46,7 @@ export const Route = createFileRoute("/signup")({
   beforeLoad: async () => {
     if (isLoggedIn()) {
       throw redirect({
-        to: "/v2/library",
+        to: getDefaultFrontendPath() as never,
       })
     }
   },

--- a/src/routes/v2.tsx
+++ b/src/routes/v2.tsx
@@ -6,15 +6,30 @@ import {
   TaskforceShell,
 } from "@/components/V2/TaskforceShell"
 import { isLoggedIn } from "@/hooks/useAuth"
+import {
+  getCurrentFrontendPath,
+  readExperimentalModePreference,
+} from "@/lib/experimentalMode"
 
 export const Route = createFileRoute("/v2")({
-  beforeLoad: async () => {
+  beforeLoad: async ({ location }) => {
     if (!isLoggedIn()) {
       throw redirect({ to: "/login" })
     }
 
     try {
       const currentUser = await UsersService.readUserMe()
+      const canUseExperimental =
+        currentUser.is_superuser && readExperimentalModePreference()
+
+      if (!canUseExperimental) {
+        throw redirect({
+          to: getCurrentFrontendPath(location.pathname) as never,
+          search: location.search as never,
+          replace: true,
+        })
+      }
+
       return { currentUser }
     } catch (error) {
       if (error instanceof ApiError && [401, 403].includes(error.status)) {


### PR DESCRIPTION
## Summary
- add a persisted experimental mode preference, defaulting off, to switch superusers between current frontend routes and `/v2` routes
- restore existing legacy app pages as the default authenticated frontend while experimental mode is off
- gate `/v2` behind superuser + experimental mode and redirect back to current frontend when disabled
- show Experimental mode above Demo mode, and hide both sliders from non-superuser accounts
- clear stored demo/experimental mode for non-superusers when they enter the current frontend

## Validation
- `npx biome check --write --unsafe ...`
- `npx biome check ...`
- `npx tsc -p tsconfig.build.json --noEmit`
- `npx vite build` (passes; existing Node 18/Vite 7 warning and large chunk warning still emitted)
- mocked Playwright browser smoke: superuser experimental off redirects `/v2/library` -> `/home`; superuser experimental on redirects `/home` -> `/v2/library`; non-superuser sees neither slider and stored modes are cleared
- `git diff --check`