### PR TITLE
Tighten pricing tier copy and headline treatment

### DIFF
--- a/src/data/membershipPlans.ts
+++ b/src/data/membershipPlans.ts
@@ -20,8 +20,7 @@ export const membershipPlans: MembershipPlan[] = [
     eyebrow: "Start here",
     price: "$0",
     priceDetail: "/ month",
-    description:
-      "A lightweight workspace for trying Taskforce and keeping your context organized.",
+    description: "For hobbyists and those getting started",
     benefits: [
       "Up to 3 agent profiles",
       "256 MB of library storage",
@@ -34,10 +33,10 @@ export const membershipPlans: MembershipPlan[] = [
     eyebrow: "Early adopter special",
     price: "$4.99",
     priceDetail: "/ month for the first 3 months",
-    description: "A robust memory layer for serious builders and teams.",
+    description: "For serious builders and small teams",
     benefits: [
       "Up to 100 agent profiles",
-      "100 GB of document storage",
+      "100 GB of library storage",
       "Organizations up to 100 members",
     ],
     cta: "Select this tier",
@@ -50,7 +49,7 @@ export const membershipPlans: MembershipPlan[] = [
     price: "$49.99",
     priceDetail: "/ month",
     description:
-      "For enterprise scale teams who can't waste a moment or token.",
+      "For enterprise scale teams who can't waste a moment or token",
     benefits: [
       "Up to 1,000 agent profiles",
       "1 TB of library storage",

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -66,8 +66,9 @@ function PublicPricing() {
           <div className="font-mono text-[0.85rem] font-medium uppercase tracking-[0.22em] text-[#8447ff]">
             Pricing
           </div>
-          <h1 className="text-4xl font-semibold leading-tight tracking-[-0.025em] md:text-5xl">
-            Choose the Taskforce tier right for your team
+          <h1 className="text-2xl font-semibold leading-tight tracking-[-0.025em] md:whitespace-nowrap md:text-4xl">
+            Choose the <span className="text-[#8447ff]">Taskforce</span> tier
+            right for your team
           </h1>
         </div>
 

--- a/src/routes/v2/pricing.tsx
+++ b/src/routes/v2/pricing.tsx
@@ -68,8 +68,9 @@ function TaskforcePricing({ currentUser }: { currentUser: UserPublic }) {
           <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
             Taskforce Membership
           </p>
-          <h1 className="text-3xl font-semibold tracking-tight">
-            Choose the Taskforce tier right for your team
+          <h1 className="text-2xl font-semibold tracking-tight md:whitespace-nowrap md:text-3xl">
+            Choose the <span className="text-[#8447ff]">Taskforce</span> tier
+            right for your team
           </h1>
         </div>
 


### PR DESCRIPTION
## Summary
- Locked tier descriptions: Free → "For hobbyists and those getting started"; Pro → "For serious builders and small teams"; Max → "For enterprise scale teams who can't waste a moment or token". No trailing periods.
- Pro benefit "100 GB of document storage" → "100 GB of library storage".
- Pricing headline (both `/pricing` and `/v2/pricing`): slightly smaller, single-line on md+, "Taskforce" in brand purple.

## Test plan
- [ ] Visit `/pricing` and `/v2/pricing` — headline reads on one line at md+ with purple "Taskforce", and each tier card shows the new description.