### PR TITLE
Keep summary block in layout while landing terminal collapses

### DIFF
--- a/src/components/V2/LandingTerminal.tsx
+++ b/src/components/V2/LandingTerminal.tsx
@@ -450,37 +450,35 @@ export function LandingTerminal({
               )
             })}
           </div>
+        </div>
+      </div>
 
-          <div
-            className={cn(
-              "mt-4 grid gap-3 border border-white/15 bg-white/[0.04] p-3 text-[0.65rem] transition-opacity duration-300 sm:grid-cols-[1fr_auto_auto]",
-              summaryVisible ? "opacity-100" : "pointer-events-none opacity-0",
-            )}
-            aria-hidden={!summaryVisible}
-          >
-            <div>
-              <div className="uppercase tracking-[0.16em] text-zinc-500">
-                recorded
-              </div>
-              <div className="mt-1 text-zinc-200">
-                {scenario.summary.profile}
-              </div>
-            </div>
-            <div>
-              <div className="uppercase tracking-[0.16em] text-zinc-500">
-                saved
-              </div>
-              <div className="mt-1 text-sm font-semibold text-[#c9a8ff] tabular-nums">
-                {scenario.summary.saved}
-              </div>
-            </div>
-            <div>
-              <div className="uppercase tracking-[0.16em] text-zinc-500">
-                metrics
-              </div>
-              <div className="mt-1 text-zinc-200">session link ready →</div>
-            </div>
+      <div
+        className={cn(
+          "mt-4 grid gap-3 border border-white/15 bg-white/[0.04] p-3 text-[0.65rem] transition-opacity duration-300 sm:grid-cols-[1fr_auto_auto]",
+          summaryVisible && bodyVisible
+            ? "opacity-100"
+            : "pointer-events-none opacity-0",
+        )}
+        aria-hidden={!summaryVisible || !bodyVisible}
+      >
+        <div>
+          <div className="uppercase tracking-[0.16em] text-zinc-500">
+            recorded
           </div>
+          <div className="mt-1 text-zinc-200">{scenario.summary.profile}</div>
+        </div>
+        <div>
+          <div className="uppercase tracking-[0.16em] text-zinc-500">saved</div>
+          <div className="mt-1 text-sm font-semibold text-[#c9a8ff] tabular-nums">
+            {scenario.summary.saved}
+          </div>
+        </div>
+        <div>
+          <div className="uppercase tracking-[0.16em] text-zinc-500">
+            metrics
+          </div>
+          <div className="mt-1 text-zinc-200">session link ready →</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- The summary block was inside the collapsing grid row, so the close animation shrank below the empty-scenario starting height (which already reserves space for the summary). The next scenario then expanded back to that reserved height, producing a visible snap
- Move the summary outside the collapsing wrapper so its layout space is always reserved; fade opacity based on \`summaryVisible && bodyVisible\`
- Lines area still collapses 1fr → 0fr with cubic-bezier(0.65, 0, 0.35, 1) easing; the terminal now lands exactly on the starting height with no snap

## Test plan
- [ ] Watch a full scenario cycle on /landing — the terminal should collapse to the same height the empty starting state shows, with no snap-back when the next scenario begins streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)