### PR TITLE
Fix profile sticky header scroll bleed-through

### DIFF
--- a/src/components/V2/v2PageShell.ts
+++ b/src/components/V2/v2PageShell.ts
@@ -17,6 +17,12 @@ export const V2_PAGE_CONTENT = cn(
 )
 
 /**
+ * Padded page body when `V2_PAGE_FRAME` is the scroll container (avoids nested overflow
+ * breaking `position: sticky`).
+ */
+export const V2_PAGE_BODY = cn("flex flex-col gap-6", V2_PAGE_PADDING)
+
+/**
  * Library-style tab body: same padding as Agents, but overflow hidden for split panes.
  */
 export const V2_PAGE_CONTENT_FIXED = cn(
@@ -28,9 +34,9 @@ export const V2_PAGE_CONTENT_FIXED = cn(
 export const V2_TAB_EYEBROW_CLASS =
   "font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground"
 
-/** Sticky page header inside a `V2_PAGE_CONTENT` scroll area (offsets `p-6` padding). */
+/** Sticky page header inside a padded scroll area (offsets `p-6` padding). */
 export const V2_STICKY_HEADER_CLASS = cn(
-  "sticky top-0 z-20 -mx-6 shrink-0 border-b bg-background px-6 pb-4",
+  "sticky top-0 z-30 -mx-6 -mt-6 shrink-0 border-b bg-background px-6 pt-6 pb-4",
 )
 
 /** @deprecated Prefer V2_PAGE_CONTENT for tab pages. */

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -33,6 +33,7 @@ import {
   formatRelativeTime,
 } from "@/components/V2/Agents/formatters"
 import {
+  V2_PAGE_BODY,
   V2_PAGE_CONTENT,
   V2_PAGE_FRAME,
   V2_STICKY_HEADER_CLASS,
@@ -49,7 +50,7 @@ export const Route = createFileRoute("/v2/agents/$slug")({
   }),
 })
 
-const AGENTS_DETAIL_SHELL = V2_PAGE_CONTENT
+const AGENTS_DETAIL_SHELL = V2_PAGE_BODY
 
 function initials(name: string) {
   return name

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -842,7 +842,7 @@ function TaskforceDocumentDetail() {
         <div
           data-testid="v2-document-sticky-header"
           className={cn(
-            "sticky top-0 z-20 -mx-6 border-b bg-background px-6 pt-1 pb-3",
+            "sticky top-0 z-30 -mx-6 border-b bg-background px-6 pt-1 pb-3",
             isSplit && "md:shrink-0",
           )}
         >


### PR DESCRIPTION
## Summary
Nested `overflow-y-auto` on frame + content broke sticky positioning, so routing chips scrolled over the breadcrumb row even with opaque bg.

- Add `V2_PAGE_BODY` (padded, no inner scroll) for profile detail
- Sticky header: solid bg, `z-30`, `-mt-6 pt-6` to cover parent padding
- Library document sticky: solid bg + `z-30`


Made with [Cursor](https://cursor.com)