### PR TITLE
[codex] Build expressive landing page

### DIFF
--- a/src/components/V2/Agents/AgentDetailSkeleton.tsx
+++ b/src/components/V2/Agents/AgentDetailSkeleton.tsx
@@ -1,13 +1,10 @@
-import { cn } from "@/lib/utils"
 import { V2_STICKY_HEADER_CLASS } from "@/components/V2/v2PageShell"
+import { cn } from "@/lib/utils"
 
 function Bone({ className }: { className?: string }) {
   return (
     <div
-      className={cn(
-        "animate-pulse bg-zinc-200/90 dark:bg-white/10",
-        className,
-      )}
+      className={cn("animate-pulse bg-zinc-200/90 dark:bg-white/10", className)}
     />
   )
 }
@@ -37,32 +34,34 @@ export function AgentDetailSkeleton({
   hideHeader = false,
 }: AgentDetailSkeletonProps) {
   return (
-    <div
+    <output
       className={cn(shellClassName, "py-6")}
       aria-busy="true"
       aria-label="Loading specialist"
     >
       {!hideHeader && (
-        <header
-          className={cn(
-            V2_STICKY_HEADER_CLASS,
-            "grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end",
-          )}
-        >
-          <div>
-            <Bone className="h-[0.65rem] w-44" />
-            <div className="mt-1 flex items-center gap-3">
-              <Bone className="size-5 shrink-0" />
-              <Bone className="h-7 w-56 max-w-full" />
+        <>
+          <header
+            className={cn(
+              V2_STICKY_HEADER_CLASS,
+              "grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end",
+            )}
+          >
+            <div>
+              <Bone className="h-[0.65rem] w-44" />
+              <div className="mt-1 flex items-center gap-3">
+                <Bone className="size-5 shrink-0" />
+                <Bone className="h-7 w-56 max-w-full" />
+              </div>
+              <Bone className="mt-1 h-4 w-72 max-w-full" />
             </div>
-            <Bone className="mt-1 h-4 w-72 max-w-full" />
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Bone className="h-8 w-28" />
-            <Bone className="h-8 w-24" />
-          </div>
-        </header>
-        <Bone className="h-4 w-full max-w-xl" />
+            <div className="flex flex-wrap items-center gap-2">
+              <Bone className="h-8 w-28" />
+              <Bone className="h-8 w-24" />
+            </div>
+          </header>
+          <Bone className="h-4 w-full max-w-xl" />
+        </>
       )}
 
       <section className="my-4 grid border border-black/10 bg-white sm:grid-cols-2 lg:grid-cols-4 dark:border-white/12 dark:bg-zinc-950">
@@ -72,9 +71,7 @@ export function AgentDetailSkeleton({
             className="space-y-2 border-b border-black/10 p-4 last:border-b-0 sm:odd:border-r lg:border-r lg:border-b-0 lg:last:border-r-0 dark:border-white/12"
           >
             <Bone className="h-[0.62rem] w-24" />
-            <Bone
-              className={cn("h-8", index === 0 ? "w-28" : "w-20")}
-            />
+            <Bone className={cn("h-8", index === 0 ? "w-28" : "w-20")} />
             <Bone className="h-[0.68rem] w-36 max-w-full" />
           </div>
         ))}
@@ -219,6 +216,6 @@ export function AgentDetailSkeleton({
           </table>
         </div>
       </section>
-    </div>
+    </output>
   )
 }

--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/landing")({
-  component: LandingMinimal,
+  component: LandingExpressive,
   head: () => ({
     meta: [
       {
@@ -12,114 +12,217 @@ export const Route = createFileRoute("/landing")({
 })
 
 const proofStats = [
+  { label: "Saved in demo", value: "50,359 tokens" },
+  { label: "Specialist routed", value: "Jensen" },
+  { label: "Setup", value: "4-min MCP" },
+]
+
+const terminalLines = [
   {
-    label: "Avg tokens saved / week",
-    value: "412K",
-    sub: "across pilot teams · 5-12 engineers",
+    name: "you",
+    tone: "prompt",
+    text: "/tf Stripe is double-charging users on plan upgrades — webhook retries are getting fulfilled twice. Can you fix it?",
   },
   {
-    label: "Rediscovery avoided",
-    value: "73%",
-    sub: "of repeat questions resolved from memory",
+    name: "tf",
+    tone: "dim",
+    text: "Checking Taskforce for the right specialist...",
   },
   {
-    label: "Setup time",
-    value: "4 min",
-    sub: "connect MCP, point at repo, done",
+    name: "tf",
+    tone: "dim",
+    text: 'Sending prompt + cwd + files + git_branch "demo/stripe-double-charge". No code body. No chat history.',
   },
   {
-    label: "Works with",
-    value: "Claude Code · Codex · Cursor",
-    sub: "team library, shared across machines",
-    compact: true,
+    name: "tf",
+    tone: "body",
+    text: "Routed to Jensen — Billing Reliability Specialist.",
+    accent: "Confidence: high · Stripe webhook retries · plan upgrades",
+  },
+  {
+    name: "tf",
+    tone: "body",
+    text: "Jensen is bringing in Stripe webhook idempotency strategy and the plan-upgrade replay regression pattern.",
+  },
+  {
+    name: "you",
+    tone: "prompt",
+    text: "Apply that pattern and prove the retry only fulfills once.",
+  },
+  {
+    name: "tf",
+    tone: "body",
+    text: "Patch written. Regression test passes. Recording the session back to Taskforce.",
   },
 ]
 
-function LandingMinimal() {
+function LandingExpressive() {
   return (
-    <main className="min-h-svh bg-white text-zinc-950 dark:bg-zinc-950 dark:text-white">
-      <nav className="flex items-center justify-between border-b border-zinc-200 bg-white px-5 py-4 dark:border-white/10 dark:bg-zinc-950 md:px-8">
+    <main
+      data-testid="landing-expressive"
+      className="min-h-svh overflow-hidden bg-white text-zinc-950 dark:bg-zinc-950 dark:text-white"
+    >
+      <nav className="relative z-10 flex h-14 items-center justify-between border-b border-zinc-200 bg-white px-5 dark:border-white/10 dark:bg-zinc-950 md:px-8">
         <Link
           to="/landing"
           className="inline-flex items-center gap-2 text-sm font-semibold"
+          aria-label="Taskforce landing"
         >
           <img
-            src="/assets/brand/icon-192.png"
+            src="/assets/brand/tf-icon-filled.svg"
             alt=""
-            className="size-6"
+            className="size-6 dark:hidden"
+          />
+          <img
+            src="/assets/brand/tf-icon-filled-dark.svg"
+            alt=""
+            className="hidden size-6 dark:block"
           />
           Taskforce
         </Link>
-        <div className="hidden items-center gap-5 font-mono text-xs tracking-[0.04em] text-zinc-500 md:flex dark:text-zinc-400">
-          <span>Docs</span>
-          <span>Pricing</span>
-          <Link to="/login">Log in</Link>
+        <div className="flex items-center gap-4 font-mono text-[0.68rem] text-zinc-500 dark:text-zinc-400">
+          <span className="hidden sm:inline">Docs</span>
+          <span className="hidden sm:inline">Pricing</span>
+          <Link
+            to="/login"
+            className="hover:text-zinc-950 dark:hover:text-white"
+          >
+            Log in
+          </Link>
           <Link
             to="/signup"
             className="bg-zinc-950 px-3 py-2 text-white dark:bg-white dark:text-zinc-950"
           >
-            Sign up
+            Sign up →
           </Link>
         </div>
       </nav>
 
-      <section className="max-w-5xl px-5 pt-12 pb-6 md:px-8 md:pt-16">
-        <div className="font-mono text-xs font-medium uppercase tracking-[0.22em] text-[#8447ff]">
-          AI work memory · for engineering teams
-        </div>
-        <h1 className="mt-4 max-w-[16ch] text-5xl font-semibold leading-[0.98] tracking-[-0.04em] text-balance md:text-7xl">
-          Taskforce <em className="not-italic text-[#8447ff]">remembers</em>{" "}
-          what you and your team already did.
-        </h1>
-        <p className="mt-5 max-w-2xl text-base leading-7 text-zinc-600 text-pretty dark:text-zinc-300 md:text-lg">
-          Taskforce captures decisions from Claude Code, Codex, and Cursor,
-          stores them as searchable{" "}
-          <b className="font-medium text-zinc-950 dark:text-white">documents</b>
-          , and replays them as context to your next prompt. Engineers stop
-          re-explaining the codebase to every new chat.
-        </p>
-        <div className="mt-6 flex flex-wrap items-center gap-3">
-          <Link
-            to="/signup"
-            className="border border-zinc-950 bg-zinc-950 px-4 py-3 font-mono text-xs tracking-[0.04em] text-white dark:border-white dark:bg-white dark:text-zinc-950"
-          >
-            Start free →
-          </Link>
-          <Link
-            to="/"
-            className="border border-zinc-950 px-4 py-3 font-mono text-xs tracking-[0.04em] dark:border-white/30"
-          >
-            Watch 90s demo
-          </Link>
-          <span className="font-mono text-xs text-zinc-500 dark:text-zinc-400">
-            no credit card · works with claude code, codex, cursor, mcp
-          </span>
-        </div>
-      </section>
-
-      <section className="mx-5 mt-3 grid border-y border-zinc-300 md:mx-8 md:grid-cols-4 dark:border-white/15">
-        {proofStats.map((stat) => (
-          <div
-            key={stat.label}
-            className="border-b border-zinc-300 px-4 py-4 last:border-b-0 md:border-r md:border-b-0 md:last:border-r-0 dark:border-white/15"
-          >
-            <div className="font-mono text-[0.65rem] uppercase tracking-[0.17em] text-zinc-400 dark:text-zinc-500">
-              {stat.label}
+      <section className="grid min-h-[calc(100svh-3.5rem)] md:grid-cols-2">
+        <div className="relative flex flex-col justify-start border-b border-zinc-200 px-5 py-8 dark:border-white/10 md:border-r md:border-b-0 md:px-8 md:py-10">
+          <div className="max-w-2xl">
+            <div className="font-mono text-[0.68rem] font-medium uppercase tracking-[0.22em] text-[#8447ff]">
+              AI work memory · for engineering teams
             </div>
-            <div
-              className={
-                stat.compact
-                  ? "mt-2 text-sm font-semibold"
-                  : "mt-1 text-2xl font-semibold tracking-[-0.02em] tabular-nums"
-              }
-            >
-              {stat.value}
-            </div>
-            <div className="mt-1 font-mono text-[0.65rem] text-zinc-500 dark:text-zinc-400">
-              {stat.sub}
+            <h1 className="mt-4 max-w-[14ch] text-5xl font-semibold leading-[0.96] tracking-[-0.035em] text-balance md:text-6xl lg:text-7xl">
+              Stop <em className="not-italic text-[#8447ff]">re-explaining</em>{" "}
+              your codebase.
+            </h1>
+            <p className="mt-5 max-w-[50ch] text-sm leading-6 text-zinc-600 text-pretty dark:text-zinc-300 md:text-base">
+              Taskforce turns agent sessions into linkable{" "}
+              <b className="font-medium text-zinc-950 dark:text-white">
+                documents
+              </b>
+              , routes new prompts to the right specialist, and replays the
+              relevant decisions before another engineer starts from zero.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-2">
+              <Link
+                to="/signup"
+                className="border border-zinc-950 bg-zinc-950 px-4 py-3 font-mono text-xs tracking-[0.04em] text-white dark:border-white dark:bg-white dark:text-zinc-950"
+              >
+                Start free →
+              </Link>
+              <Link
+                to="/login"
+                className="border border-zinc-950 px-4 py-3 font-mono text-xs tracking-[0.04em] hover:bg-zinc-950 hover:text-white dark:border-white/30 dark:hover:bg-white dark:hover:text-zinc-950"
+              >
+                Open Taskforce
+              </Link>
             </div>
           </div>
-        ))}
+
+          <dl className="mt-10 grid border-t border-zinc-200 pt-4 font-mono text-[0.68rem] text-zinc-500 dark:border-white/10 dark:text-zinc-400 sm:grid-cols-3 md:mt-auto">
+            {proofStats.map((stat) => (
+              <div
+                key={stat.label}
+                className="border-b border-zinc-200 py-3 last:border-b-0 sm:border-r sm:border-b-0 sm:px-4 sm:first:pl-0 sm:last:border-r-0 dark:border-white/10"
+              >
+                <dt className="uppercase tracking-[0.16em]">{stat.label}</dt>
+                <dd className="mt-1 font-sans text-sm font-semibold text-zinc-950 dark:text-white">
+                  {stat.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <div className="flex min-h-[36rem] flex-col justify-end bg-zinc-50 px-5 py-6 dark:bg-zinc-900/40 md:min-h-0 md:items-end md:px-8 md:py-8">
+          <div className="w-full max-w-[42rem]">
+            <div className="mb-2 font-mono text-[0.65rem] uppercase tracking-[0.18em] text-zinc-400 dark:text-zinc-500">
+              Live · Claude Code /tf skill
+            </div>
+            <div className="border border-zinc-950 bg-zinc-950 p-3 font-mono text-[0.68rem] leading-5 text-zinc-100 shadow-2xl dark:border-white/15 md:p-4 lg:text-[0.72rem]">
+              <div className="mb-3 flex items-center gap-2 border-b border-white/15 pb-3">
+                <span className="size-1.5 bg-emerald-400" />
+                <span className="text-zinc-200">
+                  claude — demo/stripe-double-charge
+                </span>
+                <span className="ml-auto text-[0.65rem] text-zinc-500">
+                  foreground skill
+                </span>
+              </div>
+
+              <div className="space-y-1.5">
+                {terminalLines.map((line, index) => (
+                  <div
+                    key={`${line.name}-${index}`}
+                    className="grid grid-cols-[2rem_minmax(0,1fr)] gap-2"
+                  >
+                    <span
+                      className={
+                        line.name === "tf" ? "text-[#c9a8ff]" : "text-zinc-500"
+                      }
+                    >
+                      {line.name}
+                    </span>
+                    <span
+                      className={
+                        line.tone === "dim"
+                          ? "text-zinc-500"
+                          : line.tone === "prompt"
+                            ? "text-zinc-100"
+                            : "text-zinc-300"
+                      }
+                    >
+                      {line.text}
+                      {line.accent && (
+                        <span className="block text-emerald-300">
+                          {line.accent}
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-4 grid gap-3 border border-white/15 bg-white/[0.04] p-3 text-[0.65rem] sm:grid-cols-[1fr_auto_auto]">
+                <div>
+                  <div className="uppercase tracking-[0.16em] text-zinc-500">
+                    recorded
+                  </div>
+                  <div className="mt-1 text-zinc-200">
+                    Jensen invocation · 2 docs referenced
+                  </div>
+                </div>
+                <div>
+                  <div className="uppercase tracking-[0.16em] text-zinc-500">
+                    saved
+                  </div>
+                  <div className="mt-1 text-sm font-semibold text-[#c9a8ff] tabular-nums">
+                    50,359
+                  </div>
+                </div>
+                <div>
+                  <div className="uppercase tracking-[0.16em] text-zinc-500">
+                    metrics
+                  </div>
+                  <div className="mt-1 text-zinc-200">session link ready →</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </section>
     </main>
   )

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test"
+
+test.use({
+  storageState: {
+    cookies: [],
+    origins: [],
+  },
+})
+
+test("/landing renders the expressive Taskforce demo page", async ({
+  page,
+}) => {
+  await page.goto("/landing")
+
+  await expect(page.getByTestId("landing-expressive")).toBeVisible()
+  await expect(
+    page.getByRole("heading", {
+      name: /stop re-explaining your codebase/i,
+    }),
+  ).toBeVisible()
+  await expect(page.getByText("Live · Claude Code /tf skill")).toBeVisible()
+  await expect(
+    page.getByText("/tf Stripe is double-charging users on plan upgrades", {
+      exact: false,
+    }),
+  ).toBeVisible()
+  await expect(
+    page.getByText("Routed to Jensen — Billing Reliability Specialist"),
+  ).toBeVisible()
+  await expect(page.getByText("session link ready →")).toBeVisible()
+  await expect(page.getByRole("link", { name: /sign up/i })).toHaveAttribute(
+    "href",
+    "/signup",
+  )
+  await expect(page.getByRole("link", { name: /log in/i })).toHaveAttribute(
+    "href",
+    "/login",
+  )
+})


### PR DESCRIPTION
## Summary
- Replace `/landing` with the expressive split landing page from the screenshot direction.
- Move the product copy to the top-left and anchor the `/tf` terminal demo at the lower-right.
- Update the terminal script to match the current `/tf` foreground skill demo: prompt/cwd/files/branch payload, Jensen routing, Stripe webhook docs, session recording, and metrics link.
- Add a focused `/landing` Playwright spec.
- Include a minimal JSX/ARIA fix for `AgentDetailSkeleton`, which was blocking the TypeScript build on `main`.

## Validation
- `npx biome check --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true src/routes/landing.tsx tests/landing.spec.ts src/components/V2/Agents/AgentDetailSkeleton.tsx`
- `npx tsc -p tsconfig.build.json --noEmit`
- `npx playwright test tests/landing.spec.ts --project=chromium --no-deps`