### PR TITLE
Frontend polish: drop negative triggers UI, purple/green accents

### DIFF
--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -32,6 +32,7 @@ import {
   V2_TAB_EYEBROW_CLASS,
 } from "@/components/V2/v2PageShell"
 import { usePersistentState } from "@/hooks/usePersistentState"
+import { cn } from "@/lib/utils"
 import { formatDelta, formatMetricValue } from "./formatters"
 import { MethodologyLink } from "./MethodologyLink"
 import { MetricBreakdown } from "./MetricBreakdown"
@@ -840,7 +841,14 @@ function ExperimentalMetricTile({
         {total}
       </div>
       {delta && (
-        <div className="mt-1 font-mono text-xs text-muted-foreground">
+        <div
+          className={cn(
+            "mt-1 font-mono text-xs",
+            delta.sign === "up" && "text-emerald-600 dark:text-emerald-400",
+            delta.sign === "down" && "text-rose-600 dark:text-rose-400",
+            delta.sign === "flat" && "text-muted-foreground",
+          )}
+        >
           {delta.sign === "flat"
             ? "No change"
             : `${delta.sign === "up" ? "▲" : "▼"} ${delta.label} vs previous`}
@@ -1014,7 +1022,6 @@ function formatRatioValue(value: number) {
     maximumFractionDigits: value >= 10 ? 0 : 1,
   })
 }
-
 
 function SessionLogTable({
   entries,

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -22,7 +22,6 @@ import {
   AGENT_DETAIL_SUBTITLE_CLASS,
   AGENT_PAGE_TITLE_CLASS,
   AGENT_ROUTE_CHIP_CLASS,
-  AGENT_ROUTE_LABEL_CLASS,
   AGENT_SECTION_META_CLASS,
   AGENT_SECTION_TITLE_CLASS,
   AGENT_STAT_LABEL_CLASS,
@@ -131,23 +130,13 @@ function SectionHeader({ title, meta }: { title: string; meta?: string }) {
   )
 }
 
-function Chips({
-  values,
-  variant = "positive",
-}: {
-  values: string[]
-  variant?: "positive" | "negative"
-}) {
+function Chips({ values }: { values: string[] }) {
   return (
     <div className="flex flex-wrap gap-1.5">
       {values.map((value) => (
         <span
           key={value}
-          className={`${
-            variant === "negative"
-              ? "border border-zinc-200 px-1.5 py-0.5 text-xs text-zinc-500 line-through dark:border-white/10 dark:text-zinc-500"
-              : `${AGENT_ROUTE_CHIP_CLASS} border-[#8447ff]/30 text-[#8447ff]`
-          }`}
+          className={`${AGENT_ROUTE_CHIP_CLASS} border-[#8447ff]/30 text-[#8447ff]`}
         >
           {value}
         </span>
@@ -425,23 +414,8 @@ function AgentDetailPage() {
 
             <section className="pt-2">
               <SectionHeader title="Tags" />
-              <div className="space-y-3 py-3">
-                <div className="space-y-2">
-                  <Chips values={agent.routing_triggers} />
-                </div>
-                {agent.negative_triggers.length > 0 && (
-                  <div className="space-y-2">
-                    <div className={AGENT_ROUTE_LABEL_CLASS}>
-                      <span className="text-zinc-400 dark:text-zinc-600">
-                        do_not_route_when:
-                      </span>
-                    </div>
-                    <Chips
-                      values={agent.negative_triggers}
-                      variant="negative"
-                    />
-                  </div>
-                )}
+              <div className="py-3">
+                <Chips values={agent.routing_triggers} />
               </div>
             </section>
 

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -144,7 +144,9 @@ function AgentsFeatureStrip({ agents }: { agents: AgentSpecialistSummary[] }) {
       <div className="border-b border-border px-3.5 py-3 md:border-r md:border-b-0">
         <div className={AGENT_STAT_LABEL_CLASS}>Total saved</div>
         <div className={`mt-1 ${AGENT_FEATURE_STRIP_VALUE_CLASS}`}>
-          {formatCompactNumber(tokensSaved)}{" "}
+          <span className="text-[#8447ff]">
+            {formatCompactNumber(tokensSaved)}
+          </span>{" "}
           <small className="text-xs font-medium text-muted-foreground">
             tokens
           </small>
@@ -179,8 +181,8 @@ function HeaderActions({
   return (
     <div className="flex flex-wrap items-center gap-2">
       <ViewToggle view={view} onChange={onChange} />
-      <Button type="button" size="sm" variant="outline" className="w-fit">
-        + Create profile
+      <Button type="button" size="sm" className="w-fit">
+        + Profile
       </Button>
     </div>
   )


### PR DESCRIPTION
## Summary

- Remove the `do_not_route_when` block from the profile detail page Tags section entirely. Drop the now-unused `variant` prop on `Chips` and the `AGENT_ROUTE_LABEL_CLASS` import.
- Agents index "Total saved" number now renders in primary purple (#8447ff); the trailing "tokens" small stays muted.
- Rename "+ Create profile" to "+ Profile" and switch from outline to filled primary variant, matching library's "+ Document" affordance.
- Color metrics page deltas: up = emerald, down = rose, flat = muted — matches the existing `MetricCard` treatment so positive trends read green on the main dashboard.

## Test plan

- [ ] /v2/agents/jensen and any other profile: no `do_not_route_when:` block at all
- [ ] /v2/agents header: "Total saved" number is purple, "tokens" stays muted
- [ ] /v2/agents header: button reads "+ Profile" as a filled primary button
- [ ] /v2/metrics overview: +X% deltas render green, -X% render rose

🤖 Generated with [Claude Code](https://claude.com/claude-code)