### PR TITLE
Add minimal Library header

### DIFF
--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -14,7 +14,6 @@ import {
   FileText,
   Folder,
   FolderOpen,
-  FolderPlus,
   MoreHorizontal,
   Pencil,
   Plus,
@@ -517,6 +516,10 @@ function TaskforceLibrary() {
     (libraryView === "files" || folders.length === 0)
   const isFolderEmpty =
     !isLoading && documents.length > 0 && visibleDocuments.length === 0
+  const totalDocumentCount = documentsQuery.data?.count ?? allDocuments.length
+  const teamSharedDocumentCount = allDocuments.filter(
+    (document) => document.visibility === "organization",
+  ).length
   const canMutateLibrary =
     !moveDocumentMutation.isPending &&
     !moveFolderMutation.isPending &&
@@ -646,8 +649,35 @@ function TaskforceLibrary() {
       }}
     >
       <section className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden">
-        <div className="sticky top-0 z-20 flex shrink-0 flex-col gap-4 border-b bg-background/95 py-3 backdrop-blur lg:flex-row lg:items-end lg:justify-between">
-          <h1 className="text-2xl font-semibold">Library</h1>
+        <div className="sticky top-0 z-20 flex shrink-0 flex-col gap-4 border-b bg-background/95 py-3 backdrop-blur">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <div className="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-muted-foreground">
+                Library · {totalDocumentCount} documents ·{" "}
+                {teamSharedDocumentCount} shared with team
+              </div>
+              <h1 className="mt-1 text-2xl font-semibold">Library</h1>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="w-fit"
+                onClick={() => setCreateFolderOpen(true)}
+              >
+                + Folder
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                className="w-fit"
+                onClick={() => setCreateDocumentOpen(true)}
+              >
+                + New document
+              </Button>
+            </div>
+          </div>
           <div className="flex flex-wrap items-center gap-2">
             <div
               role="tablist"
@@ -687,25 +717,6 @@ function TaskforceLibrary() {
                 onClick={() => setLibraryView("folders")}
               />
             </div>
-            <Button
-              type="button"
-              size="sm"
-              className="w-fit"
-              onClick={() => setCreateDocumentOpen(true)}
-            >
-              <Plus className="size-4" />
-              New document
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="w-fit"
-              onClick={() => setCreateFolderOpen(true)}
-            >
-              <FolderPlus className="size-4" />
-              Create folder
-            </Button>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Updates the base V2 Library sticky header to use the `library-minimal` top-section structure.
- Adds the metadata line `Library · <documents> documents · <shared> shared with team` above the existing `Library` title.
- Moves the primary actions into the header as `+ Folder` and `+ New document`, preserving existing dialogs.
- Keeps current Library font sizing and leaves the rest of the page design unchanged.

## Validation
- `npx biome check --write --unsafe src/routes/v2/library.tsx`
- `npx tsc -p tsconfig.build.json --noEmit`
- `VITE_FIREBASE_API_KEY=... VITE_API_URL=http://localhost:8000 npx vite build`
- `git diff --check`

Note: Vite build still emits the existing Node 18 version warning and large chunk warning, but exits successfully.
