### PR TITLE
Left-align agent detail role line with avatar

### DIFF
--- a/src/components/V2/Agents/AgentDetailSkeleton.tsx
+++ b/src/components/V2/Agents/AgentDetailSkeleton.tsx
@@ -49,7 +49,7 @@ export function AgentDetailSkeleton({
               <Bone className="size-5 shrink-0" />
               <Bone className="h-7 w-56 max-w-full" />
             </div>
-            <Bone className="mt-1 ml-8 h-4 w-72 max-w-full" />
+            <Bone className="mt-1 h-4 w-72 max-w-full" />
             <Bone className="mt-4 h-4 w-full max-w-xl" />
           </div>
           <div className="flex flex-wrap items-center gap-2">

--- a/src/components/V2/Agents/agentsTypography.ts
+++ b/src/components/V2/Agents/agentsTypography.ts
@@ -18,9 +18,9 @@ export const AGENT_EYEBROW_CLASS =
 /** Detail breadcrumb — same mono eyebrow as Agents list meta line. */
 export const AGENT_BREADCRUMB_CLASS = AGENT_EYEBROW_CLASS
 
-/** Role · playbook line under the specialist name (indented past the avatar). */
+/** Role · playbook line — left-aligned with avatar and breadcrumb. */
 export const AGENT_DETAIL_SUBTITLE_CLASS =
-  "mt-1 pl-8 text-sm leading-5 text-muted-foreground"
+  "mt-1 text-sm leading-5 text-muted-foreground"
 
 export const AGENT_DETAIL_AVATAR_CLASS =
   "grid size-5 shrink-0 place-items-center border border-background bg-[#8447ff] font-mono text-[0.58rem] font-semibold text-white outline outline-1 outline-border"


### PR DESCRIPTION
## Summary
- Remove `pl-8` from the specialist subtitle so `{role} · specialist playbook` aligns with the avatar left edge.

## Test plan
- [ ] Open `/v2/agents/jensen` and confirm role line aligns with the purple icon block

Made with [Cursor](https://cursor.com)