### PR TITLE
Slide landing terminal closed and split hero compatibility line

### DIFF
--- a/src/components/V2/LandingTerminal.tsx
+++ b/src/components/V2/LandingTerminal.tsx
@@ -239,7 +239,7 @@ const PRE_LINE_PAUSE_YOU = 650
 const PRE_LINE_PAUSE_TF = 380
 const POST_LINE_PAUSE = 320
 const SUMMARY_HOLD_MS = 5000
-const CLOSE_FADE_MS = 420
+const CLOSE_FADE_MS = 620
 const LOOP_PAUSE_MS = 700
 
 type ActiveLine = {
@@ -394,10 +394,10 @@ export function LandingTerminal({
 
       <div
         className={cn(
-          "space-y-1.5 transition-opacity",
+          "space-y-1.5 transition-[opacity,transform] ease-[cubic-bezier(0.65,0,0.35,1)] will-change-transform",
           bodyVisible
-            ? "opacity-100 duration-200"
-            : "opacity-0 duration-[420ms]",
+            ? "translate-y-0 opacity-100 duration-200"
+            : "translate-y-10 opacity-0 duration-[600ms]",
         )}
         aria-hidden="true"
       >
@@ -448,10 +448,12 @@ export function LandingTerminal({
 
       <div
         className={cn(
-          "mt-4 grid gap-3 border border-white/15 bg-white/[0.04] p-3 text-[0.65rem] transition-opacity sm:grid-cols-[1fr_auto_auto]",
+          "mt-4 grid gap-3 border border-white/15 bg-white/[0.04] p-3 text-[0.65rem] transition-[opacity,transform] ease-[cubic-bezier(0.65,0,0.35,1)] will-change-transform sm:grid-cols-[1fr_auto_auto]",
           summaryVisible && bodyVisible
-            ? "opacity-100 duration-300"
-            : "pointer-events-none opacity-0 duration-[420ms]",
+            ? "translate-y-0 opacity-100 duration-300"
+            : bodyVisible
+              ? "pointer-events-none translate-y-0 opacity-0 duration-300"
+              : "pointer-events-none translate-y-10 opacity-0 duration-[600ms]",
         )}
         aria-hidden={!summaryVisible || !bodyVisible}
       >

--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -179,7 +179,8 @@ function LandingExpressive() {
               for coding agents. It remembers the work your team has already
               done so the next agent doesn't have to rediscover the same
               answers.
-              <br />
+            </p>
+            <p className="mt-3 max-w-[50ch] font-mono text-xs leading-5 tracking-[0.02em] text-zinc-500 dark:text-zinc-400">
               Works with Claude Code, Codex, and Cursor.
             </p>
             <div className="mt-6 flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- Slide the landing terminal contents downward with cubic-bezier(0.65, 0, 0.35, 1) easing during the close/reset, instead of a flat opacity fade
- Replace the inline line break with a dedicated mono compatibility paragraph and add spacing between the hero block and the "Works with Claude Code, Codex, and Cursor." line

## Test plan
- [ ] Open /landing and watch a full scenario cycle — the body and summary should slide down together as the terminal resets, then the next scenario streams in fresh
- [ ] Confirm the hero copy now reads as two stacked blocks with breathing room between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)