### PR TITLE
TF-208: Ledger tab — org session feed (P1 frontend)

### DIFF
--- a/src/api/v2Ledger.ts
+++ b/src/api/v2Ledger.ts
@@ -1,0 +1,81 @@
+import { type CancelablePromise, OpenAPI } from "@/client"
+import { request } from "@/client/core/request"
+
+/**
+ * TF-208 / pipeline-surfaces P1 — org session ledger.
+ *
+ * GET /v2/taskforce/ledger — the raw tier of the pipeline: a paginated,
+ * org-scoped feed of sessions grouped from real metrics events. Hand-written
+ * wrapper (like the other src/api/v2*.ts modules) until the next
+ * `npm run generate-client` run picks the endpoint up from the OpenAPI spec.
+ *
+ * Decimal `usd_amount` arrives as a string from the backend (Pydantic),
+ * matching how v2Taskforce types `usd_saved`.
+ */
+
+export interface LedgerDocRef {
+  document_id: string
+  title: string
+  href: string
+}
+
+export interface LedgerSessionRow {
+  session_id: string
+  actor_id: string
+  actor_name: string
+  client: string | null
+  specialist_slug: string | null
+  specialist_name: string | null
+  specialist_href: string | null
+  documents: LedgerDocRef[]
+  kinds: string[]
+  net_saved_tokens: number
+  usd_amount: string
+  event_count: number
+  cross_boundary: boolean
+  occurred_at_first: string
+  occurred_at_last: string
+}
+
+export interface LedgerResponse {
+  scope: "organization"
+  organization_id: string | null
+  total: number
+  limit: number
+  offset: number
+  rows: LedgerSessionRow[]
+}
+
+export interface ReadLedgerArgs {
+  demo?: boolean
+  actorId?: string
+  client?: string
+  specialist?: string
+  crossBoundary?: boolean
+  since?: string
+  until?: string
+  q?: string
+  limit?: number
+  offset?: number
+}
+
+export function readLedger(
+  args: ReadLedgerArgs = {},
+): CancelablePromise<LedgerResponse> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/taskforce/ledger",
+    query: {
+      demo: args.demo || undefined,
+      actor_id: args.actorId || undefined,
+      client: args.client || undefined,
+      specialist: args.specialist || undefined,
+      cross_boundary: args.crossBoundary || undefined,
+      since: args.since || undefined,
+      until: args.until || undefined,
+      q: args.q || undefined,
+      limit: args.limit ?? undefined,
+      offset: args.offset ?? undefined,
+    },
+  })
+}

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -1,0 +1,220 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { ArrowLeftRight, Loader2, Search } from "lucide-react"
+import { useState } from "react"
+
+import { readLedger } from "@/api/v2Ledger"
+import { useDemoMode } from "@/components/demo-mode-provider"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  formatCompactNumber,
+  formatRelativeTime,
+  formatUsd,
+} from "@/components/V2/Agents/formatters"
+import {
+  V2_PAGE_CONTENT,
+  V2_PAGE_FRAME,
+  V2_TAB_EYEBROW_CLASS,
+} from "@/components/V2/v2PageShell"
+import { cn } from "@/lib/utils"
+
+const CLIENT_LABELS: Record<string, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+  cursor: "Cursor",
+}
+
+function clientLabel(value: string | null): string {
+  if (!value) return "—"
+  return CLIENT_LABELS[value] ?? value
+}
+
+export function LedgerPage() {
+  const { isDemoMode } = useDemoMode()
+  const [search, setSearch] = useState("")
+  const [query, setQuery] = useState("")
+  const [crossOnly, setCrossOnly] = useState(false)
+
+  const ledgerQuery = useQuery({
+    queryKey: ["v2-ledger", { demo: isDemoMode, q: query, crossOnly }],
+    queryFn: () =>
+      readLedger({
+        demo: isDemoMode,
+        q: query || undefined,
+        crossBoundary: crossOnly || undefined,
+      }),
+  })
+
+  const data = ledgerQuery.data
+  const rows = data?.rows ?? []
+
+  const onSearchSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    setQuery(search.trim())
+  }
+
+  return (
+    <section
+      className={cn(V2_PAGE_FRAME, "bg-background font-sans text-foreground")}
+    >
+      <div className={V2_PAGE_CONTENT}>
+        <header className="flex flex-col gap-2">
+          <span className={V2_TAB_EYEBROW_CLASS}>
+            Ledger{data ? ` · ${data.total} sessions` : ""}
+          </span>
+          <h1 className="text-2xl font-semibold tracking-tight">Ledger</h1>
+          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+            Every session your team runs through a Taskforce-enabled tool — what
+            was done, what it reused, and what it saved. The raw record the
+            Library and Profiles are distilled from.
+          </p>
+        </header>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <form onSubmit={onSearchSubmit} className="relative max-w-sm flex-1">
+            <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              className="pl-9"
+              placeholder="Search sessions (prompt or document)"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </form>
+          <Button
+            type="button"
+            variant={crossOnly ? "default" : "outline"}
+            size="sm"
+            onClick={() => setCrossOnly((value) => !value)}
+            aria-pressed={crossOnly}
+          >
+            <ArrowLeftRight className="size-4" />
+            Cross-boundary only
+          </Button>
+        </div>
+
+        {ledgerQuery.isError ? (
+          <div className="rounded-lg border border-dashed border-border bg-background p-8 text-sm text-muted-foreground">
+            Couldn't load the ledger. This view is organization-scoped — you
+            need to belong to an organization.
+          </div>
+        ) : ledgerQuery.isLoading ? (
+          <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            Loading sessions…
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-background p-10 text-center">
+            <h2 className="text-base font-semibold">No sessions yet</h2>
+            <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-muted-foreground">
+              {crossOnly
+                ? "No cross-boundary sessions match. Clear the filter to see all sessions."
+                : "Sessions appear here as your team works through Taskforce-enabled tools."}
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-border">
+            <Table>
+              <TableHeader>
+                <TableRow className="bg-muted">
+                  <TableHead>Who · tool</TableHead>
+                  <TableHead>Worked on</TableHead>
+                  <TableHead>Specialist</TableHead>
+                  <TableHead className="text-right">Saved</TableHead>
+                  <TableHead className="text-right">When</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.session_id}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{row.actor_name}</span>
+                        {row.cross_boundary ? (
+                          <Badge
+                            variant="secondary"
+                            className="gap-1 normal-case"
+                            title="Crossed a person or tool boundary"
+                          >
+                            <ArrowLeftRight className="size-3" />
+                            cross
+                          </Badge>
+                        ) : null}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {clientLabel(row.client)}
+                      </div>
+                    </TableCell>
+                    <TableCell className="max-w-xs">
+                      {row.documents.length > 0 ? (
+                        <div className="flex flex-col gap-0.5">
+                          {row.documents.slice(0, 3).map((doc) => (
+                            <Link
+                              key={doc.document_id}
+                              to="/v2/library/$documentId"
+                              params={{ documentId: doc.document_id }}
+                              className="truncate text-sm text-foreground hover:underline"
+                            >
+                              {doc.title}
+                            </Link>
+                          ))}
+                          {row.documents.length > 3 ? (
+                            <span className="text-xs text-muted-foreground">
+                              +{row.documents.length - 3} more
+                            </span>
+                          ) : null}
+                        </div>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {row.specialist_slug ? (
+                        <Link
+                          to="/v2/agents/$slug"
+                          params={{ slug: row.specialist_slug }}
+                          className="text-sm text-foreground hover:underline"
+                        >
+                          {row.specialist_name ?? row.specialist_slug}
+                        </Link>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="text-sm tabular-nums">
+                        {formatCompactNumber(row.net_saved_tokens)} tok
+                      </div>
+                      <div className="text-xs tabular-nums text-muted-foreground">
+                        {formatUsd(row.usd_amount)}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right text-xs tabular-nums text-muted-foreground">
+                      {formatRelativeTime(row.occurred_at_last)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        {ledgerQuery.isFetching && !ledgerQuery.isLoading ? (
+          <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="size-3 animate-spin" />
+            Refreshing
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
+}

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -6,6 +6,7 @@ import {
   useRouterState,
 } from "@tanstack/react-router"
 import {
+  ArrowLeftRight,
   BookOpen,
   Bot,
   ChevronDown,
@@ -63,10 +64,14 @@ type TaskforceNavItem = {
   path: string
 }
 
+// Ordered by the pipeline's distillation altitude (TF-206): most-distilled
+// first (Profiles ← Library ← Ledger), then Metrics as the rollup. Search stays
+// on top as the entry point; Upgrade stays at the bottom.
 const taskforceItems: TaskforceNavItem[] = [
   { icon: Search, title: "Search", path: "/v2/search" },
-  { icon: BookOpen, title: "Library", path: "/v2/library" },
   { icon: Bot, title: "Profiles", path: "/v2/agents" },
+  { icon: BookOpen, title: "Library", path: "/v2/library" },
+  { icon: ArrowLeftRight, title: "Ledger", path: "/v2/ledger" },
   { icon: LineChart, title: "Metrics", path: "/v2/metrics" },
   { icon: Rocket, title: "Upgrade", path: "/v2/pricing" },
 ]

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as V2SearchRouteImport } from './routes/v2/search'
 import { Route as V2PricingRouteImport } from './routes/v2/pricing'
 import { Route as V2MetricsRouteImport } from './routes/v2/metrics'
 import { Route as V2LibraryRouteImport } from './routes/v2/library'
+import { Route as V2LedgerRouteImport } from './routes/v2/ledger'
 import { Route as V2HomeRouteImport } from './routes/v2/home'
 import { Route as V2AgentsRouteImport } from './routes/v2/agents'
 import { Route as V2AdminRouteImport } from './routes/v2/admin'
@@ -111,6 +112,11 @@ const V2LibraryRoute = V2LibraryRouteImport.update({
   path: '/library',
   getParentRoute: () => V2Route,
 } as any)
+const V2LedgerRoute = V2LedgerRouteImport.update({
+  id: '/ledger',
+  path: '/ledger',
+  getParentRoute: () => V2Route,
+} as any)
 const V2HomeRoute = V2HomeRouteImport.update({
   id: '/home',
   path: '/home',
@@ -190,6 +196,7 @@ export interface FileRoutesByFullPath {
   '/v2/admin': typeof V2AdminRoute
   '/v2/agents': typeof V2AgentsRouteWithChildren
   '/v2/home': typeof V2HomeRoute
+  '/v2/ledger': typeof V2LedgerRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2/pricing': typeof V2PricingRoute
@@ -217,6 +224,7 @@ export interface FileRoutesByTo {
   '/v2/admin': typeof V2AdminRoute
   '/v2/agents': typeof V2AgentsRouteWithChildren
   '/v2/home': typeof V2HomeRoute
+  '/v2/ledger': typeof V2LedgerRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2/pricing': typeof V2PricingRoute
@@ -247,6 +255,7 @@ export interface FileRoutesById {
   '/v2/admin': typeof V2AdminRoute
   '/v2/agents': typeof V2AgentsRouteWithChildren
   '/v2/home': typeof V2HomeRoute
+  '/v2/ledger': typeof V2LedgerRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2/pricing': typeof V2PricingRoute
@@ -277,6 +286,7 @@ export interface FileRouteTypes {
     | '/v2/admin'
     | '/v2/agents'
     | '/v2/home'
+    | '/v2/ledger'
     | '/v2/library'
     | '/v2/metrics'
     | '/v2/pricing'
@@ -304,6 +314,7 @@ export interface FileRouteTypes {
     | '/v2/admin'
     | '/v2/agents'
     | '/v2/home'
+    | '/v2/ledger'
     | '/v2/library'
     | '/v2/metrics'
     | '/v2/pricing'
@@ -333,6 +344,7 @@ export interface FileRouteTypes {
     | '/v2/admin'
     | '/v2/agents'
     | '/v2/home'
+    | '/v2/ledger'
     | '/v2/library'
     | '/v2/metrics'
     | '/v2/pricing'
@@ -461,6 +473,13 @@ declare module '@tanstack/react-router' {
       path: '/library'
       fullPath: '/v2/library'
       preLoaderRoute: typeof V2LibraryRouteImport
+      parentRoute: typeof V2Route
+    }
+    '/v2/ledger': {
+      id: '/v2/ledger'
+      path: '/ledger'
+      fullPath: '/v2/ledger'
+      preLoaderRoute: typeof V2LedgerRouteImport
       parentRoute: typeof V2Route
     }
     '/v2/home': {
@@ -611,6 +630,7 @@ interface V2RouteChildren {
   V2AdminRoute: typeof V2AdminRoute
   V2AgentsRoute: typeof V2AgentsRouteWithChildren
   V2HomeRoute: typeof V2HomeRoute
+  V2LedgerRoute: typeof V2LedgerRoute
   V2LibraryRoute: typeof V2LibraryRouteWithChildren
   V2MetricsRoute: typeof V2MetricsRouteWithChildren
   V2PricingRoute: typeof V2PricingRoute
@@ -623,6 +643,7 @@ const V2RouteChildren: V2RouteChildren = {
   V2AdminRoute: V2AdminRoute,
   V2AgentsRoute: V2AgentsRouteWithChildren,
   V2HomeRoute: V2HomeRoute,
+  V2LedgerRoute: V2LedgerRoute,
   V2LibraryRoute: V2LibraryRouteWithChildren,
   V2MetricsRoute: V2MetricsRouteWithChildren,
   V2PricingRoute: V2PricingRoute,

--- a/src/routes/v2/ledger.tsx
+++ b/src/routes/v2/ledger.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { LedgerPage } from "@/components/V2/Ledger/LedgerPage"
+
+export const Route = createFileRoute("/v2/ledger")({
+  component: LedgerPage,
+  head: () => ({
+    meta: [
+      {
+        title: "Taskforce | Ledger",
+      },
+    ],
+  }),
+})


### PR DESCRIPTION
Part of **TF-206** (pipeline surfaces). The raw tier of the pipeline as a real surface — a dense, scannable activity feed of the org's Taskforce sessions across tools, framed as **recall/activity**, not "proof". Pairs with backend `GET /v2/taskforce/ledger` (al-exe/EnderAI #112). Spec: `docs/planning/taskforce-pipeline-surfaces-design.md` → P1.

### Changes
- `api/v2Ledger.ts`: `readLedger()` wrapper over `request(OpenAPI, …)`.
- `components/V2/Ledger/LedgerPage.tsx`: a table feed — who · tool · documents worked on (deep-linked to the Library) · specialist (deep-linked to Profiles) · tokens + USD saved · when. Free-text search + a **"Cross-boundary only"** toggle; cross-boundary is a quiet per-row badge, never a headline. Honors demo mode; reuses the Agents formatters.
- `routes/v2/ledger.tsx` + sidebar entry; sidebar reordered to the pipeline's distillation altitude: **Search · Profiles · Library · Ledger · Metrics · Upgrade**.

### Verification
- `tsc` + `vite build` + `biome` lint green; route tree regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)