### PR TITLE
Align tab meta line typography with Metrics eyebrow

### DIFF
--- a/src/components/V2/Agents/agentsTypography.ts
+++ b/src/components/V2/Agents/agentsTypography.ts
@@ -1,3 +1,5 @@
+import { V2_TAB_EYEBROW_CLASS } from "@/components/V2/v2PageShell"
+
 /** Page title — matches Library / Metrics v2 tabs. */
 export const AGENT_PAGE_TITLE_CLASS = "text-2xl font-semibold"
 
@@ -11,12 +13,11 @@ export const AGENT_ROLE_CLASS = "text-sm leading-4 text-muted-foreground"
 /** Detail page specialist name (same scale as other v2 tab titles). */
 export const AGENT_DETAIL_NAME_CLASS = AGENT_PAGE_TITLE_CLASS
 
-/** Page eyebrow — matches Library tab meta line. */
-export const AGENT_EYEBROW_CLASS =
-  "font-mono text-[0.65rem] uppercase tracking-[0.18em] text-muted-foreground"
+/** Page eyebrow — matches Metrics tab meta line. */
+export const AGENT_EYEBROW_CLASS = V2_TAB_EYEBROW_CLASS
 
 /** Detail breadcrumb — same mono eyebrow as Agents list meta line. */
-export const AGENT_BREADCRUMB_CLASS = AGENT_EYEBROW_CLASS
+export const AGENT_BREADCRUMB_CLASS = V2_TAB_EYEBROW_CLASS
 
 /** Role · playbook line — left-aligned with avatar and breadcrumb. */
 export const AGENT_DETAIL_SUBTITLE_CLASS =

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -26,7 +26,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { V2_PAGE_CONTENT, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
+import {
+  V2_PAGE_CONTENT,
+  V2_PAGE_FRAME,
+  V2_TAB_EYEBROW_CLASS,
+} from "@/components/V2/v2PageShell"
 import { usePersistentState } from "@/hooks/usePersistentState"
 import { formatDelta, formatMetricValue } from "./formatters"
 import { MethodologyLink } from "./MethodologyLink"
@@ -514,7 +518,7 @@ function ExperimentalMetricsPage({
     >
       <header className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
         <div>
-          <div className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          <div className={V2_TAB_EYEBROW_CLASS}>
             Metrics · {windowCopy.label} · personal
           </div>
           <h1 className="mt-2 text-3xl font-semibold leading-none tracking-tight md:text-4xl">
@@ -687,7 +691,7 @@ function ExperimentalSessionMetrics({
     >
       <header className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
         <div>
-          <div className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          <div className={V2_TAB_EYEBROW_CLASS}>
             Metrics · session · {sessionShortId}
           </div>
           <h1 className="mt-2 text-3xl font-semibold leading-none tracking-tight md:text-4xl">

--- a/src/components/V2/v2PageShell.ts
+++ b/src/components/V2/v2PageShell.ts
@@ -24,6 +24,10 @@ export const V2_PAGE_CONTENT_FIXED = cn(
   V2_PAGE_PADDING,
 )
 
+/** Tab page meta line (e.g. "Metrics · 7d · personal"). */
+export const V2_TAB_EYEBROW_CLASS =
+  "font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground"
+
 /** Sticky page header inside a `V2_PAGE_CONTENT` scroll area (offsets `p-6` padding). */
 export const V2_STICKY_HEADER_CLASS = cn(
   "sticky top-0 z-20 -mx-6 shrink-0 border-b bg-background/95 px-6 pb-4 backdrop-blur supports-[backdrop-filter]:bg-background/80",

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -83,6 +83,7 @@ import { cn } from "@/lib/utils"
 import {
   V2_PAGE_CONTENT_FIXED,
   V2_PAGE_FRAME,
+  V2_TAB_EYEBROW_CLASS,
 } from "@/components/V2/v2PageShell"
 
 export const Route = createFileRoute("/v2/library")({
@@ -657,7 +658,7 @@ function TaskforceLibrary() {
         <div className="sticky top-0 z-20 flex shrink-0 flex-col gap-4 border-b bg-background/95 backdrop-blur">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <div className="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-muted-foreground">
+              <div className={V2_TAB_EYEBROW_CLASS}>
                 Library · {totalDocumentCount} documents ·{" "}
                 {teamSharedDocumentCount} shared with team
               </div>


### PR DESCRIPTION
## Summary
- Add shared `V2_TAB_EYEBROW_CLASS` (`text-xs`, matching Metrics experimental header).
- Use it on Library and Agents list/detail eyebrows (was `text-[0.65rem]`).
- Refactor Metrics experimental headers to the same token.

## Test plan
- [ ] Library: meta line "Library · …" matches Metrics "Metrics · 7d · personal" size
- [ ] Agents/Profiles: meta line matches same size
- [ ] Agent detail breadcrumb unchanged visually except size bump to `text-xs`


Made with [Cursor](https://cursor.com)