### PR TITLE
Align v2 tab page padding with Metrics

### DIFF
--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -26,6 +26,7 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { usePersistentState } from "@/hooks/usePersistentState"
+import { V2_PAGE_CONTENT } from "@/components/V2/v2PageShell"
 import { MethodologyLink } from "./MethodologyLink"
 import { MetricBreakdown } from "./MetricBreakdown"
 import { MetricCard } from "./MetricCard"
@@ -268,7 +269,7 @@ export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
     })
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-6">
+    <div className={V2_PAGE_CONTENT}>
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold">Metrics</h1>

--- a/src/components/V2/v2PageShell.ts
+++ b/src/components/V2/v2PageShell.ts
@@ -1,7 +1,13 @@
-/** Horizontal inset for v2 pages — matches Library document detail layout. */
-export const V2_CONTENT_SHELL =
-  "mx-auto flex w-full max-w-none flex-col px-4 md:px-6 lg:px-8"
-
-/** Scrollable v2 page frame inside TaskforceShell (no negative margins). */
+/** Scrollable v2 page frame inside TaskforceShell (no extra horizontal inset). */
 export const V2_PAGE_FRAME =
   "flex min-h-0 flex-1 flex-col overflow-y-auto"
+
+/**
+ * Inner page content padding — matches the Metrics tab (p-6 inside shell main
+ * padding). Use on Library, Agents, Metrics, and other v2 tab bodies.
+ */
+export const V2_PAGE_CONTENT =
+  "flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-6"
+
+/** @deprecated Prefer V2_PAGE_CONTENT for tab pages. */
+export const V2_CONTENT_SHELL = V2_PAGE_CONTENT

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -30,7 +30,7 @@ import {
   formatCompactNumber,
   formatRelativeTime,
 } from "@/components/V2/Agents/formatters"
-import { V2_CONTENT_SHELL, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
+import { V2_PAGE_CONTENT, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
 
 export const Route = createFileRoute("/v2/agents/$slug")({
   component: AgentDetailPage,
@@ -43,7 +43,7 @@ export const Route = createFileRoute("/v2/agents/$slug")({
   }),
 })
 
-const AGENTS_DETAIL_SHELL = `${V2_CONTENT_SHELL} gap-6 py-6`
+const AGENTS_DETAIL_SHELL = V2_PAGE_CONTENT
 
 function initials(name: string) {
   return name
@@ -340,7 +340,7 @@ function AgentDetailPage() {
         className={`${V2_PAGE_FRAME} bg-white font-sans dark:bg-zinc-950`}
       >
         <div
-          className={`${V2_CONTENT_SHELL} flex min-h-[50vh] flex-col items-center justify-center py-12 text-center`}
+          className={`${V2_PAGE_CONTENT} min-h-[50vh] items-center justify-center text-center`}
         >
           <h1 className={AGENT_PAGE_TITLE_CLASS}>Specialist not found</h1>
           <p className="mt-3 max-w-lg text-sm leading-6 text-zinc-500 dark:text-zinc-400">

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -25,7 +25,7 @@ import {
   AGENT_STAT_LABEL_CLASS,
   AGENT_TABLE_HEADER_CLASS,
 } from "@/components/V2/Agents/agentsTypography"
-import { V2_CONTENT_SHELL, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
+import { V2_PAGE_CONTENT, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
 
 export const Route = createFileRoute("/v2/agents")({
   component: TaskforceAgents,
@@ -259,7 +259,7 @@ function AgentsIndex() {
     <section
       className={`${V2_PAGE_FRAME} bg-background font-sans text-foreground`}
     >
-      <div className={`${V2_CONTENT_SHELL} gap-4 py-5`}>
+      <div className={V2_PAGE_CONTENT}>
         <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div>
             <div className={AGENT_EYEBROW_CLASS}>

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -809,14 +809,14 @@ function TaskforceDocumentDetail() {
     >
       <article
         className={cn(
-          "mx-auto flex w-full max-w-none flex-col px-4 md:px-6 lg:px-8",
+          "mx-auto flex w-full max-w-none flex-col p-6",
           isSplit ? "md:min-h-0 md:flex-1 md:overflow-hidden" : "pb-16",
         )}
       >
         <div
           data-testid="v2-document-sticky-header"
           className={cn(
-            "sticky top-0 z-20 -mx-4 border-b bg-background/95 px-4 pt-3 pb-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:-mx-6 md:px-6 lg:-mx-8 lg:px-8",
+            "sticky top-0 z-20 -mx-6 border-b bg-background/95 px-6 pt-3 pb-3 backdrop-blur supports-[backdrop-filter]:bg-background/80",
             isSplit && "md:shrink-0",
           )}
         >

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -648,7 +648,7 @@ function TaskforceLibrary() {
         onDelete: requestDeleteDocument,
       }}
     >
-      <section className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden">
+      <section className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden p-6">
         <div className="sticky top-0 z-20 flex shrink-0 flex-col gap-4 border-b bg-background/95 py-3 backdrop-blur">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div>


### PR DESCRIPTION
## Summary
- Add shared `V2_PAGE_CONTENT` (`p-6`) as the canonical inner inset for v2 tab bodies.
- Apply it to Library, Agents, and Metrics so horizontal padding matches.
- Update Library document detail sticky header margins for the new `p-6` shell.

## Test plan
- [ ] Compare `/v2/library`, `/v2/agents`, and `/v2/metrics` side by side — content should align to the same left/right inset
- [ ] Open a library document and confirm the sticky header still spans full width

Made with [Cursor](https://cursor.com)