### PR TITLE
Use BookOpen and LineChart icons in v2 nav

### DIFF
--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -6,8 +6,8 @@ import {
   useRouterState,
 } from "@tanstack/react-router"
 import {
-  BarChart3,
-  BookOpenText,
+  BookOpen,
+  LineChart,
   Bot,
   ChevronDown,
   ChevronUp,
@@ -65,9 +65,9 @@ type TaskforceNavItem = {
 
 const taskforceItems: TaskforceNavItem[] = [
   { icon: Search, title: "Search", path: "/v2/search" },
-  { icon: BookOpenText, title: "Library", path: "/v2/library" },
+  { icon: BookOpen, title: "Library", path: "/v2/library" },
   { icon: Bot, title: "Agents", path: "/v2/agents" },
-  { icon: BarChart3, title: "Metrics", path: "/v2/metrics" },
+  { icon: LineChart, title: "Metrics", path: "/v2/metrics" },
   { icon: Rocket, title: "Upgrade", path: "/v2/pricing" },
 ]
 


### PR DESCRIPTION
## Summary
- Library nav icon: `BookOpen`
- Metrics nav icon: `LineChart`

## Test plan
- [ ] Open Taskforce v2 shell and confirm Library/Metrics icons

Made with [Cursor](https://cursor.com)