### PR TITLE
Prevent v2 no-access flash on route errors

### DIFF
--- a/src/routes/v2.tsx
+++ b/src/routes/v2.tsx
@@ -11,10 +11,14 @@ import {
   readTaskforceSession,
 } from "@/lib/taskforceSession"
 
+function V2BlankFallback() {
+  return <main className="min-h-svh bg-background" aria-busy="true" />
+}
+
 function V2Pending() {
   const currentUser = peekTaskforceSession()
   if (!currentUser) {
-    return <main className="min-h-svh bg-background" aria-busy="true" />
+    return <V2BlankFallback />
   }
 
   return <TaskforceShell currentUser={currentUser} />
@@ -30,7 +34,7 @@ function V2RouteError({ error }: { error: unknown }) {
     return <TaskforceShell currentUser={currentUser} />
   }
 
-  return <TaskforceNoAccess />
+  return <V2BlankFallback />
 }
 
 export const Route = createFileRoute("/v2")({
@@ -44,7 +48,7 @@ export const Route = createFileRoute("/v2")({
       const currentUser = await readTaskforceSession()
       return { currentUser }
     } catch (error) {
-      if (error instanceof ApiError && [401, 403].includes(error.status)) {
+      if (error instanceof ApiError && error.status === 401) {
         localStorage.removeItem("access_token")
         throw redirect({ to: "/login" })
       }

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -9,11 +9,11 @@ import {
 } from "@/api/v2Agents"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Button } from "@/components/ui/button"
+import { AgentDetailSkeleton } from "@/components/V2/Agents/AgentDetailSkeleton"
 import {
   agentSummaryToDetailPlaceholder,
   findAgentSummaryInList,
 } from "@/components/V2/Agents/agentDetailPlaceholder"
-import { AgentDetailSkeleton } from "@/components/V2/Agents/AgentDetailSkeleton"
 import {
   AGENT_DESCRIPTION_CLASS,
   AGENT_EYEBROW_CLASS,
@@ -219,6 +219,7 @@ function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
                 <td className="py-3 pl-3 text-right align-top">
                   <a
                     href={document.href}
+                    aria-label={`Open ${document.title}`}
                     className="inline-flex items-center justify-end gap-1 font-mono text-[0.62rem] uppercase tracking-[0.08em] text-[#8447ff]"
                   >
                     Open
@@ -314,16 +315,18 @@ function AgentDetailPage() {
     },
   })
   const agent = agentQuery.data
+  const isAgentError = agentQuery.isError
+  const isAgentFetched = agentQuery.isFetched
+  const isAgentFetching = agentQuery.isFetching
+  const isAgentPending = agentQuery.isPending
+  const isAgentPlaceholderData = agentQuery.isPlaceholderData
   const hasMatchingAgent = agent?.slug === slug
   const showNotFound =
-    agentQuery.isError ||
-    (agentQuery.isFetched && !agentQuery.isFetching && !hasMatchingAgent)
+    isAgentError || (isAgentFetched && !isAgentFetching && !hasMatchingAgent)
   const showFullSkeleton =
-    !showNotFound && !agent && (agentQuery.isPending || agentQuery.isFetching)
+    !showNotFound && !agent && (isAgentPending || isAgentFetching)
   const isHydratingDetail =
-    hasMatchingAgent &&
-    agentQuery.isFetching &&
-    agentQuery.isPlaceholderData
+    hasMatchingAgent && isAgentFetching && isAgentPlaceholderData
 
   if (showFullSkeleton) {
     return (
@@ -414,7 +417,10 @@ function AgentDetailPage() {
         </header>
 
         {isHydratingDetail ? (
-          <AgentDetailSkeleton shellClassName={AGENTS_DETAIL_SHELL} hideHeader />
+          <AgentDetailSkeleton
+            shellClassName={AGENTS_DETAIL_SHELL}
+            hideHeader
+          />
         ) : (
           <>
             <StatLine agent={agent} />

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -148,7 +148,9 @@ test("direct specialist URL renders detail instead of the agents grid", async ({
   await page.goto("/v2/agents/jensen")
 
   await expect(page).toHaveURL(/\/v2\/agents\/jensen$/)
-  await expect(page.getByRole("heading", { name: "Jensen", level: 2 })).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Jensen", level: 2 }),
+  ).toBeVisible()
   await expect(page.getByText("Operating instructions")).toBeVisible()
   await expect(
     page.getByRole("heading", { name: /Reusable .*specialists/i }),
@@ -175,7 +177,35 @@ test("agent detail navigation does not flash no-access or not-found", async ({
   await expect(
     page.getByRole("heading", { name: "Specialist not found", exact: true }),
   ).toHaveCount(0)
-  await expect(page.getByRole("heading", { name: "Jensen", level: 2 })).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Jensen", level: 2 }),
+  ).toBeVisible()
+})
+
+test("v2 route transient session errors do not render membership no-access", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "test-token")
+  })
+
+  await page.route("**/api/v1/users/me", async (route) => {
+    await route.fulfill({
+      status: 500,
+      json: { detail: "transient session read failure" },
+    })
+  })
+
+  const userResponse = page.waitForResponse("**/api/v1/users/me")
+  await page.goto("/v2/agents")
+  await userResponse
+
+  await expect(
+    page.getByRole("heading", { name: "No access", exact: true }),
+  ).toHaveCount(0)
+  await expect(page.getByRole("link", { name: "View membership" })).toHaveCount(
+    0,
+  )
 })
 
 test("agents grid links to specialist detail and session metrics", async ({
@@ -196,11 +226,11 @@ test("agents grid links to specialist detail and session metrics", async ({
     page.getByRole("heading", { name: "Mira", level: 3 }),
   ).toBeVisible()
 
-  await page
-    .getByRole("link", { name: /open specialist jensen/i })
-    .click()
+  await page.getByRole("link", { name: /open specialist jensen/i }).click()
   await expect(page).toHaveURL(/\/v2\/agents\/jensen$/)
-  await expect(page.getByRole("heading", { name: "Jensen", level: 2 })).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Jensen", level: 2 }),
+  ).toBeVisible()
   await expect(page.getByText("Operating instructions")).toBeVisible()
 
   const linkedKnowledge = page.getByRole("link", {


### PR DESCRIPTION
## Summary
- Prevent the V2 route error boundary from rendering the membership/no-access page for generic transient loader errors.
- Keep the membership/no-access page reserved for explicit `403` API responses, and keep `401` redirecting to login.
- Add a regression test covering transient `/users/me` failures so normal V2 navigation cannot flash the membership callout.
- Fix the agent detail query-state narrowing that blocked TypeScript validation, and add an accessible label for linked-knowledge open links.

## Root cause
The `/v2` route error component used `TaskforceNoAccess` as the fallback whenever a route error occurred before a cached current user was available. During route transitions, a transient loader/query failure could hit that boundary briefly, so the membership page appeared even though access had not actually been denied.

## Validation
- `npx biome check --write --unsafe src/routes/v2.tsx 'src/routes/v2/agents.$slug.tsx' tests/agents-routing.spec.ts`
- `npx tsc -p tsconfig.build.json --noEmit`
- `npx playwright test tests/agents-routing.spec.ts --project=chromium --no-deps`
- `VITE_FIREBASE_API_KEY=... VITE_API_URL=http://localhost:8000 npx vite build`

Note: Vite build still emits the repo's existing Node 18 warning and large chunk warning, but exits successfully.
