### PR TITLE
Halve document page bottom padding

### DIFF
--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -850,7 +850,7 @@ function TaskforceDocumentDetail() {
     >
       <article
         className={cn(
-          "flex w-full max-w-none flex-col px-6 pb-6 pt-0",
+          "flex w-full max-w-none flex-col px-6 pb-3 pt-0",
           isSplit && "md:min-h-0 md:flex-1 md:overflow-hidden",
         )}
       >


### PR DESCRIPTION
## Summary
- Reduce the document detail page bottom padding from \`pb-6\` to \`pb-3\` so the last content block sits closer to the viewport edge.

## Test plan
- [ ] Open a document — confirm the empty space at the bottom is roughly half of what it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)