### PR TITLE
Add profile session card view to the agents index

### DIFF
--- a/src/components/V2/Agents/AgentSessionCard.tsx
+++ b/src/components/V2/Agents/AgentSessionCard.tsx
@@ -1,0 +1,134 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { ArrowRight } from "lucide-react"
+
+import {
+  type AgentSpecialistInvocationSummary,
+  type AgentSpecialistSummary,
+  getAgent,
+} from "@/api/v2Agents"
+import { useDemoMode } from "@/components/demo-mode-provider"
+import { Skeleton } from "@/components/ui/skeleton"
+import { cn } from "@/lib/utils"
+import { AGENT_ROUTE_CHIP_CLASS } from "./agentsTypography"
+import { formatRelativeTime } from "./formatters"
+
+const INVOCATION_LIMIT = 3
+
+type Props = {
+  agent: AgentSpecialistSummary
+}
+
+export function AgentSessionCard({ agent }: Props) {
+  const { isDemoMode } = useDemoMode()
+  const detailQuery = useQuery({
+    queryKey: ["v2-agent-detail", agent.slug, isDemoMode],
+    queryFn: () => getAgent(agent.slug, { demo: isDemoMode }),
+    staleTime: 30_000,
+  })
+
+  const invocations = detailQuery.data?.recent_invocations.slice(
+    0,
+    INVOCATION_LIMIT,
+  )
+
+  return (
+    <article
+      data-testid="agent-session-card"
+      className="group relative flex flex-col border border-border bg-background transition-colors hover:border-foreground/40"
+    >
+      <Link
+        to="/v2/agents/$slug"
+        params={{ slug: agent.slug }}
+        aria-label={`Open profile ${agent.name}`}
+        className="absolute inset-0 z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+      />
+
+      <header className="px-4 pt-4 pb-3">
+        <h3 className="text-2xl font-semibold leading-tight tracking-tight text-foreground">
+          {agent.name}
+        </h3>
+        <p className="mt-1 text-sm leading-5 text-muted-foreground">
+          {agent.role}
+        </p>
+      </header>
+
+      <div className="flex flex-wrap gap-1 px-4 pb-3">
+        {agent.domain_tags.slice(0, 4).map((tag) => (
+          <span key={tag} className={AGENT_ROUTE_CHIP_CLASS}>
+            {tag.toLowerCase()}
+          </span>
+        ))}
+      </div>
+
+      <div className="border-t border-border/70 px-4 py-3">
+        <InvocationList
+          isLoading={detailQuery.isLoading}
+          invocations={invocations}
+        />
+      </div>
+
+      <footer className="mt-auto flex items-center justify-between gap-3 border-t border-border/70 px-4 py-2 text-xs text-muted-foreground">
+        <span className="tabular-nums">
+          Last invoked {formatRelativeTime(agent.last_invoked_at)}
+        </span>
+        <span className="relative z-20 inline-flex items-center gap-1 text-foreground">
+          Open
+          <ArrowRight className="size-3.5" aria-hidden />
+        </span>
+      </footer>
+    </article>
+  )
+}
+
+function InvocationList({
+  isLoading,
+  invocations,
+}: {
+  isLoading: boolean
+  invocations: AgentSpecialistInvocationSummary[] | undefined
+}) {
+  if (isLoading || !invocations) {
+    return (
+      <ul className="space-y-2">
+        {Array.from({ length: INVOCATION_LIMIT }).map((_, index) => (
+          <li
+            key={index}
+            className="grid grid-cols-[1fr_auto] items-center gap-3"
+          >
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-10" />
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  if (invocations.length === 0) {
+    return (
+      <p className="text-xs italic text-muted-foreground">
+        No invocations yet.
+      </p>
+    )
+  }
+
+  return (
+    <ul className="space-y-1.5">
+      {invocations.map((invocation) => (
+        <li
+          key={invocation.id}
+          className={cn(
+            "grid grid-cols-[1fr_auto] items-baseline gap-3 text-xs",
+          )}
+        >
+          <span className="truncate text-foreground" title={invocation.prompt}>
+            {invocation.prompt}
+          </span>
+          <span className="tabular-nums text-muted-foreground">
+            {formatRelativeTime(invocation.created_at)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -5,16 +5,13 @@ import {
   Outlet,
   useRouterState,
 } from "@tanstack/react-router"
-import { Bot, Loader2 } from "lucide-react"
+import { Bot, LayoutGrid, List, Loader2 } from "lucide-react"
+import { useEffect, useState } from "react"
 
 import { type AgentSpecialistSummary, listAgents } from "@/api/v2Agents"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Skeleton } from "@/components/ui/skeleton"
-import { cn } from "@/lib/utils"
-import {
-  formatCompactNumber,
-  formatRelativeTime,
-} from "@/components/V2/Agents/formatters"
+import { AgentSessionCard } from "@/components/V2/Agents/AgentSessionCard"
 import {
   AGENT_EYEBROW_CLASS,
   AGENT_FEATURE_STRIP_VALUE_CLASS,
@@ -25,7 +22,33 @@ import {
   AGENT_STAT_LABEL_CLASS,
   AGENT_TABLE_HEADER_CLASS,
 } from "@/components/V2/Agents/agentsTypography"
+import {
+  formatCompactNumber,
+  formatRelativeTime,
+} from "@/components/V2/Agents/formatters"
 import { V2_PAGE_CONTENT, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
+import { cn } from "@/lib/utils"
+
+type AgentsViewMode = "grid" | "list"
+
+const AGENTS_VIEW_STORAGE_KEY = "v2-agents-view"
+
+function readStoredView(): AgentsViewMode {
+  if (typeof window === "undefined") return "list"
+  const stored = window.sessionStorage.getItem(AGENTS_VIEW_STORAGE_KEY)
+  return stored === "grid" || stored === "list" ? stored : "list"
+}
+
+function useAgentsViewMode(): [AgentsViewMode, (mode: AgentsViewMode) => void] {
+  const [view, setView] = useState<AgentsViewMode>(() => readStoredView())
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    window.sessionStorage.setItem(AGENTS_VIEW_STORAGE_KEY, view)
+  }, [view])
+
+  return [view, setView]
+}
 
 export const Route = createFileRoute("/v2/agents")({
   component: TaskforceAgents,
@@ -145,21 +168,86 @@ function AgentsFeatureStrip({ agents }: { agents: AgentSpecialistSummary[] }) {
   )
 }
 
-function FilterPills() {
+function HeaderActions({
+  view,
+  onChange,
+}: {
+  view: AgentsViewMode
+  onChange: (mode: AgentsViewMode) => void
+}) {
   return (
-    <div className="flex flex-wrap gap-1.5 text-xs uppercase tracking-wide">
-      <span className="border border-zinc-950 bg-zinc-950 px-2 py-1 text-white dark:border-white dark:bg-white dark:text-zinc-950">
-        All
-      </span>
-      <span className="border border-border px-2 py-1 text-muted-foreground">
-        Mine
-      </span>
-      <span className="border border-border px-2 py-1 text-muted-foreground">
-        Team
-      </span>
+    <div className="flex flex-wrap items-center gap-1.5 text-xs uppercase tracking-wide">
+      <ViewToggle view={view} onChange={onChange} />
       <span className="border border-border px-2 py-1 text-muted-foreground normal-case">
         + Create profile
       </span>
+    </div>
+  )
+}
+
+function ViewToggle({
+  view,
+  onChange,
+}: {
+  view: AgentsViewMode
+  onChange: (mode: AgentsViewMode) => void
+}) {
+  return (
+    <div className="inline-flex border border-border">
+      <ToggleButton
+        active={view === "list"}
+        onClick={() => onChange("list")}
+        label="List view"
+        icon={<List className="size-3.5" aria-hidden />}
+      />
+      <ToggleButton
+        active={view === "grid"}
+        onClick={() => onChange("grid")}
+        label="Grid view"
+        icon={<LayoutGrid className="size-3.5" aria-hidden />}
+      />
+    </div>
+  )
+}
+
+function ToggleButton({
+  active,
+  onClick,
+  label,
+  icon,
+}: {
+  active: boolean
+  onClick: () => void
+  label: string
+  icon: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      aria-label={label}
+      onClick={onClick}
+      className={cn(
+        "flex items-center justify-center px-2 py-1 transition-colors",
+        active
+          ? "bg-zinc-950 text-white dark:bg-white dark:text-zinc-950"
+          : "text-muted-foreground hover:bg-muted",
+      )}
+    >
+      {icon}
+    </button>
+  )
+}
+
+function AgentsGrid({ agents }: { agents: AgentSpecialistSummary[] }) {
+  return (
+    <div
+      data-testid="agents-card-grid"
+      className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+    >
+      {agents.map((agent) => (
+        <AgentSessionCard key={agent.id} agent={agent} />
+      ))}
     </div>
   )
 }
@@ -187,10 +275,7 @@ function AgentRow({ agent }: { agent: AgentSpecialistSummary }) {
 
       <div className="flex flex-wrap gap-1">
         {tags.map((tag) => (
-          <span
-            key={tag}
-            className={AGENT_ROUTE_CHIP_CLASS}
-          >
+          <span key={tag} className={AGENT_ROUTE_CHIP_CLASS}>
             {tag.toLowerCase()}
           </span>
         ))}
@@ -260,6 +345,7 @@ function EmptyAgents({ isDemoMode }: { isDemoMode: boolean }) {
 
 function AgentsIndex() {
   const { isDemoMode } = useDemoMode()
+  const [view, setView] = useAgentsViewMode()
   const agentsQuery = useQuery({
     queryKey: ["v2-agents", isDemoMode],
     queryFn: () => listAgents({ demo: isDemoMode }),
@@ -279,7 +365,7 @@ function AgentsIndex() {
             </div>
             <h1 className={cn("mt-1", AGENT_PAGE_TITLE_CLASS)}>Profiles</h1>
           </div>
-          <FilterPills />
+          <HeaderActions view={view} onChange={setView} />
         </header>
 
         <AgentsFeatureStrip agents={agents} />
@@ -287,7 +373,11 @@ function AgentsIndex() {
         {agentsQuery.isLoading ? (
           <AgentsLoading />
         ) : agents.length > 0 ? (
-          <AgentsList agents={agents} />
+          view === "grid" ? (
+            <AgentsGrid agents={agents} />
+          ) : (
+            <AgentsList agents={agents} />
+          )
         ) : (
           <EmptyAgents isDemoMode={isDemoMode} />
         )}


### PR DESCRIPTION
## Summary

- New `AgentSessionCard` component on `/v2/agents`: large profile name + role on top, route chips, list of 3 recent invocations, slim "Last invoked / Open" footer. No tokens-saved sparkline. No owner avatars.
- Per-card `getAgent(slug)` fetch via react-query for the recent invocations (parallel + cached, no backend changes needed).
- New grid/list view toggle in the index header; choice persists in `sessionStorage` (`v2-agents-view`) per tab.
- Removed the All / Mine / Team filter pills (`+ Create profile` CTA stays).

## Test plan

- [ ] Open `/v2/agents` — list view renders unchanged (default)
- [ ] Click grid icon — cards render with name, role, chips, 3 invocations, foot
- [ ] Refresh — grid view persists (sessionStorage)
- [ ] Open new tab, navigate to `/v2/agents` — defaults to list view again (per-tab scope)
- [ ] Click a card — opens `/v2/agents/$slug`
- [ ] Demo mode toggle — cards re-fetch invocations correctly
- [ ] Loading state — skeleton rows show for ~150ms then fill in

Note: local node is 18 so vite build wasn't run; `tsc --noEmit` and `biome check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)