### PR TITLE
Add public /pricing route and tighten landing nav

### DIFF
--- a/src/data/membershipPlans.ts
+++ b/src/data/membershipPlans.ts
@@ -1,0 +1,62 @@
+export type MembershipTier = "free" | "pro" | "max"
+
+export type MembershipPlan = {
+  tier: MembershipTier
+  name: string
+  eyebrow: string
+  price: string
+  priceDetail: string
+  description: string
+  benefits: string[]
+  cta: string
+  disabled?: boolean
+  highlighted?: boolean
+}
+
+export const membershipPlans: MembershipPlan[] = [
+  {
+    tier: "free",
+    name: "Free",
+    eyebrow: "Start here",
+    price: "$0",
+    priceDetail: "/ month",
+    description:
+      "A lightweight workspace for trying Taskforce and keeping your context organized.",
+    benefits: [
+      "Up to 3 agent profiles",
+      "256 MB of library storage",
+    ],
+    cta: "Included",
+  },
+  {
+    tier: "pro",
+    name: "Pro",
+    eyebrow: "Early adopter special",
+    price: "$4.99",
+    priceDetail: "/ month for the first 3 months",
+    description: "A robust memory layer for serious builders and teams.",
+    benefits: [
+      "Up to 100 agent profiles",
+      "100 GB of document storage",
+      "Organizations up to 100 members",
+    ],
+    cta: "Select this tier",
+    highlighted: true,
+  },
+  {
+    tier: "max",
+    name: "Max",
+    eyebrow: "The ultimate package",
+    price: "$49.99",
+    priceDetail: "/ month",
+    description:
+      "For enterprise scale teams who can't waste a moment or token.",
+    benefits: [
+      "Up to 1,000 agent profiles",
+      "1 TB of library storage",
+      "Organizations up to 1,000 members",
+      "Access to Enterprise Search in Taskforce",
+    ],
+    cta: "Select this tier",
+  },
+]

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as V2RouteImport } from './routes/v2'
 import { Route as SignupRouteImport } from './routes/signup'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as RecoverPasswordRouteImport } from './routes/recover-password'
+import { Route as PricingRouteImport } from './routes/pricing'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as LandingRouteImport } from './routes/landing'
 import { Route as LayoutRouteImport } from './routes/_layout'
@@ -54,6 +55,11 @@ const ResetPasswordRoute = ResetPasswordRouteImport.update({
 const RecoverPasswordRoute = RecoverPasswordRouteImport.update({
   id: '/recover-password',
   path: '/recover-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PricingRoute = PricingRouteImport.update({
+  id: '/pricing',
+  path: '/pricing',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -170,6 +176,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/landing': typeof LandingRoute
   '/login': typeof LoginRoute
+  '/pricing': typeof PricingRoute
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
@@ -197,6 +204,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/landing': typeof LandingRoute
   '/login': typeof LoginRoute
+  '/pricing': typeof PricingRoute
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
@@ -225,6 +233,7 @@ export interface FileRoutesById {
   '/_layout': typeof LayoutRouteWithChildren
   '/landing': typeof LandingRoute
   '/login': typeof LoginRoute
+  '/pricing': typeof PricingRoute
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
@@ -254,6 +263,7 @@ export interface FileRouteTypes {
     | '/'
     | '/landing'
     | '/login'
+    | '/pricing'
     | '/recover-password'
     | '/reset-password'
     | '/signup'
@@ -281,6 +291,7 @@ export interface FileRouteTypes {
     | '/'
     | '/landing'
     | '/login'
+    | '/pricing'
     | '/recover-password'
     | '/reset-password'
     | '/signup'
@@ -308,6 +319,7 @@ export interface FileRouteTypes {
     | '/_layout'
     | '/landing'
     | '/login'
+    | '/pricing'
     | '/recover-password'
     | '/reset-password'
     | '/signup'
@@ -337,6 +349,7 @@ export interface RootRouteChildren {
   LayoutRoute: typeof LayoutRouteWithChildren
   LandingRoute: typeof LandingRoute
   LoginRoute: typeof LoginRoute
+  PricingRoute: typeof PricingRoute
   RecoverPasswordRoute: typeof RecoverPasswordRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
   SignupRoute: typeof SignupRoute
@@ -371,6 +384,13 @@ declare module '@tanstack/react-router' {
       path: '/recover-password'
       fullPath: '/recover-password'
       preLoaderRoute: typeof RecoverPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/pricing': {
+      id: '/pricing'
+      path: '/pricing'
+      fullPath: '/pricing'
+      preLoaderRoute: typeof PricingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -618,6 +638,7 @@ const rootRouteChildren: RootRouteChildren = {
   LayoutRoute: LayoutRouteWithChildren,
   LandingRoute: LandingRoute,
   LoginRoute: LoginRoute,
+  PricingRoute: PricingRoute,
   RecoverPasswordRoute: RecoverPasswordRoute,
   ResetPasswordRoute: ResetPasswordRoute,
   SignupRoute: SignupRoute,

--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -13,8 +13,8 @@ export const Route = createFileRoute("/landing")({
 
 const proofStats = [
   { label: "Saved this week", value: "$614 / 40.9M tokens" },
-  { label: "Profile selected", value: "Jensen" },
-  { label: "Setup", value: "4-min MCP" },
+  { label: "Context saved today", value: "127 work sessions" },
+  { label: "Setup time", value: "3 minutes" },
 ]
 
 const terminalLines = [
@@ -80,9 +80,13 @@ function LandingExpressive() {
           />
           Taskforce
         </Link>
-        <div className="flex items-center gap-5 font-mono text-[1.0625rem] text-zinc-500 dark:text-zinc-400">
-          <span className="hidden sm:inline">Docs</span>
-          <span className="hidden sm:inline">Pricing</span>
+        <div className="flex items-center gap-5 font-mono text-[0.796875rem] text-zinc-500 dark:text-zinc-400">
+          <Link
+            to="/pricing"
+            className="hidden hover:text-zinc-950 dark:hover:text-white sm:inline"
+          >
+            Pricing
+          </Link>
           <Link
             to="/login"
             className="hover:text-zinc-950 dark:hover:text-white"
@@ -91,7 +95,7 @@ function LandingExpressive() {
           </Link>
           <Link
             to="/signup"
-            className="bg-zinc-950 px-[1.171875rem] py-[0.78125rem] text-white dark:bg-white dark:text-zinc-950"
+            className="bg-zinc-950 px-[0.78125rem] py-[0.46875rem] text-white dark:bg-white dark:text-zinc-950"
           >
             Sign up →
           </Link>
@@ -155,9 +159,6 @@ function LandingExpressive() {
                 <span className="size-1.5 bg-emerald-400" />
                 <span className="text-zinc-200">
                   claude — fix/stripe-webhook-double-fulfillment
-                </span>
-                <span className="ml-auto text-[0.65rem] text-zinc-500">
-                  foreground skill
                 </span>
               </div>
 

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -1,0 +1,127 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { Check } from "lucide-react"
+
+import { membershipPlans } from "@/data/membershipPlans"
+import { cn } from "@/lib/utils"
+
+export const Route = createFileRoute("/pricing")({
+  component: PublicPricing,
+  head: () => ({
+    meta: [
+      {
+        title: "Taskforce | Pricing",
+      },
+    ],
+  }),
+})
+
+function PublicPricing() {
+  return (
+    <main
+      data-testid="public-pricing"
+      className="min-h-svh overflow-hidden bg-white text-zinc-950 dark:bg-zinc-950 dark:text-white"
+    >
+      <nav className="relative z-10 flex h-[5.46875rem] items-center justify-between border-b border-zinc-200 bg-white px-5 dark:border-white/10 dark:bg-zinc-950 md:px-8">
+        <Link
+          to="/landing"
+          className="inline-flex items-center gap-3 text-[1.3671875rem] font-semibold leading-none"
+          aria-label="Taskforce landing"
+        >
+          <img
+            src="/assets/brand/tf-icon-filled.svg"
+            alt=""
+            className="size-[2.34375rem] dark:hidden"
+          />
+          <img
+            src="/assets/brand/tf-icon-filled-dark.svg"
+            alt=""
+            className="hidden size-[2.34375rem] dark:block"
+          />
+          Taskforce
+        </Link>
+        <div className="flex items-center gap-5 font-mono text-[0.796875rem] text-zinc-500 dark:text-zinc-400">
+          <Link
+            to="/pricing"
+            className="hidden text-zinc-950 dark:text-white sm:inline"
+          >
+            Pricing
+          </Link>
+          <Link
+            to="/login"
+            className="hover:text-zinc-950 dark:hover:text-white"
+          >
+            Log in
+          </Link>
+          <Link
+            to="/signup"
+            className="bg-zinc-950 px-[0.78125rem] py-[0.46875rem] text-white dark:bg-white dark:text-zinc-950"
+          >
+            Sign up →
+          </Link>
+        </div>
+      </nav>
+
+      <section className="mx-auto max-w-6xl px-5 py-12 md:px-8 md:py-16">
+        <div className="max-w-3xl space-y-3">
+          <div className="font-mono text-[0.85rem] font-medium uppercase tracking-[0.22em] text-[#8447ff]">
+            Pricing
+          </div>
+          <h1 className="text-4xl font-semibold leading-tight tracking-[-0.025em] md:text-5xl">
+            Choose the Taskforce tier right for your team
+          </h1>
+        </div>
+
+        <div className="mt-10 grid gap-4 lg:grid-cols-3">
+          {membershipPlans.map((plan) => (
+            <div
+              key={plan.tier}
+              data-testid={`public-plan-${plan.tier}`}
+              className={cn(
+                "flex flex-col border border-zinc-200 bg-white p-6 dark:border-white/10 dark:bg-zinc-950",
+                plan.highlighted && "bg-zinc-50 dark:bg-zinc-900/40",
+              )}
+            >
+              <p className="font-mono text-[0.7rem] font-medium uppercase tracking-[0.18em] text-zinc-500 dark:text-zinc-400">
+                {plan.eyebrow}
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold">{plan.name}</h2>
+              <p className="mt-2 text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+                {plan.description}
+              </p>
+
+              <div className="mt-6 flex items-baseline gap-2">
+                <span className="text-4xl font-semibold">{plan.price}</span>
+                {plan.priceDetail && (
+                  <span className="text-sm text-zinc-500 dark:text-zinc-400">
+                    {plan.priceDetail}
+                  </span>
+                )}
+              </div>
+
+              <ul className="mt-6 flex flex-1 flex-col gap-3 text-sm text-zinc-700 dark:text-zinc-300">
+                {plan.benefits.map((benefit) => (
+                  <li key={benefit} className="flex items-start gap-3">
+                    <Check className="mt-0.5 size-4 shrink-0 text-emerald-600" />
+                    <span>{benefit}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <Link
+                to="/signup"
+                className={cn(
+                  "mt-8 inline-flex items-center justify-center border px-4 py-3 font-mono text-xs tracking-[0.04em]",
+                  plan.tier === "free"
+                    ? "border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-white/20 dark:text-zinc-200 dark:hover:bg-white/10"
+                    : "border-zinc-950 bg-zinc-950 text-white dark:border-white dark:bg-white dark:text-zinc-950",
+                )}
+              >
+                {plan.tier === "free" ? "Start free →" : `Get ${plan.name} →`}
+              </Link>
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/routes/v2/pricing.tsx
+++ b/src/routes/v2/pricing.tsx
@@ -16,73 +16,13 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { LoadingButton } from "@/components/ui/loading-button"
+import {
+  membershipPlans,
+  type MembershipTier,
+} from "@/data/membershipPlans"
 import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
 import { handleError } from "@/utils"
-
-type MembershipTier = "free" | "pro" | "max"
-
-type MembershipPlan = {
-  tier: MembershipTier
-  name: string
-  eyebrow: string
-  price: string
-  priceDetail: string
-  description: string
-  benefits: string[]
-  cta: string
-  disabled?: boolean
-  highlighted?: boolean
-}
-
-const membershipPlans: MembershipPlan[] = [
-  {
-    tier: "free",
-    name: "Free",
-    eyebrow: "Start here",
-    price: "$0",
-    priceDetail: "/ month",
-    description:
-      "A lightweight workspace for trying Taskforce and keeping your context organized.",
-    benefits: [
-      "Up to 3 agent profiles",
-      "256 MB of library storage",
-    ],
-    cta: "Included",
-  },
-  {
-    tier: "pro",
-    name: "Pro",
-    eyebrow: "Early adopter special",
-    price: "$4.99",
-    priceDetail: "/ month for the first 3 months",
-    description:
-      "A robust memory layer for serious builders and teams.",
-    benefits: [
-      "Up to 100 agent profiles",
-      "100 GB of document storage",
-      "Organizations up to 100 members",
-    ],
-    cta: "Select this tier",
-    highlighted: true,
-  },
-  {
-    tier: "max",
-    name: "Max",
-    eyebrow: "The ultimate package",
-    price: "$49.99",
-    priceDetail: "/ month",
-    description:
-      "For enterprise scale teams who can't waste a moment or token.",
-    benefits: [
-      "Up to 1,000 agent profiles",
-      "1 TB of library storage",
-      "Organizations up to 1,000 members",
-      "Access to Enterprise Search in Taskforce",
-    ],
-    cta: "Select this tier",
-  },
-]
 
 export const Route = createFileRoute("/v2/pricing")({
   component: TaskforcePricingRoute,


### PR DESCRIPTION
## Summary
- New public `/pricing` route (no auth) reusing the locked Free/Pro/Max plan data, extracted to `src/data/membershipPlans.ts` and shared with `/v2/pricing`.
- Landing nav: "Pricing" now links to the new public page, removed "Docs", shrunk nav font ~25%, tightened "Sign up" button padding (font unchanged).
- Landing terminal header: dropped "foreground skill" badge.
- Landing proof stats: replaced "Profile selected / Jensen" → "Context saved today / 127 work sessions"; "Setup / 4-min MCP" → "Setup time / 3 minutes".

## Test plan
- [ ] Visit `/landing` — confirm nav shows Pricing/Log in/Sign up (no Docs), smaller fonts, tighter Sign up button.
- [ ] Click "Pricing" → lands on public `/pricing` with three tier cards; "Sign up" CTAs route to `/signup`.
- [ ] Confirm `/v2/pricing` still works for logged-in users (data reused from shared module).