### PR TITLE
Start landing terminal at a random scenario

### DIFF
--- a/src/components/V2/LandingTerminal.tsx
+++ b/src/components/V2/LandingTerminal.tsx
@@ -311,7 +311,7 @@ export function LandingTerminal() {
 
     const play = async () => {
       try {
-        let s = 0
+        let s = Math.floor(Math.random() * SCENARIOS.length)
         while (!signal.aborted) {
           setScenarioIndex(s)
           setVisibleCount(0)


### PR DESCRIPTION
## Summary
- Pick a random scenario index on mount so each `/landing` refresh leads with a different problem; the rotation then continues in order and loops.
- Reduced-motion path unchanged (renders the first scenario only) so the landing test stays deterministic.

## Test plan
- [ ] Refresh `/landing` several times — first scenario shown varies; subsequent scenarios advance in order, wrapping after the 5th.