### PR TITLE
Cycle 5 landing terminal scenarios with faster typing

### DIFF
--- a/src/components/V2/LandingTerminal.tsx
+++ b/src/components/V2/LandingTerminal.tsx
@@ -9,53 +9,236 @@ type Line = {
   accent?: string
 }
 
-const LINES: Line[] = [
+type Scenario = {
+  branch: string
+  lines: Line[]
+  summary: {
+    profile: string
+    saved: string
+  }
+}
+
+const SCENARIOS: Scenario[] = [
   {
-    name: "you",
-    tone: "prompt",
-    text: "/tf Stripe is double-charging users on plan upgrades — webhook retries are getting fulfilled twice. Can you fix it?",
+    branch: "fix/stripe-webhook-double-fulfillment",
+    summary: { profile: "Jensen profile · 2 docs referenced", saved: "$614" },
+    lines: [
+      {
+        name: "you",
+        tone: "prompt",
+        text: "/tf Stripe is double-charging users on plan upgrades — webhook retries are getting fulfilled twice. Can you fix it?",
+      },
+      {
+        name: "tf",
+        tone: "dim",
+        text: "Checking Taskforce for the right profile...",
+      },
+      {
+        name: "tf",
+        tone: "dim",
+        text: 'Sending prompt + cwd + files + git_branch "fix/stripe-webhook-double-fulfillment". No code body. No chat history.',
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Selected profile: Jensen — Billing Reliability.",
+        accent: "Confidence: high · Stripe webhook retries · plan upgrades",
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Jensen is bringing in Stripe webhook idempotency strategy and the plan-upgrade replay regression pattern.",
+      },
+      {
+        name: "you",
+        tone: "prompt",
+        text: "Apply that pattern and prove the retry only fulfills once.",
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Patch written. Regression test passes. Recording the session back to Taskforce.",
+      },
+    ],
   },
   {
-    name: "tf",
-    tone: "dim",
-    text: "Checking Taskforce for the right profile...",
+    branch: "fix/jwt-refresh-race",
+    summary: { profile: "Mira profile · 3 docs referenced", saved: "$892" },
+    lines: [
+      {
+        name: "you",
+        tone: "prompt",
+        text: "/tf Mobile clients are getting kicked out mid-session — JWT refresh is racing the new rotation flow. Can you patch it?",
+      },
+      {
+        name: "tf",
+        tone: "dim",
+        text: "Checking Taskforce for the right profile...",
+      },
+      {
+        name: "tf",
+        tone: "dim",
+        text: 'Sending prompt + cwd + files + git_branch "fix/jwt-refresh-race". No code body. No chat history.',
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Selected profile: Mira — Auth & Sessions.",
+        accent: "Confidence: high · JWT rotation · refresh race",
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Mira is bringing in the refresh-token mutex pattern and last quarter's rotation rollback notes.",
+      },
+      {
+        name: "you",
+        tone: "prompt",
+        text: "Apply it and add a regression that two parallel refreshes only consume one rotation.",
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Patch applied. Race test passes. Recording the session back to Taskforce.",
+      },
+    ],
   },
   {
-    name: "tf",
-    tone: "dim",
-    text: 'Sending prompt + cwd + files + git_branch "fix/stripe-webhook-double-fulfillment". No code body. No chat history.',
+    branch: "perf/orders-list-n-plus-one",
+    summary: { profile: "Park profile · 4 docs referenced", saved: "$1,103" },
+    lines: [
+      {
+        name: "you",
+        tone: "prompt",
+        text: "/tf Orders page is taking 8s to load for big merchants — looks like an N+1. Can you trace it?",
+      },
+      {
+        name: "tf",
+        tone: "dim",
+        text: "Checking Taskforce for the right profile...",
+      },
+      {
+        name: "tf",
+        tone: "dim",
+        text: 'Sending prompt + cwd + files + git_branch "perf/orders-list-n-plus-one". No code body. No chat history.',
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Selected profile: Park — Query Performance.",
+        accent: "Confidence: high · ORM N+1 · merchant scale",
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Park is bringing in the prefetch_related playbook from the inventory refactor.",
+      },
+      {
+        name: "you",
+        tone: "prompt",
+        text: "Apply it and prove the query count drops below 5 for 1k orders.",
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Patch written. Query trace: 412 → 4. Recording the session back to Taskforce.",
+      },
+    ],
   },
   {
-    name: "tf",
-    tone: "body",
-    text: "Selected profile: Jensen — Billing Reliability.",
-    accent: "Confidence: high · Stripe webhook retries · plan upgrades",
+    branch: "hotfix/blue-green-cutover",
+    summary: { profile: "Iris profile · 3 docs referenced", saved: "$478" },
+    lines: [
+      {
+        name: "you",
+        tone: "prompt",
+        text: "/tf Blue/green cutover is failing the readiness gate on us-east-2 since the new health check landed. What broke?",
+      },
+      {
+        name: "tf",
+        tone: "dim",
+        text: "Checking Taskforce for the right profile...",
+      },
+      {
+        name: "tf",
+        tone: "dim",
+        text: 'Sending prompt + cwd + files + git_branch "hotfix/blue-green-cutover". No code body. No chat history.',
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Selected profile: Iris — Release Engineering.",
+        accent: "Confidence: high · readiness probes · cutover",
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Iris is bringing in the readiness-grace bump from the March rollback and the ALB drain timing notes.",
+      },
+      {
+        name: "you",
+        tone: "prompt",
+        text: "Apply the grace bump and rerun the canary.",
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Probe grace tuned. Canary green. Recording the session back to Taskforce.",
+      },
+    ],
   },
   {
-    name: "tf",
-    tone: "body",
-    text: "Jensen is bringing in Stripe webhook idempotency strategy and the plan-upgrade replay regression pattern.",
-  },
-  {
-    name: "you",
-    tone: "prompt",
-    text: "Apply that pattern and prove the retry only fulfills once.",
-  },
-  {
-    name: "tf",
-    tone: "body",
-    text: "Patch written. Regression test passes. Recording the session back to Taskforce.",
+    branch: "fix/react-key-collision",
+    summary: { profile: "Noor profile · 2 docs referenced", saved: "$356" },
+    lines: [
+      {
+        name: "you",
+        tone: "prompt",
+        text: "/tf Library list is dropping rows in prod after the virtualization swap — keys collide on duplicate titles. Fix?",
+      },
+      {
+        name: "tf",
+        tone: "dim",
+        text: "Checking Taskforce for the right profile...",
+      },
+      {
+        name: "tf",
+        tone: "dim",
+        text: 'Sending prompt + cwd + files + git_branch "fix/react-key-collision". No code body. No chat history.',
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Selected profile: Noor — Frontend Reliability.",
+        accent: "Confidence: high · virtualization · key strategy",
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Noor is bringing in the stable-id derivation pattern we shipped for the metrics table.",
+      },
+      {
+        name: "you",
+        tone: "prompt",
+        text: "Apply it and assert no duplicate keys for 5k generated docs.",
+      },
+      {
+        name: "tf",
+        tone: "body",
+        text: "Stable keys wired. Render test green. Recording the session back to Taskforce.",
+      },
+    ],
   },
 ]
 
-const YOU_CHAR_MS = 22
-const YOU_CHAR_JITTER = 26
-const TF_CHAR_MS = 9
-const ACCENT_CHAR_MS = 12
+const YOU_CHAR_MS = 20
+const YOU_CHAR_JITTER = 23
+const TF_CHAR_MS = 8
+const ACCENT_CHAR_MS = 11
 const PRE_LINE_PAUSE_YOU = 650
 const PRE_LINE_PAUSE_TF = 380
 const POST_LINE_PAUSE = 320
-const SUMMARY_HOLD_MS = 6500
+const SUMMARY_HOLD_MS = 5000
 const LOOP_PAUSE_MS = 700
 
 type ActiveLine = {
@@ -88,13 +271,15 @@ function prefersReducedMotion(): boolean {
 }
 
 export function LandingTerminal() {
+  const [scenarioIndex, setScenarioIndex] = useState(0)
   const [visibleCount, setVisibleCount] = useState(0)
   const [active, setActive] = useState<ActiveLine | null>(null)
   const [summaryVisible, setSummaryVisible] = useState(false)
 
   useEffect(() => {
     if (prefersReducedMotion()) {
-      setVisibleCount(LINES.length)
+      setScenarioIndex(0)
+      setVisibleCount(SCENARIOS[0].lines.length)
       setSummaryVisible(true)
       return
     }
@@ -126,15 +311,20 @@ export function LandingTerminal() {
 
     const play = async () => {
       try {
+        let s = 0
         while (!signal.aborted) {
+          setScenarioIndex(s)
           setVisibleCount(0)
           setActive(null)
           setSummaryVisible(false)
           await wait(LOOP_PAUSE_MS)
 
-          for (let i = 0; i < LINES.length; i++) {
-            const line = LINES[i]
-            await wait(line.name === "you" ? PRE_LINE_PAUSE_YOU : PRE_LINE_PAUSE_TF)
+          const scenario = SCENARIOS[s]
+          for (let i = 0; i < scenario.lines.length; i++) {
+            const line = scenario.lines[i]
+            await wait(
+              line.name === "you" ? PRE_LINE_PAUSE_YOU : PRE_LINE_PAUSE_TF,
+            )
             await streamLine(i, line)
             setVisibleCount(i + 1)
             setActive(null)
@@ -144,6 +334,8 @@ export function LandingTerminal() {
           await wait(500)
           setSummaryVisible(true)
           await wait(SUMMARY_HOLD_MS)
+
+          s = (s + 1) % SCENARIOS.length
         }
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
@@ -160,29 +352,27 @@ export function LandingTerminal() {
     }
   }, [])
 
+  const scenario = SCENARIOS[scenarioIndex]
+
   return (
     <div className="border border-zinc-950 bg-zinc-950 p-3 font-mono text-[0.68rem] leading-5 text-zinc-100 shadow-2xl dark:border-white/15 md:p-4 lg:text-[0.72rem]">
       <div className="mb-3 flex items-center gap-2 border-b border-white/15 pb-3">
         <span className="size-1.5 bg-emerald-400" />
-        <span className="text-zinc-200">
-          claude — fix/stripe-webhook-double-fulfillment
-        </span>
+        <span className="text-zinc-200">claude — {scenario.branch}</span>
       </div>
 
       <div className="space-y-1.5" aria-hidden="true">
-        {LINES.map((line, index) => {
+        {scenario.lines.map((line, index) => {
           const isFull = index < visibleCount
           const isActive = active?.index === index
           if (!isFull && !isActive) return null
 
-          const displayedText = isFull ? line.text : active?.text ?? ""
-          const displayedAccent = isFull
-            ? line.accent
-            : active?.accent ?? ""
+          const displayedText = isFull ? line.text : (active?.text ?? "")
+          const displayedAccent = isFull ? line.accent : (active?.accent ?? "")
 
           return (
             <div
-              key={`${line.name}-${index}`}
+              key={`${scenarioIndex}-${index}`}
               className="grid grid-cols-[2rem_minmax(0,1fr)] gap-2"
             >
               <span
@@ -228,16 +418,12 @@ export function LandingTerminal() {
           <div className="uppercase tracking-[0.16em] text-zinc-500">
             recorded
           </div>
-          <div className="mt-1 text-zinc-200">
-            Jensen profile · 2 docs referenced
-          </div>
+          <div className="mt-1 text-zinc-200">{scenario.summary.profile}</div>
         </div>
         <div>
-          <div className="uppercase tracking-[0.16em] text-zinc-500">
-            saved
-          </div>
+          <div className="uppercase tracking-[0.16em] text-zinc-500">saved</div>
           <div className="mt-1 text-sm font-semibold text-[#c9a8ff] tabular-nums">
-            $614
+            {scenario.summary.saved}
           </div>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- Replace the single Jensen/Stripe scenario with five rotating scenarios — each with its own branch, agent profile, problem framing, and saved-cost summary:
  - Jensen — Billing Reliability (Stripe double-charge)
  - Mira — Auth & Sessions (JWT refresh race)
  - Park — Query Performance (N+1 on orders)
  - Iris — Release Engineering (blue/green readiness)
  - Noor — Frontend Reliability (React key collision)
- After the summary holds 5s, advance to the next scenario; loop indefinitely.
- Bump typing/streaming cadence ~10% across the board (you 22→20ms, jitter 26→23ms, tf 9→8ms, accent 12→11ms).

## Test plan
- [ ] Visit `/landing` — first scenario types, summary appears, holds ~5s, then next scenario fades to its own branch + summary; loop wraps after the 5th.
- [ ] With "Reduce motion" on, first scenario renders immediately and does not cycle.