### PR TITLE
Clean up experimental metrics trend boxes + drop Tokens Used tile

### DIFF
--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -556,17 +556,10 @@ function ExperimentalMetricsPage({
           </div>
         </div>
         <div className="flex flex-col gap-4 border-t border-border p-5 lg:border-t-0 lg:border-l">
-          <div>
-            <div className="font-mono text-xs uppercase tracking-[0.16em] opacity-70">
-              Daily trend
-            </div>
-            <div className="mt-2">
-              <MetricTrendChart
-                title="Tokens saved per day"
-                series={tokensSaved?.series ?? []}
-              />
-            </div>
-          </div>
+          <MetricTrendChart
+            title="Daily tokens saved"
+            series={tokensSaved?.series ?? []}
+          />
           <div className="grid border border-border sm:grid-cols-2">
             <ExperimentalRatioCell
               label="Reuse rate"
@@ -604,18 +597,10 @@ function ExperimentalMetricsPage({
       </section>
 
       <section className="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
-        <section className="border border-border bg-background p-4">
-          <div className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
-            Tokens saved · daily
-          </div>
-          <h2 className="mt-1 text-sm font-semibold">Reuse trend</h2>
-          <div className="mt-4">
-            <MetricTrendChart
-              title="Reuse trend"
-              series={tokensSaved?.series ?? []}
-            />
-          </div>
-        </section>
+        <MetricTrendChart
+          title="Tokens saved · daily"
+          series={tokensSaved?.series ?? []}
+        />
         <ExperimentalBreakdownPanel
           title="Where savings came from"
           kicker="Savings by source"
@@ -625,7 +610,6 @@ function ExperimentalMetricsPage({
 
       <section className="grid gap-4 md:grid-cols-3">
         {[
-          ["tokens_consumed", metrics.tokens_consumed],
           ["usd_consumed", metrics.usd_consumed],
           ["documents_touched", documentsTouched],
         ].map(([name, value]) => {


### PR DESCRIPTION
## Summary
Two visual fixes from feedback on #149:

1. **Box-in-box on the trend charts.** The previous PR wrapped `MetricTrendChart` in an outer `<section>` that had its own border + kicker + h2, while `MetricTrendChart` already renders its own bordered card with an h3 title — so users saw two stacked boxes with "Reuse trend" appearing twice. Drops both outer wrappers (the small "Daily trend" inset and the full-width "Reuse trend" panel) and lets `MetricTrendChart` be the only container. New titles:
   - inline: **"Daily tokens saved"**
   - standalone: **"Tokens saved · daily"**

2. **Removes the Tokens Used tile** from the experimental tile row. The plain-English summary above already reports tokens consumed inline, and the top-models breakdown further down covers the per-model split — the standalone tile was redundant. The data fetch (`SECONDARY_METRICS` array) and the non-experimental view are unchanged.

## Test plan
- [ ] CI green
- [ ] Open `/v2/metrics` in experimental mode → one bordered chart per trend section, single title, hover tooltip works
- [ ] Bottom tile row shows 3 tiles (USD spent, Documents touched, USD net saved) — no Tokens Used

🤖 Generated with [Claude Code](https://claude.com/claude-code)