### PR TITLE
Align Agents v2 typography with Library and Metrics

### DIFF
--- a/src/components/V2/Agents/agentsTypography.ts
+++ b/src/components/V2/Agents/agentsTypography.ts
@@ -1,18 +1,34 @@
-/** Shared agent name / role typography (listing cards + detail header). */
+/** Page title — matches Library / Metrics v2 tabs. */
+export const AGENT_PAGE_TITLE_CLASS = "text-2xl font-semibold"
+
+/** Listing card + detail header name. */
 export const AGENT_NAME_CLASS =
-  "text-[1rem] font-semibold leading-tight tracking-[-0.01em] text-zinc-950 dark:text-white"
+  "text-base font-semibold leading-tight text-zinc-950 dark:text-white"
+
+/** Detail page specialist name (same scale as other v2 tab titles). */
+export const AGENT_DETAIL_NAME_CLASS = AGENT_PAGE_TITLE_CLASS
 
 export const AGENT_ROLE_CLASS =
-  "mt-1 text-xs leading-4 text-zinc-500 dark:text-zinc-400"
+  "mt-1 text-sm leading-5 text-zinc-500 dark:text-zinc-400"
 
-export const AGENT_EYEBROW_CLASS =
-  "font-mono text-[0.65rem] uppercase tracking-[0.22em] text-zinc-400 dark:text-zinc-500"
+export const AGENT_EYEBROW_CLASS = "text-sm text-zinc-500 dark:text-zinc-400"
 
-export const AGENT_ROUTE_LABEL_CLASS =
-  "font-mono text-[0.66rem] text-zinc-500 dark:text-zinc-400"
+export const AGENT_ROUTE_LABEL_CLASS = "text-sm text-zinc-500 dark:text-zinc-400"
 
 export const AGENT_ROUTE_CHIP_CLASS =
-  "border border-black/10 px-1.5 py-0.5 font-mono text-[0.66rem] text-zinc-900 dark:border-white/12 dark:text-zinc-100"
+  "border border-black/10 px-1.5 py-0.5 text-xs text-zinc-900 dark:border-white/12 dark:text-zinc-100"
 
 export const AGENT_DESCRIPTION_CLASS =
   "text-sm leading-5 text-zinc-600 dark:text-zinc-300"
+
+export const AGENT_STAT_LABEL_CLASS =
+  "text-xs uppercase tracking-wide text-zinc-400 dark:text-zinc-500"
+
+export const AGENT_STAT_VALUE_CLASS =
+  "text-sm font-semibold tabular-nums text-zinc-950 dark:text-white"
+
+export const AGENT_SECTION_TITLE_CLASS =
+  "text-sm font-semibold text-zinc-950 dark:text-white"
+
+export const AGENT_SECTION_META_CLASS =
+  "text-xs text-zinc-400 dark:text-zinc-500"

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -16,11 +16,15 @@ import {
 } from "@/components/V2/Agents/agentDetailPlaceholder"
 import {
   AGENT_DESCRIPTION_CLASS,
+  AGENT_DETAIL_NAME_CLASS,
   AGENT_EYEBROW_CLASS,
-  AGENT_NAME_CLASS,
+  AGENT_PAGE_TITLE_CLASS,
   AGENT_ROLE_CLASS,
   AGENT_ROUTE_CHIP_CLASS,
   AGENT_ROUTE_LABEL_CLASS,
+  AGENT_SECTION_META_CLASS,
+  AGENT_SECTION_TITLE_CLASS,
+  AGENT_STAT_LABEL_CLASS,
 } from "@/components/V2/Agents/agentsTypography"
 import {
   formatCompactNumber,
@@ -94,17 +98,15 @@ function StatLine({ agent }: { agent: AgentSpecialistDetail }) {
           key={row.key}
           className="border-b border-black/10 p-4 last:border-b-0 sm:odd:border-r lg:border-r lg:border-b-0 lg:last:border-r-0 dark:border-white/12"
         >
-          <div className="font-mono text-[0.62rem] uppercase tracking-[0.18em] text-zinc-400 dark:text-zinc-500">
-            {row.key}
-          </div>
+          <div className={AGENT_STAT_LABEL_CLASS}>{row.key}</div>
           <div
-            className={`mt-1 text-2xl font-semibold leading-none tracking-[-0.02em] tabular-nums ${
+            className={`mt-1 text-2xl font-semibold tabular-nums ${
               row.primary ? "text-[#8447ff]" : "text-zinc-950 dark:text-white"
             }`}
           >
             {row.value}
           </div>
-          <div className="mt-1 truncate font-mono text-[0.68rem] text-zinc-500 dark:text-zinc-400">
+          <div className="mt-1 truncate text-xs text-zinc-500 dark:text-zinc-400">
             {row.sub}
           </div>
         </div>
@@ -116,14 +118,8 @@ function StatLine({ agent }: { agent: AgentSpecialistDetail }) {
 function SectionHeader({ title, meta }: { title: string; meta?: string }) {
   return (
     <div className="flex items-baseline justify-between gap-3 border-b border-black/10 pb-2 dark:border-white/12">
-      <h2 className="font-mono text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-zinc-950 dark:text-white">
-        {title}
-      </h2>
-      {meta && (
-        <span className="font-mono text-[0.68rem] tracking-[0.06em] text-zinc-400 dark:text-zinc-500">
-          {meta}
-        </span>
-      )}
+      <h2 className={AGENT_SECTION_TITLE_CLASS}>{title}</h2>
+      {meta && <span className={AGENT_SECTION_META_CLASS}>{meta}</span>}
     </div>
   )
 }
@@ -142,7 +138,7 @@ function Chips({
           key={value}
           className={`${
             variant === "negative"
-              ? "border border-zinc-200 px-1.5 py-0.5 font-mono text-[0.66rem] text-zinc-500 line-through dark:border-white/10 dark:text-zinc-500"
+              ? "border border-zinc-200 px-1.5 py-0.5 text-xs text-zinc-500 line-through dark:border-white/10 dark:text-zinc-500"
               : `${AGENT_ROUTE_CHIP_CLASS} border-[#8447ff]/30 text-[#8447ff]`
           }`}
         >
@@ -161,7 +157,7 @@ function Instructions({ instructions }: { instructions: string[] }) {
         meta={`${instructions.length} rules`}
       />
       <div className="mt-3 border border-black/10 bg-zinc-50 dark:border-white/12 dark:bg-white/5">
-        <div className="flex items-center justify-between border-b border-black/10 px-3 py-2 font-mono text-[0.6rem] uppercase tracking-[0.14em] text-zinc-400 dark:border-white/12 dark:text-zinc-500">
+        <div className="flex items-center justify-between border-b border-black/10 px-3 py-2 text-xs uppercase tracking-wide text-zinc-400 dark:border-white/12 dark:text-zinc-500">
           <span>system prompt</span>
           <span className="text-[#8447ff]">live</span>
         </div>
@@ -170,7 +166,7 @@ function Instructions({ instructions }: { instructions: string[] }) {
             .map((instruction, index) => `${index + 1}. ${instruction}`)
             .join("\n")}
         </pre>
-        <div className="flex items-center justify-between border-t border-black/10 px-3 py-2 font-mono text-[0.62rem] uppercase tracking-[0.08em] text-[#8447ff] dark:border-white/12">
+        <div className="flex items-center justify-between border-t border-black/10 px-3 py-2 text-xs uppercase tracking-wide text-[#8447ff] dark:border-white/12">
           <span>Expand</span>
           <Copy className="size-4" />
         </div>
@@ -189,7 +185,7 @@ function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
       <div className="mt-2 overflow-x-auto">
         <table className="w-full min-w-[42rem] border-collapse text-sm">
           <thead>
-            <tr className="border-b border-black/10 font-mono text-[0.62rem] uppercase tracking-[0.12em] text-zinc-400 dark:border-white/12 dark:text-zinc-500">
+            <tr className="border-b border-black/10 text-xs uppercase tracking-wide text-zinc-400 dark:border-white/12 dark:text-zinc-500">
               <th className="py-2 pr-3 text-left font-medium">Document</th>
               <th className="px-3 text-left font-medium">Anchor</th>
               <th className="px-3 text-right font-medium">Reason</th>
@@ -203,14 +199,14 @@ function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
                 className="border-b border-black/5 dark:border-white/10"
               >
                 <td className="py-3 pr-3 align-top">
-                  <div className="text-[1rem] font-semibold tracking-[-0.01em] text-zinc-950 dark:text-white">
+                  <div className="text-base font-semibold text-zinc-950 dark:text-white">
                     {document.title}
                   </div>
                   <div className="mt-1 line-clamp-1 text-xs text-zinc-500 dark:text-zinc-400">
                     {document.description}
                   </div>
                 </td>
-                <td className="px-3 py-3 align-top font-mono text-[0.95rem] text-zinc-500 dark:text-zinc-400">
+                <td className="px-3 py-3 align-top text-sm text-zinc-500 dark:text-zinc-400">
                   {document.anchor_id ?? "summary"}
                 </td>
                 <td className="px-3 py-3 text-right align-top text-xs text-zinc-500 dark:text-zinc-400">
@@ -220,7 +216,7 @@ function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
                   <a
                     href={document.href}
                     aria-label={`Open ${document.title}`}
-                    className="inline-flex items-center justify-end gap-1 font-mono text-[0.62rem] uppercase tracking-[0.08em] text-[#8447ff]"
+                    className="inline-flex items-center justify-end gap-1 text-xs font-medium text-[#8447ff]"
                   >
                     Open
                     <ArrowUpRight className="size-4" />
@@ -245,7 +241,7 @@ function RecentInvocations({ agent }: { agent: AgentSpecialistDetail }) {
       <div className="mt-2 overflow-x-auto">
         <table className="w-full min-w-[38rem] border-collapse text-sm">
           <thead>
-            <tr className="border-b border-black/10 font-mono text-[0.62rem] uppercase tracking-[0.12em] text-zinc-400 dark:border-white/12 dark:text-zinc-500">
+            <tr className="border-b border-black/10 text-xs uppercase tracking-wide text-zinc-400 dark:border-white/12 dark:text-zinc-500">
               <th className="py-2 pr-3 text-left font-medium">Query</th>
               <th className="px-3 text-left font-medium">Repo</th>
               <th className="px-3 text-right font-medium">Saved</th>
@@ -258,7 +254,7 @@ function RecentInvocations({ agent }: { agent: AgentSpecialistDetail }) {
                 key={invocation.id}
                 className="border-b border-black/5 transition-colors hover:bg-zinc-50 dark:border-white/10 dark:hover:bg-white/5"
               >
-                <td className="py-3 pr-3 align-top font-mono text-[0.95rem] text-zinc-800 dark:text-zinc-200">
+                <td className="py-3 pr-3 align-top text-sm text-zinc-800 dark:text-zinc-200">
                   {invocation.session_id ? (
                     <Link
                       to="/v2/metrics"
@@ -271,13 +267,13 @@ function RecentInvocations({ agent }: { agent: AgentSpecialistDetail }) {
                     `"${invocation.prompt}"`
                   )}
                 </td>
-                <td className="px-3 py-3 align-top font-mono text-[0.95rem] text-zinc-500 dark:text-zinc-400">
+                <td className="px-3 py-3 align-top text-sm text-zinc-500 dark:text-zinc-400">
                   {invocation.repo ?? "Taskforce"}
                 </td>
-                <td className="px-3 py-3 text-right align-top font-mono text-[0.95rem] font-semibold text-[#8447ff]">
+                <td className="px-3 py-3 text-right align-top text-sm font-semibold text-[#8447ff]">
                   +{formatCompactNumber(invocation.tokens_saved)}
                 </td>
-                <td className="py-3 pl-3 text-right align-top font-mono text-[0.62rem] text-zinc-400 dark:text-zinc-500">
+                <td className="py-3 pl-3 text-right align-top text-xs text-zinc-400 dark:text-zinc-500">
                   {formatRelativeTime(invocation.created_at)}
                 </td>
               </tr>
@@ -346,9 +342,7 @@ function AgentDetailPage() {
         <div
           className={`${V2_CONTENT_SHELL} flex min-h-[50vh] flex-col items-center justify-center py-12 text-center`}
         >
-          <h1 className="text-xl font-semibold tracking-tight">
-            Specialist not found
-          </h1>
+          <h1 className={AGENT_PAGE_TITLE_CLASS}>Specialist not found</h1>
           <p className="mt-3 max-w-lg text-sm leading-6 text-zinc-500 dark:text-zinc-400">
             This specialist is unavailable or you do not have access.
           </p>
@@ -384,7 +378,7 @@ function AgentDetailPage() {
                 {initials(agent.name)}
               </span>
               <div className="min-w-0">
-                <h2 className={AGENT_NAME_CLASS}>{agent.name}</h2>
+                <h1 className={AGENT_DETAIL_NAME_CLASS}>{agent.name}</h1>
                 <p className={AGENT_ROLE_CLASS}>
                   <span className="font-medium text-zinc-950 dark:text-white">
                     {agent.role}
@@ -399,15 +393,11 @@ function AgentDetailPage() {
             ) : null}
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <span className="inline-flex h-8 items-center gap-2 border border-black/10 px-3 font-mono text-[0.68rem] uppercase tracking-[0.08em] text-emerald-600 dark:border-white/12 dark:text-emerald-400">
-              <span className="size-2 bg-emerald-500" />
+            <span className="inline-flex h-8 items-center gap-2 rounded-md border border-black/10 px-3 text-xs font-medium text-emerald-600 dark:border-white/12 dark:text-emerald-400">
+              <span className="size-1.5 rounded-full bg-emerald-500" />
               Active
             </span>
-            <Button
-              asChild
-              variant="outline"
-              className="h-8 px-3 font-mono text-[0.68rem] uppercase tracking-[0.08em]"
-            >
+            <Button asChild variant="outline" size="sm">
               <Link to="/v2/agents">
                 <ArrowLeft className="size-4" />
                 Back
@@ -462,7 +452,7 @@ function AgentDetailPage() {
         )}
 
         {agentQuery.isFetching && !isHydratingDetail && (
-          <div className="mt-5 inline-flex items-center gap-2 font-mono text-xs text-zinc-400 dark:text-zinc-500">
+          <div className="mt-5 inline-flex items-center gap-2 text-sm text-zinc-400 dark:text-zinc-500">
             <Loader2 className="size-4 animate-spin" />
             Refreshing specialist
           </div>

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -19,8 +19,11 @@ import {
 import {
   AGENT_DESCRIPTION_CLASS,
   AGENT_NAME_CLASS,
+  AGENT_PAGE_TITLE_CLASS,
   AGENT_ROLE_CLASS,
   AGENT_ROUTE_CHIP_CLASS,
+  AGENT_STAT_LABEL_CLASS,
+  AGENT_STAT_VALUE_CLASS,
 } from "@/components/V2/Agents/agentsTypography"
 import { V2_CONTENT_SHELL, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
 
@@ -117,7 +120,7 @@ function TeamStrip({ agents }: { agents: AgentSpecialistSummary[] }) {
   return (
     <section className="grid border border-zinc-950 bg-zinc-950 text-white md:grid-cols-[1.6fr_1fr_1fr_1fr] dark:border-white/15 dark:bg-black">
       <div className="border-b border-white/15 p-4 md:border-r md:border-b-0">
-        <div className="font-mono text-[0.62rem] uppercase tracking-[0.18em] text-white/55">
+        <div className="text-xs uppercase tracking-wide text-white/55">
           Team tokens saved
         </div>
         <div className="mt-2 text-2xl font-semibold leading-none tracking-[-0.02em] tabular-nums">
@@ -134,7 +137,7 @@ function TeamStrip({ agents }: { agents: AgentSpecialistSummary[] }) {
         />
       </div>
       <div className="border-b border-white/15 p-4 md:border-r md:border-b-0">
-        <div className="font-mono text-[0.62rem] uppercase tracking-[0.18em] text-white/55">
+        <div className="text-xs uppercase tracking-wide text-white/55">
           Active
         </div>
         <div className="mt-2 text-2xl font-semibold leading-none tabular-nums">
@@ -157,24 +160,24 @@ function TeamStrip({ agents }: { agents: AgentSpecialistSummary[] }) {
         </div>
       </div>
       <div className="border-b border-white/15 p-4 md:border-r md:border-b-0">
-        <div className="font-mono text-[0.62rem] uppercase tracking-[0.18em] text-white/55">
+        <div className="text-xs uppercase tracking-wide text-white/55">
           Reuse rate
         </div>
         <div className="mt-2 text-2xl font-semibold leading-none tabular-nums">
           {reuseRate}%
         </div>
-        <div className="mt-1 font-mono text-[0.68rem] text-emerald-300">
+        <div className="mt-1 text-xs text-emerald-300">
           {invocationCount.toLocaleString()} routed runs
         </div>
       </div>
       <div className="p-4">
-        <div className="font-mono text-[0.62rem] uppercase tracking-[0.18em] text-white/55">
+        <div className="text-xs uppercase tracking-wide text-white/55">
           Linked docs
         </div>
         <div className="mt-2 text-2xl font-semibold leading-none tabular-nums">
           {linkedDocsCount}
         </div>
-        <div className="mt-1 font-mono text-[0.68rem] text-amber-200">
+        <div className="mt-1 text-xs text-amber-200">
           specialist memory
         </div>
       </div>
@@ -217,7 +220,7 @@ function AgentCard({
         </div>
       </div>
 
-      <div className="mt-3 flex flex-wrap items-center gap-1.5 font-mono text-[0.66rem] text-zinc-500 dark:text-zinc-400">
+      <div className="mt-3 flex flex-wrap items-center gap-1.5 text-xs text-zinc-500 dark:text-zinc-400">
         <span className="text-zinc-400 dark:text-zinc-600">route_when:</span>
         {tags.map((tag) => (
           <span key={tag} className={AGENT_ROUTE_CHIP_CLASS}>
@@ -242,13 +245,11 @@ function AgentCard({
 
       <div className="mt-4 grid grid-cols-[1.35fr_0.8fr_0.8fr] border-t border-black/10 pt-3 dark:border-white/12">
         <div className="border-r border-black/10 pr-3 dark:border-white/12">
-          <div className="font-mono text-[0.6rem] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-            Tokens saved
-          </div>
-          <div className="mt-1 font-mono text-[0.95rem] font-semibold tabular-nums text-zinc-950 dark:text-white">
+          <div className={AGENT_STAT_LABEL_CLASS}>Tokens saved</div>
+          <div className={cn("mt-1", AGENT_STAT_VALUE_CLASS)}>
             {formatCompactNumber(agent.tokens_saved)}
             {agent.invocations_count > 0 && (
-              <span className="ml-1 text-[0.6rem] text-emerald-600 dark:text-emerald-400">
+              <span className="ml-1 text-xs text-emerald-600 dark:text-emerald-400">
                 live
               </span>
             )}
@@ -261,24 +262,20 @@ function AgentCard({
           />
         </div>
         <div className="border-r border-black/10 px-3 dark:border-white/12">
-          <div className="font-mono text-[0.6rem] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-            Runs
-          </div>
-          <div className="mt-1 font-mono text-[0.95rem] font-semibold tabular-nums text-zinc-950 dark:text-white">
+          <div className={AGENT_STAT_LABEL_CLASS}>Runs</div>
+          <div className={cn("mt-1", AGENT_STAT_VALUE_CLASS)}>
             {agent.invocations_count}
           </div>
         </div>
         <div className="pl-3">
-          <div className="font-mono text-[0.6rem] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-            Docs
-          </div>
-          <div className="mt-1 font-mono text-[0.95rem] font-semibold tabular-nums text-zinc-950 dark:text-white">
+          <div className={AGENT_STAT_LABEL_CLASS}>Docs</div>
+          <div className={cn("mt-1", AGENT_STAT_VALUE_CLASS)}>
             {agent.linked_docs_count}
           </div>
         </div>
       </div>
 
-      <div className="mt-4 flex items-center justify-between gap-3 font-mono text-[0.62rem] uppercase tracking-[0.08em] text-zinc-400 dark:text-zinc-500">
+      <div className="mt-4 flex items-center justify-between gap-3 text-xs uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
         <span>{formatRelativeTime(agent.last_invoked_at)}</span>
         <span
           aria-hidden="true"
@@ -298,7 +295,7 @@ function EmptyAgents({ isDemoMode }: { isDemoMode: boolean }) {
       <div className="mx-auto grid size-12 place-items-center border border-zinc-200 bg-zinc-50 text-[#8447ff] dark:border-white/15 dark:bg-white/5">
         <Bot className="size-6" />
       </div>
-      <h2 className="mt-5 text-xl font-semibold tracking-tight">
+      <h2 className={cn("mt-5", AGENT_PAGE_TITLE_CLASS)}>
         No specialists yet
       </h2>
       <p className="mx-auto mt-2 max-w-lg text-sm leading-6 text-zinc-500 dark:text-zinc-400">
@@ -334,31 +331,19 @@ function TaskforceAgents() {
       className={`${V2_PAGE_FRAME} gap-6 bg-white font-sans text-zinc-950 dark:bg-zinc-950 dark:text-white`}
     >
       <div className={`${V2_CONTENT_SHELL} gap-6 py-6`}>
-        <header className="grid gap-5 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <header className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <div className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-zinc-400 dark:text-zinc-500">
-              Agents
-            </div>
-            <h1 className="mt-2 max-w-3xl text-4xl font-semibold leading-[0.95] tracking-[-0.045em] md:text-5xl">
-              Reusable{" "}
-              <em className="not-italic text-[#8447ff]">specialists</em>,
-              packaged from your work.
-            </h1>
+            <h1 className={AGENT_PAGE_TITLE_CLASS}>Agents</h1>
+            <p className="mt-1 max-w-3xl text-sm text-zinc-500 dark:text-zinc-400">
+              Reusable specialists packaged from your work.
+            </p>
           </div>
-          <div className="flex flex-wrap gap-2 font-mono text-[0.68rem] uppercase tracking-[0.08em]">
-            <Button
-              type="button"
-              variant="outline"
-              className="h-8 border-zinc-950 px-3 font-mono text-[0.68rem] uppercase tracking-[0.08em] dark:border-white/30"
-            >
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="outline" size="sm">
               Sort: impact
             </Button>
-            <Button
-              type="button"
-              disabled
-              className="h-8 bg-zinc-950 px-3 font-mono text-[0.68rem] uppercase tracking-[0.08em] text-white disabled:opacity-60 dark:bg-white dark:text-zinc-950"
-            >
-              + New specialist
+            <Button type="button" size="sm" disabled>
+              New specialist
             </Button>
           </div>
         </header>
@@ -382,7 +367,7 @@ function TaskforceAgents() {
         </div>
 
         {agentsQuery.isFetching && !agentsQuery.isLoading && (
-          <div className="mt-4 inline-flex items-center gap-2 font-mono text-xs text-zinc-400 dark:text-zinc-500">
+          <div className="mt-4 inline-flex items-center gap-2 text-sm text-zinc-400 dark:text-zinc-500">
             <Loader2 className="size-3 animate-spin" />
             Refreshing specialists
           </div>

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -149,12 +149,12 @@ test("direct specialist URL renders detail instead of the agents grid", async ({
 
   await expect(page).toHaveURL(/\/v2\/agents\/jensen$/)
   await expect(
-    page.getByRole("heading", { name: "Jensen", level: 2 }),
+    page.getByRole("heading", { name: "Jensen", level: 1 }),
   ).toBeVisible()
   await expect(page.getByText("Operating instructions")).toBeVisible()
-  await expect(
-    page.getByRole("heading", { name: /Reusable .*specialists/i }),
-  ).not.toBeVisible()
+  await expect(page.getByRole("heading", { name: "Agents", level: 1 })).toHaveCount(
+    0,
+  )
 })
 
 test("agent detail navigation does not flash no-access or not-found", async ({
@@ -215,9 +215,7 @@ test("agents grid links to specialist detail and session metrics", async ({
 
   await page.goto("/v2/agents")
 
-  await expect(
-    page.getByRole("heading", { name: /Reusable .*specialists/i }),
-  ).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Agents", level: 1 })).toBeVisible()
   await expect(page.getByTestId("agents-grid")).toBeVisible()
   await expect(
     page.getByRole("heading", { name: "Jensen", level: 3 }),
@@ -229,7 +227,7 @@ test("agents grid links to specialist detail and session metrics", async ({
   await page.getByRole("link", { name: /open specialist jensen/i }).click()
   await expect(page).toHaveURL(/\/v2\/agents\/jensen$/)
   await expect(
-    page.getByRole("heading", { name: "Jensen", level: 2 }),
+    page.getByRole("heading", { name: "Jensen", level: 1 }),
   ).toBeVisible()
   await expect(page.getByText("Operating instructions")).toBeVisible()
 


### PR DESCRIPTION
## Summary
- Standardize Agents list and specialist detail font sizes to match other v2 tabs (`text-2xl` page titles, `text-sm` body, `text-xs` labels).
- Centralize typography tokens in `agentsTypography.ts` for listing cards, detail headers, stats, and section labels.
- Update Playwright routing specs for the new page title and detail heading level.

## Test plan
- [ ] Open `/v2/agents` and confirm title matches Library/Metrics scale
- [ ] Open a specialist detail page and confirm name/sections use the same scale
- [ ] Run `npx playwright test tests/agents-routing.spec.ts`

Made with [Cursor](https://cursor.com)