### PR TITLE
Match v2 tab header typography and top spacing to Agents

### DIFF
--- a/src/components/V2/Agents/agentsTypography.ts
+++ b/src/components/V2/Agents/agentsTypography.ts
@@ -11,7 +11,11 @@ export const AGENT_ROLE_CLASS = "text-sm leading-4 text-muted-foreground"
 /** Detail page specialist name (same scale as other v2 tab titles). */
 export const AGENT_DETAIL_NAME_CLASS = AGENT_PAGE_TITLE_CLASS
 
-export const AGENT_EYEBROW_CLASS = "text-xs uppercase tracking-wide text-muted-foreground"
+/** Page eyebrow — matches Library tab meta line. */
+export const AGENT_EYEBROW_CLASS =
+  "font-mono text-[0.65rem] uppercase tracking-[0.18em] text-muted-foreground"
+
+export const AGENT_BREADCRUMB_CLASS = "text-sm text-muted-foreground"
 
 export const AGENT_ROUTE_LABEL_CLASS = "text-sm text-muted-foreground"
 

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -26,7 +26,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { V2_PAGE_CONTENT } from "@/components/V2/v2PageShell"
+import { V2_PAGE_CONTENT, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
 import { usePersistentState } from "@/hooks/usePersistentState"
 import { formatDelta, formatMetricValue } from "./formatters"
 import { MethodologyLink } from "./MethodologyLink"
@@ -306,7 +306,8 @@ export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
   }
 
   return (
-    <div className={V2_PAGE_CONTENT}>
+    <section className={V2_PAGE_FRAME}>
+      <div className={V2_PAGE_CONTENT}>
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold">Metrics</h1>
@@ -420,7 +421,8 @@ export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
           rows={tokensConsumed?.top_models ?? []}
         />
       </section>
-    </div>
+      </div>
+    </section>
   )
 }
 

--- a/src/components/V2/v2PageShell.ts
+++ b/src/components/V2/v2PageShell.ts
@@ -1,13 +1,28 @@
-/** Scrollable v2 page frame inside TaskforceShell (no extra horizontal inset). */
+import { cn } from "@/lib/utils"
+
+/** Scrollable v2 page frame inside TaskforceShell (no extra inset). */
 export const V2_PAGE_FRAME =
   "flex min-h-0 flex-1 flex-col overflow-y-auto"
 
+/** Shared padding for v2 tab bodies (Agents default). */
+export const V2_PAGE_PADDING = "p-6"
+
 /**
- * Inner page content padding — matches the Metrics tab (p-6 inside shell main
- * padding). Use on Library, Agents, Metrics, and other v2 tab bodies.
+ * Scrollable tab body — matches Agents list/detail layout inside shell main
+ * padding (`p-6 md:p-8` on TaskforceShell).
  */
-export const V2_PAGE_CONTENT =
-  "flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-6"
+export const V2_PAGE_CONTENT = cn(
+  "flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto",
+  V2_PAGE_PADDING,
+)
+
+/**
+ * Library-style tab body: same padding as Agents, but overflow hidden for split panes.
+ */
+export const V2_PAGE_CONTENT_FIXED = cn(
+  "flex min-h-0 flex-1 flex-col gap-6 overflow-hidden",
+  V2_PAGE_PADDING,
+)
 
 /** @deprecated Prefer V2_PAGE_CONTENT for tab pages. */
 export const V2_CONTENT_SHELL = V2_PAGE_CONTENT

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -17,7 +17,7 @@ import {
 import {
   AGENT_DESCRIPTION_CLASS,
   AGENT_DETAIL_NAME_CLASS,
-  AGENT_EYEBROW_CLASS,
+  AGENT_BREADCRUMB_CLASS,
   AGENT_PAGE_TITLE_CLASS,
   AGENT_ROLE_CLASS,
   AGENT_ROUTE_CHIP_CLASS,
@@ -361,7 +361,7 @@ function AgentDetailPage() {
       <div className={AGENTS_DETAIL_SHELL}>
         <header className="grid gap-4 border-b border-black/10 pb-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end dark:border-white/12">
           <div>
-            <div className={AGENT_EYEBROW_CLASS}>
+            <div className={AGENT_BREADCRUMB_CLASS}>
               <Link
                 to="/v2/agents"
                 className="hover:text-zinc-950 dark:hover:text-white"

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -263,7 +263,7 @@ function AgentsIndex() {
         <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div>
             <div className={AGENT_EYEBROW_CLASS}>
-              {activeCount} active across team
+              Agents · {activeCount} active across team
             </div>
             <h1 className={cn("mt-1", AGENT_PAGE_TITLE_CLASS)}>Agents</h1>
             <p className="mt-1 max-w-[50ch] text-sm leading-5 text-muted-foreground">

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -80,6 +80,10 @@ import {
   usePersistentState,
 } from "@/hooks/usePersistentState"
 import { cn } from "@/lib/utils"
+import {
+  V2_PAGE_CONTENT_FIXED,
+  V2_PAGE_FRAME,
+} from "@/components/V2/v2PageShell"
 
 export const Route = createFileRoute("/v2/library")({
   component: TaskforceLibrary,
@@ -648,8 +652,9 @@ function TaskforceLibrary() {
         onDelete: requestDeleteDocument,
       }}
     >
-      <section className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden p-6">
-        <div className="sticky top-0 z-20 flex shrink-0 flex-col gap-4 border-b bg-background/95 py-3 backdrop-blur">
+      <section className={cn(V2_PAGE_FRAME, "overflow-hidden")}>
+        <div className={V2_PAGE_CONTENT_FIXED}>
+        <div className="sticky top-0 z-20 flex shrink-0 flex-col gap-4 border-b bg-background/95 backdrop-blur">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div>
               <div className="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-muted-foreground">
@@ -830,6 +835,7 @@ function TaskforceLibrary() {
               />
             </div>
           )}
+        </div>
       </section>
     </DocumentDeleteContext.Provider>
   )


### PR DESCRIPTION
## Summary
- Match Agents list eyebrow typography and copy pattern to Library (`Agents · N active across team`).
- Standardize top spacing across Library, Agents, and Metrics using the Agents page shell (`V2_PAGE_FRAME` + `V2_PAGE_CONTENT`).
- Remove extra `py-3` on the Library sticky header that pushed content down.

## Test plan
- [ ] Compare `/v2/library`, `/v2/agents`, and `/v2/metrics` — meta line and title should align vertically at the top
- [ ] Confirm Library sticky header still behaves when scrolling

Made with [Cursor](https://cursor.com)