### PR TITLE
Remove Extras label from sidebar footer

### DIFF
--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -256,6 +256,7 @@ function SidebarUtilityDrawer({
         type="button"
         data-testid="taskforce-sidebar-utility-handle"
         aria-expanded={!isCollapsed}
+        aria-label="Sidebar utilities"
         className="flex h-8 w-full cursor-ns-resize items-center justify-between rounded-md px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
         onClick={handleHandleClick}
         onPointerDown={handlePointerDown}
@@ -264,7 +265,6 @@ function SidebarUtilityDrawer({
         onPointerCancel={handlePointerUp}
       >
         <GripHorizontal className="size-4" />
-        <span className="group-data-[collapsible=icon]:sr-only">Extras</span>
         <span className="group-data-[collapsible=icon]:hidden">
           {isCollapsed ? (
             <ChevronUp className="size-4" />

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -93,7 +93,7 @@ test("Taskforce v2 sidebar includes drag collapse and Extras controls", async ({
 
   await expect(page.getByTestId("sidebar-collapse-toggle")).toHaveCount(0)
   await expect(sidebarRail).toBeVisible()
-  await expect(extrasHandle).toContainText("Extras")
+  await expect(extrasHandle).toHaveAttribute("aria-label", "Sidebar utilities")
   await expect(extrasDrawer).toContainText("Demo mode")
   await expect(documentLookup).toBeVisible()
   await expect(documentLookup).toHaveAttribute(


### PR DESCRIPTION
## Summary\n- Drop "Extras" text from utility drawer toggle\n- Keep grip + chevron; add aria-label for accessibility

Made with [Cursor](https://cursor.com)