### PR TITLE
[codex] Add experimental metrics UI

### DIFF
--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/api/v2Taskforce"
 import type { UserPublic } from "@/client"
 import { useDemoMode } from "@/components/demo-mode-provider"
+import { useExperimentalMode } from "@/components/experimental-mode-provider"
 import { Badge } from "@/components/ui/badge"
 import {
   Table,
@@ -25,8 +26,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { usePersistentState } from "@/hooks/usePersistentState"
 import { V2_PAGE_CONTENT } from "@/components/V2/v2PageShell"
+import { usePersistentState } from "@/hooks/usePersistentState"
+import { formatDelta, formatMetricValue } from "./formatters"
 import { MethodologyLink } from "./MethodologyLink"
 import { MetricBreakdown } from "./MetricBreakdown"
 import { MetricCard } from "./MetricCard"
@@ -39,7 +41,11 @@ type Props = {
 }
 
 const PRIMARY_METRICS = ["tokens_saved", "usd_saved", "reuse_rate"]
-const SECONDARY_METRICS = ["tokens_consumed", "usd_consumed"]
+const SECONDARY_METRICS = [
+  "tokens_consumed",
+  "usd_consumed",
+  "documents_touched",
+]
 const SESSION_PRICING_MODEL_ID = "claude-opus-4-7"
 const SESSION_PRIMARY_METRICS = [
   "tokens_saved",
@@ -118,6 +124,12 @@ const SESSION_METRIC_DEFINITIONS: Record<string, MetricDefinitionPublic> = {
   },
 }
 
+const WINDOW_COPY: Record<MetricsWindow, { label: string; title: string }> = {
+  "7d": { label: "7d", title: "this week" },
+  "30d": { label: "30d", title: "in the last 30 days" },
+  all: { label: "all", title: "all time" },
+}
+
 function toMetricNumber(value: string | number | null | undefined) {
   if (value == null) return 0
   if (typeof value === "number") return value
@@ -184,6 +196,7 @@ function formatScore(score: number): string {
 // the MetricsScopeToggle import and the `scope` state below.
 export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
   const { isDemoMode } = useDemoMode()
+  const { isExperimentalMode } = useExperimentalMode()
   const [window, setWindow] = useState<MetricsWindow>("7d")
   const scopedSessionId = sessionId?.trim() || undefined
   const sessionShortId = scopedSessionId?.slice(0, 8)
@@ -254,7 +267,7 @@ export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
   const tokensConsumed = metrics.tokens_consumed
   const usdOffset = toMetricNumber(metrics.usd_saved?.total)
   const usdSpent = toMetricNumber(metrics.usd_consumed?.total)
-  const usdNetSaved = {
+  const usdNetSaved: MetricValuePublic = {
     total: String(usdOffset - usdSpent),
     delta_vs_prev_window: null,
     series: [],
@@ -267,6 +280,30 @@ export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
       const total = Number.parseFloat(m.total)
       return !Number.isFinite(total) || total === 0
     })
+
+  if (isExperimentalMode) {
+    return (
+      <ExperimentalMetricsPage
+        definitionsByName={definitionsByName}
+        isEmpty={isEmpty}
+        metrics={metrics}
+        metricsQueryIsError={metricsQuery.isError}
+        savingsV2Flag={savingsV2Flag}
+        scopedSessionId={scopedSessionId}
+        sessionLogEntries={sessionLogEntries}
+        sessionLogIsError={sessionLogQuery.isError}
+        sessionLogIsLoading={sessionLogQuery.isLoading}
+        sessionMetricValues={sessionMetricValues}
+        sessionSavings={sessionSavings}
+        sessionShortId={sessionShortId}
+        tokensConsumed={tokensConsumed}
+        tokensSaved={tokensSaved}
+        usdNetSaved={usdNetSaved}
+        window={window}
+        onWindowChange={setWindow}
+      />
+    )
+  }
 
   return (
     <div className={V2_PAGE_CONTENT}>
@@ -385,6 +422,708 @@ export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
       </section>
     </div>
   )
+}
+
+type ExperimentalMetricsPageProps = {
+  definitionsByName: Record<string, MetricDefinitionPublic>
+  isEmpty: boolean
+  metrics: Record<string, MetricValuePublic>
+  metricsQueryIsError: boolean
+  savingsV2Flag: boolean
+  scopedSessionId: string | undefined
+  sessionLogEntries: TaskforceSessionLogEntry[]
+  sessionLogIsError: boolean
+  sessionLogIsLoading: boolean
+  sessionMetricValues: Record<string, MetricValuePublic>
+  sessionSavings: TaskforceSessionSavingsResponse | null
+  sessionShortId: string | undefined
+  tokensConsumed: MetricValuePublic | undefined
+  tokensSaved: MetricValuePublic | undefined
+  usdNetSaved: MetricValuePublic
+  window: MetricsWindow
+  onWindowChange: (window: MetricsWindow) => void
+}
+
+function ExperimentalMetricsPage({
+  definitionsByName,
+  isEmpty,
+  metrics,
+  metricsQueryIsError,
+  savingsV2Flag,
+  scopedSessionId,
+  sessionLogEntries,
+  sessionLogIsError,
+  sessionLogIsLoading,
+  sessionMetricValues,
+  sessionSavings,
+  sessionShortId,
+  tokensConsumed,
+  tokensSaved,
+  usdNetSaved,
+  window,
+  onWindowChange,
+}: ExperimentalMetricsPageProps) {
+  if (scopedSessionId) {
+    return (
+      <ExperimentalSessionMetrics
+        entries={sessionLogEntries}
+        isError={sessionLogIsError}
+        isLoading={sessionLogIsLoading}
+        scopedSessionId={scopedSessionId}
+        sessionMetricValues={sessionMetricValues}
+        sessionSavings={sessionSavings}
+        sessionShortId={sessionShortId}
+      />
+    )
+  }
+
+  const savedTokens = tokensSaved?.total ?? 0
+  const savedUsd = metrics.usd_saved?.total ?? 0
+  const consumedTokens = tokensConsumed?.total ?? 0
+  const reuseRate = metrics.reuse_rate?.total ?? 0
+  const savingsRatio =
+    toMetricNumber(consumedTokens) > 0
+      ? toMetricNumber(savedTokens) / toMetricNumber(consumedTokens)
+      : 0
+  const documentsTouched = metrics.documents_touched
+  const windowCopy = WINDOW_COPY[window]
+
+  return (
+    <div
+      data-testid="metrics-experimental-page"
+      className={`${V2_PAGE_CONTENT} bg-background font-sans text-foreground`}
+    >
+      <header className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <div>
+          <div className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
+            Metrics · {windowCopy.label} · personal
+          </div>
+          <h1 className="mt-2 text-3xl font-semibold leading-none tracking-tight md:text-4xl">
+            You saved{" "}
+            <span className="text-primary">
+              {formatMetricValue(savedTokens, "compact-int")} tokens
+            </span>{" "}
+            {windowCopy.title}.
+          </h1>
+        </div>
+        <MetricsTimeRange value={window} onChange={onWindowChange} />
+      </header>
+
+      {metricsQueryIsError && (
+        <div className="border border-destructive bg-destructive/10 p-3 text-sm">
+          Failed to load metrics. Try again in a moment.
+        </div>
+      )}
+
+      {isEmpty && (
+        <div className="border border-dashed border-border p-6 text-sm text-muted-foreground">
+          No metrics yet. Connect your MCP and start using Taskforce. Events
+          show up here within a minute of the agent's first call.
+        </div>
+      )}
+
+      <section className="grid border border-foreground bg-foreground text-background lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
+        <div className="px-5 py-6 md:px-7">
+          <div className="font-mono text-xs uppercase tracking-[0.18em] opacity-70">
+            Tokens saved · {windowCopy.label}
+          </div>
+          <div className="mt-3 text-6xl font-semibold leading-[0.9] tracking-tight tabular-nums md:text-7xl">
+            {formatMetricValue(savedTokens, "compact-int")}
+          </div>
+          <div className="mt-4 font-mono text-xs tracking-wide text-emerald-300">
+            {formatHeroDelta(tokensSaved, "compact-int")}
+          </div>
+          <div className="mt-2 text-sm opacity-70">
+            {formatMetricValue(savedUsd, "usd")} offset ·{" "}
+            {formatMetricValue(usdNetSaved.total, "usd")} net saved
+          </div>
+        </div>
+        <div className="flex flex-col gap-4 border-t border-background/20 p-5 lg:border-t-0 lg:border-l">
+          <div>
+            <div className="font-mono text-xs uppercase tracking-[0.16em] opacity-70">
+              Daily trend
+            </div>
+            <ExperimentalSparkline series={tokensSaved?.series ?? []} />
+          </div>
+          <div className="grid border border-background/20 sm:grid-cols-2">
+            <ExperimentalRatioCell
+              label="Reuse rate"
+              value={formatMetricValue(reuseRate, "ratio")}
+            />
+            <ExperimentalRatioCell
+              label="Saved / used"
+              value={`${formatRatioValue(savingsRatio)}x`}
+              className="border-t border-background/20 sm:border-t-0 sm:border-l"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="grid border border-border md:grid-cols-[10rem_minmax(0,1fr)]">
+        <div className="border-b border-border bg-muted/40 p-4 md:border-r md:border-b-0">
+          <div className="font-mono text-xs uppercase tracking-[0.16em] text-primary">
+            Plain-English
+          </div>
+          <div className="mt-2 text-sm font-semibold">What this means</div>
+        </div>
+        <p className="max-w-4xl p-4 text-sm leading-6 text-foreground">
+          Taskforce avoided{" "}
+          <b>{formatMetricValue(savedTokens, "compact-int")} tokens</b> and
+          offset <b>{formatMetricValue(savedUsd, "usd")}</b> while using{" "}
+          <b>{formatMetricValue(consumedTokens, "compact-int")} tokens</b>. The
+          current reuse rate is{" "}
+          <span className="font-mono text-primary">
+            {formatMetricValue(reuseRate, "ratio")}
+          </span>
+          , with net savings of{" "}
+          <b>{formatMetricValue(usdNetSaved.total, "usd")}</b> after model
+          spend.
+        </p>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
+        <ExperimentalTrendPanel
+          title="Reuse trend"
+          kicker="Tokens saved · daily"
+          series={tokensSaved?.series ?? []}
+        />
+        <ExperimentalBreakdownPanel
+          title="Where savings came from"
+          kicker="Savings by source"
+          rows={tokensSaved?.breakdown_by_source ?? []}
+        />
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {[
+          ["tokens_consumed", metrics.tokens_consumed],
+          ["usd_consumed", metrics.usd_consumed],
+          ["documents_touched", documentsTouched],
+        ].map(([name, value]) => {
+          const def = definitionsByName[name as string]
+          if (!def) return null
+          return (
+            <ExperimentalMetricTile
+              key={name as string}
+              definition={def}
+              value={value as MetricValuePublic | undefined}
+            />
+          )
+        })}
+        <ExperimentalMetricTile
+          definition={USD_NET_SAVED_DEFINITION}
+          value={usdNetSaved}
+        />
+      </section>
+
+      {savingsV2Flag && (
+        <section className="grid gap-4 md:grid-cols-3">
+          {[
+            "avoided_rediscovery",
+            "avoided_rediscovery_usd",
+            "documents_consulted",
+          ].map((name) => {
+            const def = definitionsByName[name]
+            const value = metrics[name]
+            if (!def) return null
+            return (
+              <ExperimentalMetricTile
+                key={name}
+                definition={def}
+                value={value}
+              />
+            )
+          })}
+        </section>
+      )}
+
+      <ExperimentalBreakdownPanel
+        title="Top models by tokens used"
+        kicker="Model usage"
+        rows={tokensConsumed?.top_models ?? []}
+      />
+
+      <MethodologyLink />
+    </div>
+  )
+}
+
+function ExperimentalSessionMetrics({
+  entries,
+  isError,
+  isLoading,
+  scopedSessionId,
+  sessionMetricValues,
+  sessionSavings,
+  sessionShortId,
+}: {
+  entries: TaskforceSessionLogEntry[]
+  isError: boolean
+  isLoading: boolean
+  scopedSessionId: string
+  sessionMetricValues: Record<string, MetricValuePublic>
+  sessionSavings: TaskforceSessionSavingsResponse | null
+  sessionShortId: string | undefined
+}) {
+  const tokensSaved = sessionMetricValues.tokens_saved
+  const usdSaved = sessionMetricValues.usd_saved
+  const documentsConsulted = sessionMetricValues.documents_consulted
+  const firstSeen = sessionSavings?.occurred_at_first
+  const lastSeen = sessionSavings?.occurred_at_last
+
+  return (
+    <div
+      data-testid="metrics-experimental-session-page"
+      className={`${V2_PAGE_CONTENT} bg-background font-sans text-foreground`}
+    >
+      <header className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <div>
+          <div className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
+            Metrics · session · {sessionShortId}
+          </div>
+          <h1 className="mt-2 text-3xl font-semibold leading-none tracking-tight md:text-4xl">
+            This session saved{" "}
+            <span className="text-primary">
+              {formatMetricValue(tokensSaved?.total, "compact-int")} tokens
+            </span>
+            .
+          </h1>
+        </div>
+        <Link
+          to="/v2/metrics"
+          search={{}}
+          className="border border-border px-3 py-2 text-sm font-medium text-foreground underline-offset-4 hover:bg-muted"
+        >
+          view all metrics →
+        </Link>
+      </header>
+
+      <section className="grid border border-foreground bg-foreground text-background lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
+        <div className="px-5 py-6 md:px-7">
+          <div className="font-mono text-xs uppercase tracking-[0.18em] opacity-70">
+            Session tokens saved
+          </div>
+          <div className="mt-3 text-6xl font-semibold leading-[0.9] tracking-tight tabular-nums md:text-7xl">
+            {formatMetricValue(tokensSaved?.total, "compact-int")}
+          </div>
+          <div className="mt-4 text-sm opacity-70">
+            {formatMetricValue(usdSaved?.total, "usd")} estimated savings ·{" "}
+            {formatMetricValue(documentsConsulted?.total, "count")} documents
+            consulted
+          </div>
+        </div>
+        <div className="grid border-t border-background/20 sm:grid-cols-2 lg:border-t-0 lg:border-l">
+          <ExperimentalRatioCell
+            label="Documents"
+            value={formatMetricValue(documentsConsulted?.total, "count")}
+          />
+          <ExperimentalRatioCell
+            label="Pricing model"
+            value={sessionSavings?.pricing_model_id ?? SESSION_PRICING_MODEL_ID}
+            className="border-t border-background/20 sm:border-t-0 sm:border-l lg:border-l-0 xl:border-l"
+          />
+          <ExperimentalRatioCell
+            label="First event"
+            value={firstSeen ? formatSessionDate(firstSeen) : "No event"}
+            className="border-t border-background/20"
+          />
+          <ExperimentalRatioCell
+            label="Last event"
+            value={lastSeen ? formatSessionDate(lastSeen) : "No event"}
+            className="border-t border-background/20 sm:border-l"
+          />
+        </div>
+      </section>
+
+      <section className="grid border border-border md:grid-cols-[10rem_minmax(0,1fr)]">
+        <div className="border-b border-border bg-muted/40 p-4 md:border-r md:border-b-0">
+          <div className="font-mono text-xs uppercase tracking-[0.16em] text-primary">
+            Session
+          </div>
+          <div className="mt-2 text-sm font-semibold">What this means</div>
+        </div>
+        <p className="max-w-4xl p-4 text-sm leading-6 text-foreground">
+          Session{" "}
+          <code className="bg-muted px-1.5 py-0.5 font-mono text-xs">
+            {scopedSessionId}
+          </code>{" "}
+          consulted{" "}
+          <b>{formatMetricValue(documentsConsulted?.total, "count")}</b>{" "}
+          documents and avoided{" "}
+          <b>{formatMetricValue(tokensSaved?.total, "compact-int")} tokens</b>,
+          worth about <b>{formatMetricValue(usdSaved?.total, "usd")}</b> under{" "}
+          {sessionSavings?.pricing_model_id ?? SESSION_PRICING_MODEL_ID}{" "}
+          pricing.
+        </p>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {SESSION_PRIMARY_METRICS.map((name) => (
+          <ExperimentalMetricTile
+            key={name}
+            definition={SESSION_METRIC_DEFINITIONS[name]}
+            value={sessionMetricValues[name]}
+          />
+        ))}
+      </section>
+
+      <ExperimentalSessionLog
+        entries={entries}
+        isError={isError}
+        isLoading={isLoading}
+      />
+
+      <MethodologyLink />
+    </div>
+  )
+}
+
+function ExperimentalMetricTile({
+  definition,
+  value,
+}: {
+  definition: MetricDefinitionPublic
+  value: MetricValuePublic | undefined
+}) {
+  const total = formatMetricValue(value?.total, definition.presentation.format)
+  const delta =
+    definition.presentation.trend && value?.delta_vs_prev_window != null
+      ? formatDelta(value.delta_vs_prev_window, definition.presentation.format)
+      : null
+
+  return (
+    <div className="border border-border bg-background p-4">
+      <div className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+        {definition.display_name}
+      </div>
+      <div className="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
+        {total}
+      </div>
+      {delta && (
+        <div className="mt-1 font-mono text-xs text-muted-foreground">
+          {delta.sign === "flat"
+            ? "No change"
+            : `${delta.sign === "up" ? "▲" : "▼"} ${delta.label} vs previous`}
+        </div>
+      )}
+      <p className="mt-3 text-xs leading-5 text-muted-foreground">
+        {definition.description}
+      </p>
+    </div>
+  )
+}
+
+function ExperimentalRatioCell({
+  className,
+  label,
+  value,
+}: {
+  className?: string
+  label: string
+  value: string
+}) {
+  return (
+    <div className={`min-w-0 p-4 ${className ?? ""}`}>
+      <div className="truncate text-lg font-semibold tracking-tight tabular-nums">
+        {value}
+      </div>
+      <div className="mt-1 font-mono text-xs uppercase tracking-[0.12em] opacity-70">
+        {label}
+      </div>
+    </div>
+  )
+}
+
+function ExperimentalSparkline({
+  series,
+}: {
+  series: MetricValuePublic["series"]
+}) {
+  const points = buildPolyline(series, 100, 38, 0)
+  return (
+    <div className="mt-2 h-12">
+      {points ? (
+        <svg
+          viewBox="0 0 100 38"
+          preserveAspectRatio="none"
+          className="block h-full w-full"
+          aria-hidden="true"
+        >
+          <polyline
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            points={points}
+          />
+        </svg>
+      ) : (
+        <div className="grid h-full place-items-center border border-background/20 text-xs opacity-70">
+          No trend data
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ExperimentalTrendPanel({
+  kicker,
+  series,
+  title,
+}: {
+  kicker: string
+  series: MetricValuePublic["series"]
+  title: string
+}) {
+  const points = buildPolyline(series, 360, 132, 12)
+  const areaPoints = points ? `${points} 360,132 0,132` : ""
+
+  return (
+    <section className="border border-border bg-background p-4">
+      <div className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+        {kicker}
+      </div>
+      <h2 className="mt-1 text-sm font-semibold">{title}</h2>
+      <div className="mt-4 h-44">
+        {points ? (
+          <svg
+            role="img"
+            aria-label={title}
+            viewBox="0 0 360 150"
+            preserveAspectRatio="none"
+            className="block h-full w-full text-primary"
+          >
+            <title>{title}</title>
+            <polygon points={areaPoints} fill="currentColor" opacity="0.12" />
+            <polyline
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              vectorEffect="non-scaling-stroke"
+              points={points}
+            />
+            <ExperimentalXAxisLabels series={series} />
+          </svg>
+        ) : (
+          <div className="grid h-full place-items-center border border-dashed border-border text-sm text-muted-foreground">
+            No data in this window.
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function ExperimentalXAxisLabels({
+  series,
+}: {
+  series: MetricValuePublic["series"]
+}) {
+  if (series.length === 0) return null
+  const indexes =
+    series.length === 1
+      ? [0]
+      : [0, Math.floor(series.length / 2), series.length - 1]
+  const uniqueIndexes = Array.from(new Set(indexes))
+  return (
+    <>
+      {uniqueIndexes.map((index) => {
+        const x =
+          series.length === 1 ? 180 : (index / (series.length - 1)) * 360
+        return (
+          <text
+            key={`${series[index].day}-${index}`}
+            x={x}
+            y={146}
+            textAnchor={
+              index === 0
+                ? "start"
+                : index === series.length - 1
+                  ? "end"
+                  : "middle"
+            }
+            fontSize="10"
+            fill="currentColor"
+            opacity="0.65"
+          >
+            {formatShortDay(series[index].day)}
+          </text>
+        )
+      })}
+    </>
+  )
+}
+
+function ExperimentalBreakdownPanel({
+  kicker,
+  rows,
+  title,
+}: {
+  kicker: string
+  rows: NonNullable<MetricValuePublic["breakdown_by_source"]>
+  title: string
+}) {
+  const maxTokens = Math.max(...rows.map((row) => row.tokens), 0)
+
+  return (
+    <section className="border border-border bg-background p-4">
+      <div className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+        {kicker}
+      </div>
+      <h2 className="mt-1 text-sm font-semibold">{title}</h2>
+      {rows.length === 0 ? (
+        <p className="mt-4 text-sm text-muted-foreground">No data yet.</p>
+      ) : (
+        <div className="mt-3 divide-y divide-border/70">
+          {rows.map((row, index) => (
+            <div
+              key={row.key}
+              className="grid grid-cols-[1.5rem_minmax(0,1fr)_4.5rem] items-center gap-3 py-2"
+            >
+              <div className="font-mono text-xs text-muted-foreground">
+                {String(index + 1).padStart(2, "0")}
+              </div>
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">{row.label}</div>
+                <div className="mt-1 h-1 bg-muted">
+                  <div
+                    className="h-1 bg-primary"
+                    style={{
+                      width:
+                        maxTokens > 0
+                          ? `${Math.max(4, Math.round((row.tokens / maxTokens) * 100))}%`
+                          : "0%",
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="text-right font-mono text-xs tabular-nums">
+                {formatMetricValue(row.tokens, "compact-int")}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function ExperimentalSessionLog({
+  entries,
+  isError,
+  isLoading,
+}: {
+  entries: TaskforceSessionLogEntry[]
+  isError: boolean
+  isLoading: boolean
+}) {
+  return (
+    <section className="border border-border bg-background p-4">
+      <div className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+        Consult log
+      </div>
+      <h2 className="mt-1 text-sm font-semibold">Documents consulted</h2>
+
+      {isLoading ? (
+        <p className="mt-4 text-sm text-muted-foreground">
+          Loading session log...
+        </p>
+      ) : isError ? (
+        <p className="mt-4 text-sm text-destructive">
+          Failed to load the session log.
+        </p>
+      ) : entries.length === 0 ? (
+        <p className="mt-4 text-sm text-muted-foreground">
+          No consulted documents were recorded for this session.
+        </p>
+      ) : (
+        <div className="mt-3 divide-y divide-border/70">
+          <div className="grid grid-cols-[minmax(0,1.4fr)_4rem_5rem_7rem] gap-4 px-1 py-2 font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground max-md:hidden">
+            <div>Document</div>
+            <div>Score</div>
+            <div>Band</div>
+            <div className="text-right">Net tokens</div>
+          </div>
+          {entries.map((entry) => (
+            <article
+              key={`${entry.query_id}-${entry.document_id}`}
+              className="grid gap-2 px-1 py-3 md:grid-cols-[minmax(0,1.4fr)_4rem_5rem_7rem] md:items-center md:gap-4"
+            >
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">
+                  {entry.title}
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {formatSessionDate(entry.occurred_at)}
+                </div>
+              </div>
+              <div className="font-mono text-xs tabular-nums">
+                {formatScore(entry.score)}
+              </div>
+              <div>
+                <Badge variant="outline">{entry.confidence_band}</Badge>
+              </div>
+              <div className="font-mono text-xs tabular-nums md:text-right">
+                {entry.net_saved_tokens.toLocaleString()}
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function buildPolyline(
+  series: MetricValuePublic["series"],
+  width: number,
+  height: number,
+  padding: number,
+) {
+  if (series.length === 0) return ""
+  const values = series.map((point) => toMetricNumber(point.value))
+  const min = Math.min(...values, 0)
+  const max = Math.max(...values, 1)
+  const span = Math.max(max - min, 1)
+  const innerWidth = width - padding * 2
+  const innerHeight = height - padding * 2
+
+  return series
+    .map((point, index) => {
+      const value = toMetricNumber(point.value)
+      const x =
+        series.length === 1
+          ? width / 2
+          : padding + (index / (series.length - 1)) * innerWidth
+      const y = padding + innerHeight - ((value - min) / span) * innerHeight
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(" ")
+}
+
+function formatHeroDelta(
+  value: MetricValuePublic | undefined,
+  format: MetricDefinitionPublic["presentation"]["format"],
+) {
+  const delta = formatDelta(value?.delta_vs_prev_window, format)
+  if (!delta) return "No previous-period comparison yet"
+  if (delta.sign === "flat") return "No change vs previous period"
+  return `${delta.sign === "up" ? "▲" : "▼"} ${delta.label} vs previous period`
+}
+
+function formatRatioValue(value: number) {
+  if (!Number.isFinite(value)) return "0"
+  return value.toLocaleString("en-US", {
+    maximumFractionDigits: value >= 10 ? 0 : 1,
+  })
+}
+
+function formatShortDay(day: string) {
+  const parsed = new Date(day)
+  if (Number.isNaN(parsed.getTime())) return day
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    timeZone: "UTC",
+  }).format(parsed)
 }
 
 function SessionLogTable({

--- a/tests/v2-metrics-session.spec.ts
+++ b/tests/v2-metrics-session.spec.ts
@@ -51,10 +51,18 @@ function metricValue(total: string) {
   }
 }
 
-async function mockMetricsPage(page: Page) {
-  await page.addInitScript(() => {
+async function mockMetricsPage(
+  page: Page,
+  options: { experimental?: boolean } = {},
+) {
+  await page.addInitScript((experimental) => {
     window.localStorage.setItem("access_token", "test-token")
-  })
+    if (experimental) {
+      window.localStorage.setItem("taskforce-experimental-mode", "true")
+    } else {
+      window.localStorage.removeItem("taskforce-experimental-mode")
+    }
+  }, options.experimental ?? false)
 
   await page.route("**/api/v1/users/**", async (route) => {
     const url = new URL(route.request().url())
@@ -95,6 +103,12 @@ async function mockMetricsPage(page: Page) {
             "tokens",
           ),
           metricDefinition("usd_consumed", "USD Consumed", "usd", "usd"),
+          metricDefinition(
+            "documents_touched",
+            "Documents Touched",
+            "count",
+            "count",
+          ),
         ],
       },
     })
@@ -114,6 +128,7 @@ async function mockMetricsPage(page: Page) {
           reuse_rate: metricValue("0.5"),
           tokens_consumed: metricValue("2000"),
           usd_consumed: metricValue("0.25"),
+          documents_touched: metricValue("4"),
         },
       },
     })
@@ -199,6 +214,43 @@ test("metrics page shows session-scoped savings when session_id is present", asy
   await expect(page).toHaveURL(/\/v2\/metrics$/)
 })
 
+test("experimental mode shows expressive session-scoped metrics", async ({
+  page,
+}) => {
+  await mockMetricsPage(page, { experimental: true })
+
+  await page.route(
+    "**/api/v1/v2/taskforce/session-savings?*",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          session_id: sessionId,
+          doc_count: 2,
+          net_saved_tokens: 4218,
+          usd_saved: "0.42",
+          pricing_model_id: "claude-opus-4-7",
+          occurred_at_first: "2026-05-23T19:00:00Z",
+          occurred_at_last: "2026-05-23T19:04:00Z",
+        },
+      })
+    },
+  )
+
+  await page.goto(`/v2/metrics?session_id=${sessionId}`)
+
+  await expect(
+    page.getByTestId("metrics-experimental-session-page"),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: /this session saved 4\.2k tokens/i }),
+  ).toBeVisible()
+  await expect(page.getByText("Bridge incident investigation")).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Documents consulted" }),
+  ).toBeVisible()
+  await expect(page.getByText("claude-opus-4-7", { exact: true })).toBeVisible()
+})
+
 test("metrics page keeps aggregate dashboard without session_id", async ({
   page,
 }) => {
@@ -218,5 +270,31 @@ test("metrics page keeps aggregate dashboard without session_id", async ({
   await expect(page.getByText("Reuse Rate", { exact: true })).toBeVisible()
   await expect(page.getByText("1K", { exact: true }).first()).toBeVisible()
   await expect(page.getByText("$1.23", { exact: true }).first()).toBeVisible()
+  expect(sessionSavingsRequests).toBe(0)
+})
+
+test("experimental mode shows expressive aggregate metrics", async ({
+  page,
+}) => {
+  let sessionSavingsRequests = 0
+  await mockMetricsPage(page, { experimental: true })
+  await page.route(
+    "**/api/v1/v2/taskforce/session-savings?*",
+    async (route) => {
+      sessionSavingsRequests += 1
+      await route.fulfill({ status: 500, json: { detail: "Unexpected call" } })
+    },
+  )
+
+  await page.goto("/v2/metrics")
+
+  await expect(page.getByTestId("metrics-experimental-page")).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: /you saved 1k tokens this week/i }),
+  ).toBeVisible()
+  await expect(page.getByText("Saved / used")).toBeVisible()
+  await expect(page.getByText("Top models by tokens used")).toBeVisible()
+  await expect(page.getByText("Documents Touched")).toBeVisible()
+  await expect(page.getByTestId("metrics-session-filter-banner")).toHaveCount(0)
   expect(sessionSavingsRequests).toBe(0)
 })


### PR DESCRIPTION
## Summary
- Add the experimental-mode-only expressive metrics dashboard based on the `metrics-expressive` mockup.
- Add a matching expressive session-specific metrics view for `session_id` URLs.
- Keep the existing metrics UI active when experimental mode is off and avoid unsupported mockup-only claims.
- Surface supported metrics data only: tokens/USD saved, tokens/USD consumed, reuse rate, documents touched, savings source breakdown, top models, and session savings/log fields.

## Validation
- `npx tsc -p tsconfig.build.json --noEmit`
- `npx playwright test tests/v2-metrics-session.spec.ts --project=chromium --no-deps`