### PR TITLE
Metrics: specialist link in session header, drop inline trend chart

### DIFF
--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -9,6 +9,8 @@ export interface TaskforceSessionSavingsResponse {
   pricing_model_id: string
   occurred_at_first: string | null
   occurred_at_last: string | null
+  specialist_slug: string | null
+  specialist_name: string | null
 }
 
 export interface TaskforceSessionLogEntry {

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -167,6 +167,8 @@ function buildFallbackSessionSavings(
     pricing_model_id: SESSION_PRICING_MODEL_ID,
     occurred_at_first: occurredAtValues[0] ?? null,
     occurred_at_last: occurredAtValues[occurredAtValues.length - 1] ?? null,
+    specialist_slug: null,
+    specialist_name: null,
   }
 }
 
@@ -539,7 +541,7 @@ function ExperimentalMetricsPage({
         </div>
       )}
 
-      <section className="grid border border-border bg-background text-foreground lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
+      <section className="border border-border bg-background text-foreground">
         <div className="px-5 py-6 md:px-7">
           <div className="font-mono text-xs uppercase tracking-[0.18em] opacity-70">
             Tokens saved · {windowCopy.label}
@@ -555,22 +557,16 @@ function ExperimentalMetricsPage({
             {formatMetricValue(usdNetSaved.total, "usd")} net saved
           </div>
         </div>
-        <div className="flex flex-col gap-4 border-t border-border p-5 lg:border-t-0 lg:border-l">
-          <MetricTrendChart
-            title="Daily tokens saved"
-            series={tokensSaved?.series ?? []}
+        <div className="grid border-t border-border sm:grid-cols-2">
+          <ExperimentalRatioCell
+            label="Reuse rate"
+            value={formatMetricValue(reuseRate, "ratio")}
           />
-          <div className="grid border border-border sm:grid-cols-2">
-            <ExperimentalRatioCell
-              label="Reuse rate"
-              value={formatMetricValue(reuseRate, "ratio")}
-            />
-            <ExperimentalRatioCell
-              label="Saved / used"
-              value={`${formatRatioValue(savingsRatio)}x`}
-              className="border-t border-border sm:border-t-0 sm:border-l"
-            />
-          </div>
+          <ExperimentalRatioCell
+            label="Saved / used"
+            value={`${formatRatioValue(savingsRatio)}x`}
+            className="border-t border-border sm:border-t-0 sm:border-l"
+          />
         </div>
       </section>
 
@@ -701,6 +697,20 @@ function ExperimentalSessionMetrics({
             </span>
             .
           </h1>
+          {sessionSavings?.specialist_slug ? (
+            <Link
+              to="/v2/agents/$slug"
+              params={{ slug: sessionSavings.specialist_slug }}
+              className="mt-3 inline-flex items-center gap-1.5 border border-border px-2.5 py-1 font-mono text-xs uppercase tracking-[0.12em] text-foreground hover:bg-muted"
+            >
+              Routed to{" "}
+              <span className="font-semibold normal-case tracking-normal">
+                {sessionSavings.specialist_name ??
+                  sessionSavings.specialist_slug}
+              </span>
+              <span aria-hidden>→</span>
+            </Link>
+          ) : null}
         </div>
         <Link
           to="/v2/metrics"


### PR DESCRIPTION
## Summary
Three frontend changes paired with backend PR https://github.com/al-exe/EnderAI/pull/98:

1. **Specialist link.** Session metrics header now shows a "Routed to Jensen →" chip linking to `/v2/agents/<slug>`. Reads `specialist_slug` + `specialist_name` from the new TF-204 fields on the session-savings response. Renders only when routing matched a specialist.

2. **Drop the inline "Daily tokens saved" chart.** Removed the redundant trend chart sitting inside the tokens-saved card — the standalone "Tokens saved · daily" chart below the Plain-English section is the canonical view.

3. **Remove the vertical splitter.** Collapses the tokens-saved card from a two-column grid (totals + chart) to a single column with the Reuse rate / Saved-per-used ratio cells flowing below, separated only by a horizontal border. Keeps the ratio cells "in that box" per request.

Also: `buildFallbackSessionSavings` and `TaskforceSessionSavingsResponse` updated to match the new TF-204 shape.

## Test plan
- [ ] CI green
- [ ] `/v2/metrics?session_id=<routed session>` shows "Routed to Jensen →" chip that navigates to `/v2/agents/jensen` on click
- [ ] `/v2/metrics?session_id=<unrouted session>` doesn't show the chip
- [ ] `/v2/metrics` (no session) — tokens-saved card is single-column with ratio cells below, no splitter, no inline chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)