### PR TITLE
Rename Agents → Profiles, Specialist → Profile in user-facing UI

### DIFF
--- a/src/components/V2/Agents/AgentCard.tsx
+++ b/src/components/V2/Agents/AgentCard.tsx
@@ -71,7 +71,7 @@ export function AgentCard({ agent }: Props) {
           </div>
           <Button asChild size="sm" variant="outline">
             <Link to="/v2/agents/$slug" params={{ slug: agent.slug }}>
-              View specialist
+              View profile
               <ArrowRight className="size-4" />
             </Link>
           </Button>

--- a/src/components/V2/Agents/AgentDetailSkeleton.tsx
+++ b/src/components/V2/Agents/AgentDetailSkeleton.tsx
@@ -37,7 +37,7 @@ export function AgentDetailSkeleton({
     <output
       className={cn(shellClassName, "py-6")}
       aria-busy="true"
-      aria-label="Loading specialist"
+      aria-label="Loading profile"
     >
       {!hideHeader && (
         <>

--- a/src/components/V2/Agents/AgentHero.tsx
+++ b/src/components/V2/Agents/AgentHero.tsx
@@ -15,7 +15,7 @@ export function AgentHero({ agent }: Props) {
       <div className="relative max-w-4xl">
         <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-sm text-white/80">
           <Sparkles className="size-4" />
-          Taskforce specialist
+          Taskforce profile
         </div>
         <h1 className="text-4xl font-semibold tracking-tight md:text-6xl">
           {agent.name}

--- a/src/components/V2/Agents/AgentStatsRail.tsx
+++ b/src/components/V2/Agents/AgentStatsRail.tsx
@@ -15,7 +15,7 @@ export function AgentStatsRail({ stats }: Props) {
 
   return (
     <aside className="rounded-3xl border bg-background p-6 shadow-sm">
-      <h2 className="text-lg font-semibold">Specialist impact</h2>
+      <h2 className="text-lg font-semibold">Profile impact</h2>
       <div className="mt-5 space-y-4">
         {rows.map(([label, value]) => (
           <div key={label} className="rounded-2xl bg-muted/40 p-4">

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -707,7 +707,7 @@ function ExperimentalSessionMetrics({
               params={{ slug: sessionSavings.specialist_slug }}
               className="mt-3 inline-flex items-center gap-1.5 border border-border px-2.5 py-1 font-mono text-xs uppercase tracking-[0.12em] text-foreground hover:bg-muted"
             >
-              Routed to{" "}
+              Selected profile:{" "}
               <span className="font-semibold normal-case tracking-normal">
                 {sessionSavings.specialist_name ??
                   sessionSavings.specialist_slug}

--- a/src/components/V2/TaskforceLandingPage.tsx
+++ b/src/components/V2/TaskforceLandingPage.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button"
 const navItems = [
   { icon: Search, label: "Search" },
   { icon: BookOpenText, label: "Library" },
-  { icon: Bot, label: "Agents" },
+  { icon: Bot, label: "Profiles" },
   { icon: BarChart3, label: "Metrics" },
 ]
 

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -66,7 +66,7 @@ type TaskforceNavItem = {
 const taskforceItems: TaskforceNavItem[] = [
   { icon: Search, title: "Search", path: "/v2/search" },
   { icon: BookOpen, title: "Library", path: "/v2/library" },
-  { icon: Bot, title: "Agents", path: "/v2/agents" },
+  { icon: Bot, title: "Profiles", path: "/v2/agents" },
   { icon: LineChart, title: "Metrics", path: "/v2/metrics" },
   { icon: Rocket, title: "Upgrade", path: "/v2/pricing" },
 ]

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -43,7 +43,7 @@ export const Route = createFileRoute("/v2/agents/$slug")({
   head: () => ({
     meta: [
       {
-        title: "Taskforce | Agent Specialist",
+        title: "Taskforce | Profile",
       },
     ],
   }),
@@ -344,12 +344,12 @@ function AgentDetailPage() {
         <div
           className={`${V2_PAGE_CONTENT} min-h-[50vh] items-center justify-center text-center`}
         >
-          <h1 className={AGENT_PAGE_TITLE_CLASS}>Specialist not found</h1>
+          <h1 className={AGENT_PAGE_TITLE_CLASS}>Profile not found</h1>
           <p className="mt-3 max-w-lg text-sm leading-6 text-muted-foreground">
-            This specialist is unavailable or you do not have access.
+            This profile is unavailable or you do not have access.
           </p>
           <Button asChild className="mt-6">
-            <Link to="/v2/agents">Back to agents</Link>
+            <Link to="/v2/agents">Back to profiles</Link>
           </Button>
         </div>
       </section>
@@ -386,7 +386,7 @@ function AgentDetailPage() {
             </div>
             <p className={AGENT_DETAIL_SUBTITLE_CLASS}>
               <span className="font-semibold text-foreground">{agent.role}</span>
-              <span> · specialist playbook</span>
+              <span> · profile playbook</span>
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -457,7 +457,7 @@ function AgentDetailPage() {
         {agentQuery.isFetching && !isHydratingDetail && (
           <div className="mt-5 inline-flex items-center gap-2 text-sm text-zinc-400 dark:text-zinc-500">
             <Loader2 className="size-4 animate-spin" />
-            Refreshing specialist
+            Refreshing profile
           </div>
         )}
       </div>


### PR DESCRIPTION
External buyers read 'agent' / 'specialist' as autonomous LLM agents. Renames user-visible strings only. Pairs with backend TF-205 (#99). /v2/agents/<slug> URL kept for deep-link compat. AgentSpecialist class + specialist_slug/_name field names unchanged.