### PR TITLE
Fix experimental mode scope to v2 UI variants

### DIFF
--- a/src/components/Home/HomePage.tsx
+++ b/src/components/Home/HomePage.tsx
@@ -16,7 +16,6 @@ import {
 } from "lucide-react"
 
 import type { UserPublic } from "@/client"
-import { useExperimentalMode } from "@/components/experimental-mode-provider"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -37,7 +36,6 @@ type HomePageProps = {
 
 export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
   const isPublic = mode === "public"
-  const { isExperimentalMode } = useExperimentalMode()
   const canUseApp = !isPublic || signedIn
   const firstName = user?.full_name?.trim().split(/\s+/)[0]
   const displayName = firstName || user?.email || "there"
@@ -72,24 +70,14 @@ export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
                 {isPublic ? (
                   <>
                     <Button asChild size="lg" className={styles.primaryCta}>
-                      <RouterLink
-                        to={
-                          signedIn && isExperimentalMode
-                            ? "/v2/library"
-                            : signedIn
-                              ? "/home"
-                              : "/signup"
-                        }
-                      >
+                      <RouterLink to={signedIn ? "/v2/library" : "/signup"}>
                         <Sparkles className={styles.icon} />
                         Try the demo
                       </RouterLink>
                     </Button>
                     <Button asChild variant="outline" size="lg">
                       {signedIn ? (
-                        <RouterLink
-                          to={isExperimentalMode ? "/v2/library" : "/home"}
-                        >
+                        <RouterLink to="/v2/library">
                           <LogIn className={styles.icon} />
                           Open Home
                         </RouterLink>
@@ -110,23 +98,13 @@ export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
                       </RouterLink>
                     </Button>
                     <Button asChild size="lg">
-                      {isExperimentalMode ? (
-                        <RouterLink
-                          to="/v2/settings"
-                          search={{ tab: "connect-agent" }}
-                          data-testid="home-connect-agent-link"
-                        >
-                          Connect agent
-                        </RouterLink>
-                      ) : (
-                        <RouterLink
-                          to="/settings"
-                          search={{ tab: "connect-agent" }}
-                          data-testid="home-connect-agent-link"
-                        >
-                          Connect agent
-                        </RouterLink>
-                      )}
+                      <RouterLink
+                        to="/v2/settings"
+                        search={{ tab: "connect-agent" }}
+                        data-testid="home-connect-agent-link"
+                      >
+                        Connect agent
+                      </RouterLink>
                     </Button>
                   </>
                 )}

--- a/src/components/Sidebar/AppSidebar.tsx
+++ b/src/components/Sidebar/AppSidebar.tsx
@@ -1,6 +1,5 @@
 import { Box, Boxes, Home, Sparkles, Users } from "lucide-react"
 
-import type { UserPublic } from "@/client"
 import { Logo } from "@/components/Common/Logo"
 import {
   Sidebar,
@@ -8,6 +7,7 @@ import {
   SidebarFooter,
   SidebarHeader,
 } from "@/components/ui/sidebar"
+import useAuth from "@/hooks/useAuth"
 import { type Item, Main } from "./Main"
 import { DemoModeToggle, ExperimentalModeToggle } from "./ModeSwitches"
 import { User } from "./User"
@@ -19,11 +19,9 @@ const baseItems: Item[] = [
   { icon: Sparkles, title: "Skills", path: "/skills" },
 ]
 
-type AppSidebarProps = {
-  currentUser: UserPublic | null
-}
+export function AppSidebar() {
+  const { user: currentUser } = useAuth()
 
-export function AppSidebar({ currentUser }: AppSidebarProps) {
   const items = currentUser?.is_superuser
     ? [...baseItems, { icon: Users, title: "Admin", path: "/admin" }]
     : baseItems

--- a/src/components/Sidebar/ModeSwitches.tsx
+++ b/src/components/Sidebar/ModeSwitches.tsx
@@ -1,13 +1,8 @@
-import { useNavigate, useRouterState } from "@tanstack/react-router"
 import { FlaskConical, type LucideIcon, Rocket } from "lucide-react"
 
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { useExperimentalMode } from "@/components/experimental-mode-provider"
 import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar"
-import {
-  getCurrentFrontendPath,
-  getExperimentalFrontendPath,
-} from "@/lib/experimentalMode"
 import { cn } from "@/lib/utils"
 
 type ModeToggleProps = {
@@ -68,19 +63,7 @@ function ModeToggle({
 }
 
 export function ExperimentalModeToggle() {
-  const navigate = useNavigate()
-  const router = useRouterState()
-  const { isExperimentalMode, setExperimentalMode } = useExperimentalMode()
-
-  const handleClick = () => {
-    const nextEnabled = !isExperimentalMode
-    const nextPath = nextEnabled
-      ? getExperimentalFrontendPath(router.location.pathname)
-      : getCurrentFrontendPath(router.location.pathname)
-
-    setExperimentalMode(nextEnabled)
-    void navigate({ to: nextPath as never })
-  }
+  const { isExperimentalMode, toggleExperimentalMode } = useExperimentalMode()
 
   return (
     <ModeToggle
@@ -93,7 +76,7 @@ export function ExperimentalModeToggle() {
           ? "Disable experimental mode"
           : "Enable experimental mode"
       }
-      onClick={handleClick}
+      onClick={toggleExperimentalMode}
     />
   )
 }

--- a/src/components/Sidebar/User.tsx
+++ b/src/components/Sidebar/User.tsx
@@ -4,7 +4,6 @@ import { ChevronsUpDown, LogOut, Settings } from "lucide-react"
 
 import { readMyOrganizationInvitations } from "@/api/organizations"
 import { PendingInvitationBadge } from "@/components/Common/PendingInvitationBadge"
-import { useExperimentalMode } from "@/components/experimental-mode-provider"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import {
   DropdownMenu,
@@ -57,7 +56,6 @@ function UserInfo({
 
 export function User({ user }: { user: any }) {
   const { logout } = useAuth()
-  const { isExperimentalMode } = useExperimentalMode()
   const { isMobile, setOpenMobile } = useSidebar()
   const invitationsQuery = useQuery({
     queryKey: ["my-organization-invitations"],
@@ -112,10 +110,7 @@ export function User({ user }: { user: any }) {
               />
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <RouterLink
-              to={isExperimentalMode ? "/v2/settings" : "/settings"}
-              onClick={handleMenuClick}
-            >
+            <RouterLink to="/v2/settings" onClick={handleMenuClick}>
               <DropdownMenuItem>
                 <Settings />
                 <span>User Settings</span>

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -30,6 +30,7 @@ import {
 import { readV2Documents, type V2DocumentPublic } from "@/api/v2Documents"
 import type { UserPublic } from "@/client"
 import { useDemoMode } from "@/components/demo-mode-provider"
+import { useExperimentalMode } from "@/components/experimental-mode-provider"
 import {
   DemoModeToggle,
   ExperimentalModeToggle,
@@ -581,9 +582,23 @@ function DocumentSearch() {
   )
 }
 
+function InternalModeAccessGate({ currentUser }: TaskforceShellProps) {
+  const { setDemoMode } = useDemoMode()
+  const { setExperimentalMode } = useExperimentalMode()
+
+  useEffect(() => {
+    if (currentUser.is_superuser) return
+    setDemoMode(false)
+    setExperimentalMode(false)
+  }, [currentUser.is_superuser, setDemoMode, setExperimentalMode])
+
+  return null
+}
+
 export function TaskforceShell({ currentUser }: TaskforceShellProps) {
   return (
     <SidebarProvider className="h-svh overflow-hidden">
+      <InternalModeAccessGate currentUser={currentUser} />
       <Sidebar collapsible="icon">
         <SidebarHeader className="px-4 py-6 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-0">
           <TaskforceMark />

--- a/src/lib/experimentalMode.ts
+++ b/src/lib/experimentalMode.ts
@@ -1,16 +1,5 @@
 export const EXPERIMENTAL_MODE_STORAGE_KEY = "taskforce-experimental-mode"
-
-export const CURRENT_FRONTEND_HOME = "/home"
-export const EXPERIMENTAL_FRONTEND_HOME = "/v2/library"
-
-const routePairs = [
-  { current: "/home", experimental: "/v2/library" },
-  { current: "/topics", experimental: "/v2/library" },
-  { current: "/cases", experimental: "/v2/library" },
-  { current: "/skills", experimental: "/v2/agents" },
-  { current: "/admin", experimental: "/v2/admin" },
-  { current: "/settings", experimental: "/v2/settings" },
-] as const
+export const DEFAULT_FRONTEND_PATH = "/v2/library"
 
 export function readExperimentalModePreference(
   storageKey = EXPERIMENTAL_MODE_STORAGE_KEY,
@@ -28,29 +17,5 @@ export function writeExperimentalModePreference(
 }
 
 export function getDefaultFrontendPath() {
-  return readExperimentalModePreference()
-    ? EXPERIMENTAL_FRONTEND_HOME
-    : CURRENT_FRONTEND_HOME
-}
-
-function matchesRoute(pathname: string, routePath: string) {
-  return pathname === routePath || pathname.startsWith(`${routePath}/`)
-}
-
-export function getExperimentalFrontendPath(pathname: string) {
-  if (pathname.startsWith("/v2")) return pathname
-
-  const match = routePairs.find(({ current }) =>
-    matchesRoute(pathname, current),
-  )
-  return match?.experimental ?? EXPERIMENTAL_FRONTEND_HOME
-}
-
-export function getCurrentFrontendPath(pathname: string) {
-  if (!pathname.startsWith("/v2")) return pathname
-
-  const match = routePairs.find(({ experimental }) =>
-    matchesRoute(pathname, experimental),
-  )
-  return match?.current ?? CURRENT_FRONTEND_HOME
+  return DEFAULT_FRONTEND_PATH
 }

--- a/src/routes/_layout.tsx
+++ b/src/routes/_layout.tsx
@@ -1,70 +1,25 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
-import { useEffect } from "react"
 
-import { ApiError, type UserPublic, UsersService } from "@/client"
-import { useDemoMode } from "@/components/demo-mode-provider"
-import { useExperimentalMode } from "@/components/experimental-mode-provider"
 import { GlobalSearchBar } from "@/components/Search/GlobalSearchBar"
 import AppSidebar from "@/components/Sidebar/AppSidebar"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { isLoggedIn } from "@/hooks/useAuth"
-import {
-  getExperimentalFrontendPath,
-  readExperimentalModePreference,
-} from "@/lib/experimentalMode"
 
 export const Route = createFileRoute("/_layout")({
   component: Layout,
-  beforeLoad: async ({ location }) => {
+  beforeLoad: async () => {
     if (!isLoggedIn()) {
       throw redirect({
         to: "/login",
       })
     }
-
-    try {
-      const currentUser = await UsersService.readUserMe()
-
-      if (currentUser.is_superuser && readExperimentalModePreference()) {
-        throw redirect({
-          to: getExperimentalFrontendPath(location.pathname) as never,
-          search: location.search as never,
-          replace: true,
-        })
-      }
-
-      return { currentUser }
-    } catch (error) {
-      if (error instanceof ApiError && [401, 403].includes(error.status)) {
-        localStorage.removeItem("access_token")
-        throw redirect({ to: "/login" })
-      }
-
-      throw error
-    }
   },
 })
 
-function InternalModeAccessGate({ currentUser }: { currentUser: UserPublic }) {
-  const { setDemoMode } = useDemoMode()
-  const { setExperimentalMode } = useExperimentalMode()
-
-  useEffect(() => {
-    if (currentUser.is_superuser) return
-    setDemoMode(false)
-    setExperimentalMode(false)
-  }, [currentUser.is_superuser, setDemoMode, setExperimentalMode])
-
-  return null
-}
-
 function Layout() {
-  const { currentUser } = Route.useRouteContext()
-
   return (
     <SidebarProvider className="h-svh overflow-hidden">
-      <InternalModeAccessGate currentUser={currentUser} />
-      <AppSidebar currentUser={currentUser} />
+      <AppSidebar />
       <SidebarInset className="min-h-0 overflow-hidden">
         <header className="shrink-0 border-b bg-background px-6 md:px-8">
           <div className="flex h-16 items-center">

--- a/src/routes/_layout/admin.tsx
+++ b/src/routes/_layout/admin.tsx
@@ -1,17 +1,17 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
 import { UsersService } from "@/client"
-import { AdminUsersPage } from "@/components/Admin/AdminUsersPage"
 
 export const Route = createFileRoute("/_layout/admin")({
-  component: Admin,
   beforeLoad: async () => {
     const user = await UsersService.readUserMe()
     if (!user.is_superuser) {
       throw redirect({
-        to: "/home",
+        to: "/v2/library",
       })
     }
+
+    throw redirect({ to: "/v2/admin" })
   },
   head: () => ({
     meta: [
@@ -21,7 +21,3 @@ export const Route = createFileRoute("/_layout/admin")({
     ],
   }),
 })
-
-function Admin() {
-  return <AdminUsersPage />
-}

--- a/src/routes/_layout/cases.tsx
+++ b/src/routes/_layout/cases.tsx
@@ -1,26 +1,14 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { z } from "zod"
-
-import { CasesPage } from "@/components/Cases/CasesPage"
-
-const searchSchema = z.object({
-  caseId: z.string().optional(),
-})
+import { createFileRoute, redirect } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/_layout/cases")({
-  component: Cases,
-  validateSearch: searchSchema,
+  beforeLoad: () => {
+    throw redirect({ to: "/v2/library" })
+  },
   head: () => ({
     meta: [
       {
-        title: "Cases",
+        title: "Taskforce | Library",
       },
     ],
   }),
 })
-
-function Cases() {
-  const { caseId } = Route.useSearch()
-
-  return <CasesPage initialSelectedCaseId={caseId ?? null} />
-}

--- a/src/routes/_layout/home.tsx
+++ b/src/routes/_layout/home.tsx
@@ -1,20 +1,14 @@
-import { createFileRoute } from "@tanstack/react-router"
-
-import { HomePage } from "@/components/Home/HomePage"
+import { createFileRoute, redirect } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/_layout/home")({
-  component: Home,
+  beforeLoad: () => {
+    throw redirect({ to: "/v2/library" })
+  },
   head: () => ({
     meta: [
       {
-        title: "Home",
+        title: "Taskforce | Library",
       },
     ],
   }),
 })
-
-function Home() {
-  const { currentUser } = Route.useRouteContext()
-
-  return <HomePage mode="app" signedIn user={currentUser} />
-}

--- a/src/routes/_layout/settings.tsx
+++ b/src/routes/_layout/settings.tsx
@@ -1,19 +1,20 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute, redirect } from "@tanstack/react-router"
 import { z } from "zod"
 
-import {
-  type SettingsTab,
-  settingsTabValues,
-  UserSettingsPage,
-} from "@/components/UserSettings/UserSettingsPage"
+import { settingsTabValues } from "@/components/UserSettings/UserSettingsPage"
 
 const searchSchema = z.object({
   tab: z.enum(settingsTabValues).optional(),
 })
 
 export const Route = createFileRoute("/_layout/settings")({
-  component: UserSettings,
   validateSearch: searchSchema,
+  beforeLoad: ({ search }) => {
+    throw redirect({
+      to: "/v2/settings",
+      search: { tab: search.tab },
+    })
+  },
   head: () => ({
     meta: [
       {
@@ -22,22 +23,3 @@ export const Route = createFileRoute("/_layout/settings")({
     ],
   }),
 })
-
-function UserSettings() {
-  const navigate = useNavigate()
-  const { tab } = Route.useSearch()
-  const activeTab = tab ?? "my-profile"
-
-  return (
-    <UserSettingsPage
-      activeTab={activeTab}
-      onTabChange={(nextTab: SettingsTab) => {
-        void navigate({
-          to: "/settings",
-          search: { tab: nextTab },
-          replace: true,
-        })
-      }}
-    />
-  )
-}

--- a/src/routes/_layout/skills.tsx
+++ b/src/routes/_layout/skills.tsx
@@ -1,26 +1,14 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { z } from "zod"
-
-import { SkillsPage } from "@/components/Skills/SkillsPage"
-
-const searchSchema = z.object({
-  skillId: z.string().optional(),
-})
+import { createFileRoute, redirect } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/_layout/skills")({
-  component: Skills,
-  validateSearch: searchSchema,
+  beforeLoad: () => {
+    throw redirect({ to: "/v2/agents" })
+  },
   head: () => ({
     meta: [
       {
-        title: "Skills",
+        title: "Taskforce | Agents",
       },
     ],
   }),
 })
-
-function Skills() {
-  const { skillId } = Route.useSearch()
-
-  return <SkillsPage initialSelectedSkillId={skillId ?? null} />
-}

--- a/src/routes/_layout/topics.tsx
+++ b/src/routes/_layout/topics.tsx
@@ -1,26 +1,14 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { z } from "zod"
-
-import { TopicsPage } from "@/components/Topics/TopicsPage"
-
-const searchSchema = z.object({
-  topicId: z.string().optional(),
-})
+import { createFileRoute, redirect } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/_layout/topics")({
-  component: Topics,
-  validateSearch: searchSchema,
+  beforeLoad: () => {
+    throw redirect({ to: "/v2/library" })
+  },
   head: () => ({
     meta: [
       {
-        title: "Topics",
+        title: "Taskforce | Library",
       },
     ],
   }),
 })
-
-function Topics() {
-  const { topicId } = Route.useSearch()
-
-  return <TopicsPage initialSelectedTopicId={topicId ?? null} />
-}

--- a/src/routes/v2.tsx
+++ b/src/routes/v2.tsx
@@ -6,32 +6,17 @@ import {
   TaskforceShell,
 } from "@/components/V2/TaskforceShell"
 import { isLoggedIn } from "@/hooks/useAuth"
-import {
-  getCurrentFrontendPath,
-  readExperimentalModePreference,
-} from "@/lib/experimentalMode"
 
 export const Route = createFileRoute("/v2")({
   // Keep session user in route context without re-fetching on every child navigation.
   staleTime: Number.POSITIVE_INFINITY,
-  beforeLoad: async ({ location }) => {
+  beforeLoad: async () => {
     if (!isLoggedIn()) {
       throw redirect({ to: "/login" })
     }
 
     try {
       const currentUser = await UsersService.readUserMe()
-      const canUseExperimental =
-        currentUser.is_superuser && readExperimentalModePreference()
-
-      if (!canUseExperimental) {
-        throw redirect({
-          to: getCurrentFrontendPath(location.pathname) as never,
-          search: location.search as never,
-          replace: true,
-        })
-      }
-
       return { currentUser }
     } catch (error) {
       if (error instanceof ApiError && [401, 403].includes(error.status)) {


### PR DESCRIPTION
## Summary
- correct experimental mode so it no longer switches between legacy routes and `/v2` routes
- keep `/v2/search`, `/v2/library`, `/v2/agents`, `/v2/metrics`, etc. as the baseline frontend regardless of experimental mode
- make the experimental toggle only update the persisted UI-variant flag; it no longer navigates
- restore legacy `/home`, `/topics`, `/cases`, `/skills`, `/settings`, and `/admin` routes to redirect into the v2 baseline
- keep Experimental mode above Demo mode for superusers and continue clearing internal modes for non-superusers in the v2 shell

## Validation
- `npx biome check --write --unsafe ...`
- `npx biome check ...`
- `npx tsc -p tsconfig.build.json --noEmit`
- `npx vite build` (passes; existing Node 18/Vite 7 warning and large chunk warning still emitted)
- mocked Playwright smoke: `/v2/library` stays `/v2/library` with experimental off and on; `/home` redirects to `/v2/library`; non-superuser sees neither internal toggle and mode prefs are cleared
- `git diff --check`