### PR TITLE
Fix metrics methodology nested route

### DIFF
--- a/src/routes/v2/metrics.tsx
+++ b/src/routes/v2/metrics.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Outlet, useRouterState } from "@tanstack/react-router"
 import { z } from "zod"
 
 import { MetricsPage } from "@/components/V2/Metrics/MetricsPage"
@@ -20,7 +20,18 @@ export const Route = createFileRoute("/v2/metrics")({
 })
 
 function TaskforceMetrics() {
+  const router = useRouterState()
+  const pathname = router.location.pathname
   const { currentUser } = Route.useRouteContext()
   const { session_id: sessionId } = Route.useSearch()
+
+  // Child route /v2/metrics/methodology renders via Outlet (same pattern as library/agents).
+  if (
+    pathname.startsWith("/v2/metrics/") &&
+    pathname.replace(/\/+$/, "") !== "/v2/metrics"
+  ) {
+    return <Outlet />
+  }
+
   return <MetricsPage currentUser={currentUser} sessionId={sessionId} />
 }

--- a/tests/v2-metrics-session.spec.ts
+++ b/tests/v2-metrics-session.spec.ts
@@ -301,3 +301,25 @@ test("experimental mode shows expressive aggregate metrics", async ({
   await expect(page.getByTestId("metrics-session-filter-banner")).toHaveCount(0)
   expect(sessionSavingsRequests).toBe(0)
 })
+
+test("metrics methodology route renders from direct URL and metrics link", async ({
+  page,
+}) => {
+  await mockMetricsPage(page)
+
+  await page.goto("/v2/metrics/methodology")
+  await expect(page).toHaveURL(/\/v2\/metrics\/methodology$/)
+  await expect(
+    page.getByRole("heading", { name: /how we calculate savings/i }),
+  ).toBeVisible()
+  await expect(page.getByRole("link", { name: /back to metrics/i })).toBeVisible()
+
+  await page.getByRole("link", { name: /back to metrics/i }).click()
+  await expect(page).toHaveURL(/\/v2\/metrics$/)
+
+  await page.getByRole("link", { name: /learn how we calculate savings/i }).click()
+  await expect(page).toHaveURL(/\/v2\/metrics\/methodology$/)
+  await expect(
+    page.getByRole("heading", { name: /how we calculate savings/i }),
+  ).toBeVisible()
+})


### PR DESCRIPTION
## Summary
`/v2/metrics/methodology` was registered as a child of `/v2/metrics` but the parent always rendered `MetricsPage` without an `<Outlet />`, so the methodology page never mounted (link appeared to do nothing).

- Match library/agents pattern: hand off to `<Outlet />` when pathname is under `/v2/metrics/` but not exactly `/v2/metrics`.
- Add Playwright coverage for direct URL + back link + methodology link from metrics.

## Test plan
- [x] `npm run build`
- [x] Playwright: metrics methodology route test
- [ ] GitHub Pages deploy


Made with [Cursor](https://cursor.com)