### PR TITLE
Sticky agent detail header on scroll

### DIFF
--- a/src/components/V2/Agents/AgentDetailSkeleton.tsx
+++ b/src/components/V2/Agents/AgentDetailSkeleton.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils"
+import { V2_STICKY_HEADER_CLASS } from "@/components/V2/v2PageShell"
 
 function Bone({ className }: { className?: string }) {
   return (
@@ -42,7 +43,12 @@ export function AgentDetailSkeleton({
       aria-label="Loading specialist"
     >
       {!hideHeader && (
-        <header className="grid gap-4 border-b border-border pb-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <header
+          className={cn(
+            V2_STICKY_HEADER_CLASS,
+            "grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end",
+          )}
+        >
           <div>
             <Bone className="h-[0.65rem] w-44" />
             <div className="mt-1 flex items-center gap-3">
@@ -50,13 +56,13 @@ export function AgentDetailSkeleton({
               <Bone className="h-7 w-56 max-w-full" />
             </div>
             <Bone className="mt-1 h-4 w-72 max-w-full" />
-            <Bone className="mt-4 h-4 w-full max-w-xl" />
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <Bone className="h-8 w-28" />
             <Bone className="h-8 w-24" />
           </div>
         </header>
+        <Bone className="h-4 w-full max-w-xl" />
       )}
 
       <section className="my-4 grid border border-black/10 bg-white sm:grid-cols-2 lg:grid-cols-4 dark:border-white/12 dark:bg-zinc-950">

--- a/src/components/V2/v2PageShell.ts
+++ b/src/components/V2/v2PageShell.ts
@@ -24,5 +24,10 @@ export const V2_PAGE_CONTENT_FIXED = cn(
   V2_PAGE_PADDING,
 )
 
+/** Sticky page header inside a `V2_PAGE_CONTENT` scroll area (offsets `p-6` padding). */
+export const V2_STICKY_HEADER_CLASS = cn(
+  "sticky top-0 z-20 -mx-6 shrink-0 border-b bg-background/95 px-6 pb-4 backdrop-blur supports-[backdrop-filter]:bg-background/80",
+)
+
 /** @deprecated Prefer V2_PAGE_CONTENT for tab pages. */
 export const V2_CONTENT_SHELL = V2_PAGE_CONTENT

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -32,7 +32,11 @@ import {
   formatCompactNumber,
   formatRelativeTime,
 } from "@/components/V2/Agents/formatters"
-import { V2_PAGE_CONTENT, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
+import {
+  V2_PAGE_CONTENT,
+  V2_PAGE_FRAME,
+  V2_STICKY_HEADER_CLASS,
+} from "@/components/V2/v2PageShell"
 
 export const Route = createFileRoute("/v2/agents/$slug")({
   component: AgentDetailPage,
@@ -357,7 +361,13 @@ function AgentDetailPage() {
       className={`${V2_PAGE_FRAME} bg-background font-sans text-foreground`}
     >
       <div className={AGENTS_DETAIL_SHELL}>
-        <header className="grid gap-4 border-b border-border pb-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <header
+          data-testid="agent-detail-sticky-header"
+          className={cn(
+            V2_STICKY_HEADER_CLASS,
+            "grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end",
+          )}
+        >
           <div>
             <div className={AGENT_BREADCRUMB_CLASS}>
               <Link to="/v2/agents" className="hover:text-foreground">
@@ -378,11 +388,6 @@ function AgentDetailPage() {
               <span className="font-semibold text-foreground">{agent.role}</span>
               <span> · specialist playbook</span>
             </p>
-            {agent.description ? (
-              <p className={cn("mt-4 max-w-3xl", AGENT_DESCRIPTION_CLASS)}>
-                {agent.description}
-              </p>
-            ) : null}
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <span className="inline-flex h-8 items-center gap-2 rounded-md border border-black/10 px-3 text-xs font-medium text-emerald-600 dark:border-white/12 dark:text-emerald-400">
@@ -397,6 +402,12 @@ function AgentDetailPage() {
             </Button>
           </div>
         </header>
+
+        {agent.description ? (
+          <p className={cn("max-w-3xl", AGENT_DESCRIPTION_CLASS)}>
+            {agent.description}
+          </p>
+        ) : null}
 
         {isHydratingDetail ? (
           <AgentDetailSkeleton


### PR DESCRIPTION
## Summary
- Pin the specialist identity header (breadcrumb, name, role, actions) on scroll with backdrop blur.
- Move the long description below the sticky block so it scrolls with the rest of the page.

## Test plan
- [ ] Open `/v2/agents/jensen` and scroll — header stays fixed at top
- [ ] Confirm description and stats scroll underneath

Made with [Cursor](https://cursor.com)