### PR TITLE
Polish agents index header and card

### DIFF
--- a/src/components/V2/Agents/AgentSessionCard.tsx
+++ b/src/components/V2/Agents/AgentSessionCard.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
-import { ArrowRight } from "lucide-react"
 
 import {
   type AgentSpecialistInvocationSummary,
@@ -68,13 +67,9 @@ export function AgentSessionCard({ agent }: Props) {
         />
       </div>
 
-      <footer className="mt-auto flex items-center justify-between gap-3 border-t border-border/70 px-4 py-2 text-xs text-muted-foreground">
+      <footer className="mt-auto border-t border-border/70 px-4 py-2 text-xs text-muted-foreground">
         <span className="tabular-nums">
           Last invoked {formatRelativeTime(agent.last_invoked_at)}
-        </span>
-        <span className="relative z-20 inline-flex items-center gap-1 text-foreground">
-          Open
-          <ArrowRight className="size-3.5" aria-hidden />
         </span>
       </footer>
     </article>

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react"
 
 import { type AgentSpecialistSummary, listAgents } from "@/api/v2Agents"
 import { useDemoMode } from "@/components/demo-mode-provider"
+import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AgentSessionCard } from "@/components/V2/Agents/AgentSessionCard"
 import {
@@ -151,7 +152,7 @@ function AgentsFeatureStrip({ agents }: { agents: AgentSpecialistSummary[] }) {
       </div>
       <div className="border-b border-border px-3.5 py-3 md:border-r md:border-b-0">
         <div className={AGENT_STAT_LABEL_CLASS}>Top performer</div>
-        <div className={`mt-1 truncate text-base font-semibold`}>
+        <div className={`mt-1 truncate ${AGENT_FEATURE_STRIP_VALUE_CLASS}`}>
           {performer?.name ?? "No profiles"}
         </div>
       </div>
@@ -176,11 +177,11 @@ function HeaderActions({
   onChange: (mode: AgentsViewMode) => void
 }) {
   return (
-    <div className="flex flex-wrap items-center gap-1.5 text-xs uppercase tracking-wide">
+    <div className="flex flex-wrap items-center gap-2">
       <ViewToggle view={view} onChange={onChange} />
-      <span className="border border-border px-2 py-1 text-muted-foreground normal-case">
+      <Button type="button" size="sm" variant="outline" className="w-fit">
         + Create profile
-      </span>
+      </Button>
     </div>
   )
 }
@@ -193,7 +194,7 @@ function ViewToggle({
   onChange: (mode: AgentsViewMode) => void
 }) {
   return (
-    <div className="inline-flex border border-border">
+    <div className="inline-flex h-9 w-fit shrink-0 items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground">
       <ToggleButton
         active={view === "list"}
         onClick={() => onChange("list")}
@@ -226,12 +227,12 @@ function ToggleButton({
       type="button"
       aria-pressed={active}
       aria-label={label}
+      data-state={active ? "active" : "inactive"}
       onClick={onClick}
       className={cn(
-        "flex items-center justify-center px-2 py-1 transition-colors",
-        active
-          ? "bg-zinc-950 text-white dark:bg-white dark:text-zinc-950"
-          : "text-muted-foreground hover:bg-muted",
+        "inline-flex h-[calc(100%-1px)] items-center justify-center whitespace-nowrap rounded-md border border-transparent px-3 py-1 text-foreground transition-[color,box-shadow] focus-visible:border-ring focus-visible:outline-1 focus-visible:outline-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "data-[state=active]:bg-background data-[state=active]:shadow-sm",
+        "dark:text-muted-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
       )}
     >
       {icon}


### PR DESCRIPTION
## Summary

- Drop the redundant "Open →" affordance from `AgentSessionCard`'s footer — the card already routes via an overlay link.
- Uniformize the feature strip typography: "Top performer" now uses the same `AGENT_FEATURE_STRIP_VALUE_CLASS` as "Total saved" and "Idle > 30d".
- "+ Create profile" rebuilt as a shadcn `Button variant="outline"`, matching the library page's `+ Folder` badge.
- Grid/list view toggle rebuilt with the library ownership-toggle styling (`rounded-lg bg-muted p-[3px]` container, shadcn `data-state` active treatment).

## Test plan

- [ ] /v2/agents header shows "+ Create profile" matching library "+ Folder" style
- [ ] Grid/list toggle has the same rounded muted-bg shell as library ownership toggle
- [ ] Active toggle tab shows light background + soft shadow
- [ ] Feature strip "Top performer" value renders at the same size as "Total saved"
- [ ] Grid view cards no longer show "Open →" in the footer; click anywhere on the card still navigates

🤖 Generated with [Claude Code](https://claude.com/claude-code)