### PR TITLE
Opaque library document sticky header

### DIFF
--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -842,7 +842,7 @@ function TaskforceDocumentDetail() {
         <div
           data-testid="v2-document-sticky-header"
           className={cn(
-            "sticky top-0 z-20 -mx-6 border-b bg-background/95 px-6 pt-1 pb-3 backdrop-blur supports-[backdrop-filter]:bg-background/80",
+            "sticky top-0 z-20 -mx-6 border-b bg-background px-6 pt-1 pb-3",
             isSplit && "md:shrink-0",
           )}
         >


### PR DESCRIPTION
## Summary\nSolid `bg-background` on library document sticky header (matches profile detail #185).

Made with [Cursor](https://cursor.com)