### PR TITLE
Match document page bottom padding to top spacing

### DIFF
--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -850,7 +850,7 @@ function TaskforceDocumentDetail() {
     >
       <article
         className={cn(
-          "flex w-full max-w-none flex-col px-6 pb-16 pt-0",
+          "flex w-full max-w-none flex-col px-6 pb-6 pt-0",
           isSplit && "md:min-h-0 md:flex-1 md:overflow-hidden",
         )}
       >


### PR DESCRIPTION
## Summary
- Document detail page used \`pb-16\` (~4rem) at the bottom while the content opens with \`pt-6\` at the top, producing a visibly oversized bottom margin. Set the article's bottom padding to \`pb-6\` so the top and bottom feel balanced.

## Test plan
- [ ] Open any document — confirm the empty space below the last content block matches the top spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)