### PR TITLE
Use transparent SVG logo in V2 sidebar

### DIFF
--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -111,7 +111,7 @@ function TaskforceMark() {
       className="flex min-w-0 items-center gap-3 px-1 text-sidebar-foreground group-data-[collapsible=icon]:px-0"
     >
       <img
-        src="/assets/brand/icon-192.png"
+        src="/assets/brand/tf-logo.svg"
         alt=""
         className="size-8 shrink-0 group-data-[collapsible=icon]:size-7"
       />


### PR DESCRIPTION
## Summary
`icon-192.png` has a hard white background, which on the dark sidebar (`oklch(0.205 0 0)`) renders as a bright square — the brand mark loses its shape and reads as a misplaced light tile. Swaps to the existing `tf-logo.svg` (same purple-polygon design, no background rect), which lets the sidebar bg show through in both light and dark modes.

## Scope
Only `TaskforceShell.tsx`'s `TaskforceMark` is changed (the V2 sidebar). `landing.tsx` uses the same PNG but in a different visual context (white nav over a hero), so leaving that for a follow-up.

## Test plan
- [ ] Open `/v2/library` in light mode → logo polygons sit cleanly on the light sidebar
- [ ] Toggle to dark mode → logo polygons sit cleanly on the dark sidebar; no white square
- [ ] Collapse the sidebar → mark scales down via `group-data-[collapsible=icon]:size-7` (same as before, SVG also scales)

🤖 Generated with [Claude Code](https://claude.com/claude-code)