### PR TITLE
Surface TF-209/210 provenance metrics

### DIFF
--- a/src/api/v2Agents.ts
+++ b/src/api/v2Agents.ts
@@ -11,6 +11,7 @@ export interface AgentSpecialistSummary {
   short_description: string
   domain_tags: string[]
   status: AgentSpecialistStatus
+  created_from: string
   linked_docs_count: number
   invocations_count: number
   tokens_saved: number
@@ -55,6 +56,7 @@ export interface AgentSpecialistDetail {
   name: string
   role: string
   description: string
+  created_from: string
   domain_tags: string[]
   routing_triggers: string[]
   negative_triggers: string[]

--- a/src/api/v2Ledger.ts
+++ b/src/api/v2Ledger.ts
@@ -79,3 +79,21 @@ export function readLedger(
     },
   })
 }
+
+export function readDocumentLedgerSessions(
+  documentId: string,
+  args: Pick<ReadLedgerArgs, "demo" | "limit" | "offset"> = {},
+): CancelablePromise<LedgerResponse> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/taskforce/documents/{document_id}/sessions",
+    path: {
+      document_id: documentId,
+    },
+    query: {
+      demo: args.demo || undefined,
+      limit: args.limit ?? undefined,
+      offset: args.offset ?? undefined,
+    },
+  })
+}

--- a/src/components/V2/Agents/agentDetailPlaceholder.ts
+++ b/src/components/V2/Agents/agentDetailPlaceholder.ts
@@ -13,6 +13,7 @@ export function agentSummaryToDetailPlaceholder(
     name: summary.name,
     role: summary.role,
     description: summary.short_description,
+    created_from: summary.created_from,
     domain_tags: summary.domain_tags,
     routing_triggers: summary.domain_tags,
     negative_triggers: [],

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
-import { Link } from "@tanstack/react-router"
+import { Link, useNavigate } from "@tanstack/react-router"
 import { ArrowLeftRight, Loader2, Search } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { readLedger } from "@/api/v2Ledger"
 import { useDemoMode } from "@/components/demo-mode-provider"
@@ -34,24 +34,67 @@ const CLIENT_LABELS: Record<string, string> = {
   cursor: "Cursor",
 }
 
+type LedgerSearchFilters = {
+  actor_id?: string
+  client?: string
+  cross_boundary?: boolean
+  q?: string
+  specialist?: string
+}
+
 function clientLabel(value: string | null): string {
   if (!value) return "—"
   return CLIENT_LABELS[value] ?? value
 }
 
-export function LedgerPage() {
+function cleanLedgerSearch(filters: LedgerSearchFilters): LedgerSearchFilters {
+  return {
+    actor_id: filters.actor_id || undefined,
+    client: filters.client || undefined,
+    cross_boundary: filters.cross_boundary || undefined,
+    q: filters.q || undefined,
+    specialist: filters.specialist || undefined,
+  }
+}
+
+export function LedgerPage({
+  searchFilters,
+}: {
+  searchFilters: LedgerSearchFilters
+}) {
   const { isDemoMode } = useDemoMode()
-  const [search, setSearch] = useState("")
-  const [query, setQuery] = useState("")
-  const [crossOnly, setCrossOnly] = useState(false)
+  const navigate = useNavigate({ from: "/v2/ledger" })
+  const query = searchFilters.q?.trim() ?? ""
+  const crossOnly = searchFilters.cross_boundary === true
+  const specialist = searchFilters.specialist?.trim() || undefined
+  const client = searchFilters.client?.trim() || undefined
+  const actorId = searchFilters.actor_id?.trim() || undefined
+  const [search, setSearch] = useState(query)
+
+  useEffect(() => {
+    setSearch(query)
+  }, [query])
+
+  const setLedgerSearch = (next: Partial<LedgerSearchFilters>) => {
+    void navigate({
+      to: "/v2/ledger",
+      search: cleanLedgerSearch({ ...searchFilters, ...next }),
+    })
+  }
 
   const ledgerQuery = useQuery({
-    queryKey: ["v2-ledger", { demo: isDemoMode, q: query, crossOnly }],
+    queryKey: [
+      "v2-ledger",
+      { actorId, client, crossOnly, demo: isDemoMode, q: query, specialist },
+    ],
     queryFn: () =>
       readLedger({
+        actorId,
+        client,
         demo: isDemoMode,
         q: query || undefined,
         crossBoundary: crossOnly || undefined,
+        specialist,
       }),
   })
 
@@ -60,8 +103,12 @@ export function LedgerPage() {
 
   const onSearchSubmit = (event: React.FormEvent) => {
     event.preventDefault()
-    setQuery(search.trim())
+    setLedgerSearch({ q: search.trim() || undefined })
   }
+
+  const hasActiveFilters = Boolean(
+    actorId || client || crossOnly || query || specialist,
+  )
 
   return (
     <section
@@ -94,12 +141,39 @@ export function LedgerPage() {
             type="button"
             variant={crossOnly ? "default" : "outline"}
             size="sm"
-            onClick={() => setCrossOnly((value) => !value)}
+            onClick={() =>
+              setLedgerSearch({ cross_boundary: crossOnly ? undefined : true })
+            }
             aria-pressed={crossOnly}
           >
             <ArrowLeftRight className="size-4" />
             Cross-boundary only
           </Button>
+          {specialist ? (
+            <Badge variant="outline">Profile · {specialist}</Badge>
+          ) : null}
+          {client ? (
+            <Badge variant="outline">Tool · {clientLabel(client)}</Badge>
+          ) : null}
+          {query ? <Badge variant="outline">Search · {query}</Badge> : null}
+          {hasActiveFilters ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                setLedgerSearch({
+                  actor_id: undefined,
+                  client: undefined,
+                  cross_boundary: undefined,
+                  q: undefined,
+                  specialist: undefined,
+                })
+              }
+            >
+              Clear
+            </Button>
+          ) : null}
         </div>
 
         {ledgerQuery.isError ? (

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
+import { ArrowLeftRight } from "lucide-react"
 import { useMemo, useState } from "react"
 import {
   type MetricDefinitionPublic,
@@ -47,6 +48,8 @@ type Props = {
 
 const PRIMARY_METRICS = ["tokens_saved", "usd_saved", "reuse_rate"]
 const SECONDARY_METRICS = ["tokens_consumed"]
+const CROSS_BOUNDARY_RATE_METRIC = "cross_boundary_reuse_rate"
+const CROSS_BOUNDARY_SAVINGS_METRIC = "cross_boundary_tokens_saved"
 
 const SAVINGS_V2_DETAIL_METRICS = [
   "avoided_rediscovery",
@@ -228,6 +231,97 @@ function formatPreciseSessionUsd(value: string | number | null | undefined) {
   return formatMetricValue(value, "usd")
 }
 
+function CrossBoundaryReusePanel({
+  rateDefinition,
+  rateValue,
+  savingsDefinition,
+  savingsValue,
+  experimental = false,
+}: {
+  rateDefinition: MetricDefinitionPublic | undefined
+  rateValue: MetricValuePublic | undefined
+  savingsDefinition: MetricDefinitionPublic | undefined
+  savingsValue: MetricValuePublic | undefined
+  experimental?: boolean
+}) {
+  const rows = savingsValue?.breakdown_by_source ?? []
+  const totalTokens = rows.reduce((sum, row) => sum + row.tokens, 0)
+  const rateLabel = formatMetricValue(rateValue?.total, "ratio")
+  const savedLabel = formatMetricValue(savingsValue?.total, "compact-int")
+
+  return (
+    <Link
+      to="/v2/ledger"
+      search={{ cross_boundary: true }}
+      data-testid="cross-boundary-metric"
+      className={cn(
+        "group block border border-border bg-background p-4 text-foreground transition-colors hover:bg-muted/40",
+        experimental ? "" : "rounded-lg shadow-sm",
+      )}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-sm font-medium text-muted-foreground">
+            {rateDefinition?.display_name ?? "Boundary-Crossing Reuse"}
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {savingsDefinition?.description ??
+              "Tokens saved when work crossed a person or tool boundary."}
+          </p>
+        </div>
+        <span className="inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground group-hover:text-foreground">
+          <ArrowLeftRight className="size-4" />
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <div>
+          <div className="text-3xl font-semibold tabular-nums">{rateLabel}</div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            of document consultations
+          </div>
+        </div>
+        <div>
+          <div className="text-3xl font-semibold tabular-nums">
+            {savedLabel}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {savingsDefinition?.display_name ?? "Boundary savings"}
+          </div>
+        </div>
+      </div>
+
+      {rows.length > 0 ? (
+        <div className="mt-4 space-y-2">
+          {rows.map((row) => {
+            const share = totalTokens > 0 ? row.tokens / totalTokens : 0
+            return (
+              <div key={row.key} className="space-y-1">
+                <div className="flex items-baseline justify-between gap-3 text-xs">
+                  <span className="text-muted-foreground">{row.label}</span>
+                  <span className="tabular-nums">
+                    {formatMetricValue(row.tokens, "compact-int")}
+                  </span>
+                </div>
+                <div className="h-1 bg-muted">
+                  <div
+                    className="h-1 bg-primary"
+                    style={{ width: `${Math.round(share * 100)}%` }}
+                  />
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      ) : (
+        <p className="mt-4 text-sm text-muted-foreground">
+          No cross-boundary reuse yet.
+        </p>
+      )}
+    </Link>
+  )
+}
+
 // Org-scope toggle is intentionally deferred. The backend supports
 // scope=organization on /v2/metrics (admin-gated), but the generated
 // OpenAPI client doesn't yet expose organization_id / organization_role
@@ -304,6 +398,8 @@ export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
   }
   const tokensSaved = metrics.tokens_saved
   const tokensConsumed = metrics.tokens_consumed
+  const crossBoundaryRate = metrics[CROSS_BOUNDARY_RATE_METRIC]
+  const crossBoundarySavings = metrics[CROSS_BOUNDARY_SAVINGS_METRIC]
   const usdOffset = toMetricNumber(metrics.usd_saved?.total)
   const usdSpent = toMetricNumber(metrics.usd_consumed?.total)
   const usdNetSaved: MetricValuePublic = {
@@ -404,6 +500,15 @@ export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
             },
           )}
         </section>
+
+        {!scopedSessionId && (
+          <CrossBoundaryReusePanel
+            rateDefinition={definitionsByName[CROSS_BOUNDARY_RATE_METRIC]}
+            rateValue={crossBoundaryRate}
+            savingsDefinition={definitionsByName[CROSS_BOUNDARY_SAVINGS_METRIC]}
+            savingsValue={crossBoundarySavings}
+          />
+        )}
 
         {scopedSessionId && (
           <SessionLogTable
@@ -528,6 +633,8 @@ function ExperimentalMetricsPage({
   const savedUsd = metrics.usd_saved?.total ?? 0
   const consumedTokens = tokensConsumed?.total ?? 0
   const reuseRate = metrics.reuse_rate?.total ?? 0
+  const crossBoundaryRate = metrics[CROSS_BOUNDARY_RATE_METRIC]
+  const crossBoundarySavings = metrics[CROSS_BOUNDARY_SAVINGS_METRIC]
   const savingsRatio =
     toMetricNumber(consumedTokens) > 0
       ? toMetricNumber(savedTokens) / toMetricNumber(consumedTokens)
@@ -616,6 +723,14 @@ function ExperimentalMetricsPage({
           spend.
         </p>
       </section>
+
+      <CrossBoundaryReusePanel
+        experimental
+        rateDefinition={definitionsByName[CROSS_BOUNDARY_RATE_METRIC]}
+        rateValue={crossBoundaryRate}
+        savingsDefinition={definitionsByName[CROSS_BOUNDARY_SAVINGS_METRIC]}
+        savingsValue={crossBoundarySavings}
+      />
 
       <section className="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
         <div className="min-w-0">

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -172,12 +172,28 @@ function Instructions({ instructions }: { instructions: string[] }) {
 }
 
 function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
+  const originLabel =
+    agent.created_from === "earned" ? "Earned profile" : "Seeded profile"
+
   return (
     <section className="pt-5">
       <SectionHeader
-        title="Linked knowledge"
+        title="Earned from"
         meta={`${agent.linked_knowledge.length} documents`}
       />
+      <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+        <span className="inline-flex h-7 items-center border border-black/10 px-2.5 font-mono text-[0.66rem] uppercase tracking-[0.12em] text-muted-foreground dark:border-white/12">
+          {originLabel}
+        </span>
+        <Link
+          to="/v2/ledger"
+          search={{ specialist: agent.slug }}
+          className="inline-flex h-7 items-center gap-1.5 border border-black/10 px-2.5 text-xs font-medium text-foreground hover:bg-zinc-50 dark:border-white/12 dark:hover:bg-white/5"
+        >
+          Sessions
+          <ArrowUpRight className="size-3.5" />
+        </Link>
+      </div>
       <div className="mt-2 overflow-x-auto">
         <table className="w-full min-w-[42rem] border-collapse text-sm">
           <thead>
@@ -389,6 +405,9 @@ function AgentDetailPage() {
             <span className="inline-flex h-8 items-center gap-2 rounded-md border border-black/10 px-3 text-xs font-medium text-emerald-600 dark:border-white/12 dark:text-emerald-400">
               <span className="size-1.5 rounded-full bg-emerald-500" />
               Active
+            </span>
+            <span className="inline-flex h-8 items-center gap-2 rounded-md border border-black/10 px-3 text-xs font-medium text-foreground dark:border-white/12">
+              {agent.created_from === "earned" ? "Earned" : "Seeded"}
             </span>
             <span className="inline-flex h-8 items-center gap-2 rounded-md border border-black/10 px-3 text-xs font-medium text-foreground dark:border-white/12">
               <Pencil className="size-3.5" aria-hidden />

--- a/src/routes/v2/ledger.tsx
+++ b/src/routes/v2/ledger.tsx
@@ -1,9 +1,25 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
 
 import { LedgerPage } from "@/components/V2/Ledger/LedgerPage"
 
+const boolSearchParam = z.preprocess((value) => {
+  if (value === true || value === "true") return true
+  if (value === false || value === "false") return false
+  return undefined
+}, z.boolean().optional())
+
+const searchSchema = z.object({
+  actor_id: z.string().optional(),
+  client: z.string().optional(),
+  cross_boundary: boolSearchParam,
+  q: z.string().optional(),
+  specialist: z.string().optional(),
+})
+
 export const Route = createFileRoute("/v2/ledger")({
-  component: LedgerPage,
+  component: TaskforceLedger,
+  validateSearch: searchSchema,
   head: () => ({
     meta: [
       {
@@ -12,3 +28,8 @@ export const Route = createFileRoute("/v2/ledger")({
     ],
   }),
 })
+
+function TaskforceLedger() {
+  const search = Route.useSearch()
+  return <LedgerPage searchFilters={search} />
+}

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -2,7 +2,10 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import {
   ArrowLeft,
+  ArrowLeftRight,
   Bold,
+  Clock,
+  ExternalLink,
   Eye,
   Folder,
   Heading1,
@@ -47,6 +50,10 @@ import {
   type V2DocumentSharePublic,
   type V2DocumentUpdate,
 } from "@/api/v2Documents"
+import {
+  type LedgerSessionRow,
+  readDocumentLedgerSessions,
+} from "@/api/v2Ledger"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -57,6 +64,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
+import {
+  formatCompactNumber,
+  formatRelativeTime,
+} from "@/components/V2/Agents/formatters"
 import {
   FolderCreateDialog,
   FolderPickerDropdown,
@@ -142,6 +153,27 @@ function formatDateOnly(value: string | null): string {
     dateStyle: "medium",
     timeZone: "UTC",
   }).format(new Date(value))
+}
+
+const DOCUMENT_CLIENT_LABELS: Record<string, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+  cursor: "Cursor",
+}
+
+function documentClientLabel(value: string | null): string {
+  if (!value) return "Unknown tool"
+  return DOCUMENT_CLIENT_LABELS[value] ?? value
+}
+
+function documentSessionAction(row: LedgerSessionRow): string {
+  if (row.kinds.some((kind) => kind === "document.created")) {
+    return "Produced by"
+  }
+  if (row.kinds.some((kind) => kind === "document.consulted")) {
+    return "Reused by"
+  }
+  return "Touched by"
 }
 
 function shortAnchorId(): string {
@@ -517,6 +549,15 @@ function TaskforceDocumentDetail() {
   })
 
   const document = documentQuery.data
+  const documentSessionsQuery = useQuery({
+    queryKey: ["v2-document-sessions", documentId, { demo: isDemoMode }],
+    queryFn: () =>
+      readDocumentLedgerSessions(documentId, {
+        demo: isDemoMode,
+        limit: 6,
+      }),
+    enabled: Boolean(document),
+  })
   const isOwner = Boolean(document && user?.id === document.owner_id)
   const canEditDocument = Boolean(document && document.user_access !== "viewer")
   const canManageDocument = isOwner
@@ -1019,6 +1060,13 @@ function TaskforceDocumentDetail() {
           <AnchorHelper summaryPick={summaryPick} detailsPick={detailsPick} />
         )}
 
+        <DocumentProvenanceStrip
+          rows={documentSessionsQuery.data?.rows ?? []}
+          total={documentSessionsQuery.data?.total ?? 0}
+          isLoading={documentSessionsQuery.isLoading}
+          isError={documentSessionsQuery.isError}
+        />
+
         <div
           className={cn(
             "gap-6 pt-6",
@@ -1058,6 +1106,89 @@ function TaskforceDocumentDetail() {
           )}
         </div>
       </article>
+    </section>
+  )
+}
+
+function DocumentProvenanceStrip({
+  rows,
+  total,
+  isLoading,
+  isError,
+}: {
+  rows: LedgerSessionRow[]
+  total: number
+  isLoading: boolean
+  isError: boolean
+}) {
+  return (
+    <section className="border-b border-border py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="font-mono text-[0.66rem] uppercase tracking-[0.14em] text-muted-foreground">
+            Sessions / Reused by
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {isLoading
+              ? "Loading session provenance..."
+              : isError
+                ? "Session provenance unavailable."
+                : total > 0
+                  ? `${total} session${total === 1 ? "" : "s"} found`
+                  : "No sessions recorded yet"}
+          </div>
+        </div>
+        <Link
+          to="/v2/ledger"
+          className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          Open ledger
+          <ExternalLink className="size-3.5" />
+        </Link>
+      </div>
+
+      {rows.length > 0 ? (
+        <div className="mt-3 grid gap-2 lg:grid-cols-3">
+          {rows.slice(0, 3).map((row) => (
+            <Link
+              key={row.session_id}
+              to="/v2/metrics"
+              search={{ session_id: row.session_id }}
+              className="group min-w-0 border border-border px-3 py-2 text-sm transition-colors hover:bg-muted/40"
+            >
+              <div className="flex min-w-0 items-center justify-between gap-2">
+                <span className="truncate font-medium">
+                  {documentSessionAction(row)} {row.actor_name}
+                </span>
+                {row.cross_boundary ? (
+                  <Badge
+                    variant="secondary"
+                    className="shrink-0 gap-1 normal-case"
+                    title="Crossed a person or tool boundary"
+                  >
+                    <ArrowLeftRight className="size-3" />
+                    cross
+                  </Badge>
+                ) : null}
+              </div>
+              <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Clock className="size-3" />
+                <span>{documentClientLabel(row.client)}</span>
+                <span>·</span>
+                <span>{formatRelativeTime(row.occurred_at_last)}</span>
+              </div>
+              <div className="mt-2 flex items-center justify-between gap-2 text-xs">
+                <span className="truncate text-muted-foreground">
+                  {row.specialist_name ?? row.specialist_slug ?? "No profile"}
+                </span>
+                <span className="shrink-0 tabular-nums text-foreground">
+                  {formatCompactNumber(row.net_saved_tokens)} tok
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      ) : null}
     </section>
   )
 }

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -23,6 +23,7 @@ const agents = [
       "Stripe webhooks, subscriptions, and double-charge prevention.",
     domain_tags: ["Stripe", "Billing", "Webhooks", "Reliability"],
     status: "active",
+    created_from: "earned",
     linked_docs_count: 3,
     invocations_count: 12,
     tokens_saved: 42000,
@@ -37,6 +38,7 @@ const agents = [
       "Indexer drift, pgvector retrieval, and citation anchors.",
     domain_tags: ["Search", "Retrieval", "Citations"],
     status: "active",
+    created_from: "seeded",
     linked_docs_count: 2,
     invocations_count: 4,
     tokens_saved: 12000,
@@ -49,6 +51,7 @@ const jensenDetail = {
   slug: "jensen",
   name: "Jensen",
   role: "Billing Reliability Specialist",
+  created_from: "earned",
   description:
     "Helps debug Stripe billing, subscription upgrades, webhook retries, idempotency, duplicate invoices, and customer double-charge incidents.",
   domain_tags: ["Stripe", "Billing", "Webhooks", "Reliability"],
@@ -152,6 +155,8 @@ test("direct specialist URL renders detail instead of the agents grid", async ({
     page.getByRole("heading", { name: "Jensen", level: 1 }),
   ).toBeVisible()
   await expect(page.getByText("Operating instructions")).toBeVisible()
+  await expect(page.getByText("Earned from")).toBeVisible()
+  await expect(page.getByText("Earned profile")).toBeVisible()
   await expect(
     page.getByRole("heading", { name: "Agents", level: 1 }),
   ).toHaveCount(0)
@@ -232,6 +237,10 @@ test("agents grid links to specialist detail and session metrics", async ({
     page.getByRole("heading", { name: "Jensen", level: 1 }),
   ).toBeVisible()
   await expect(page.getByText("Operating instructions")).toBeVisible()
+  await expect(page.getByRole("link", { name: /^Sessions$/ })).toHaveAttribute(
+    "href",
+    "/v2/ledger?specialist=jensen",
+  )
 
   const linkedKnowledge = page.getByRole("link", {
     name: /Stripe webhook idempotency strategy/,

--- a/tests/fixtures/v2-documents.ts
+++ b/tests/fixtures/v2-documents.ts
@@ -114,6 +114,22 @@ const documents = [
 ]
 
 export async function mockV2Documents(page: Page) {
+  await page.route(
+    "**/api/v1/v2/taskforce/documents/*/sessions**",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          scope: "organization",
+          organization_id: null,
+          total: 0,
+          limit: 6,
+          offset: 0,
+          rows: [],
+        },
+      })
+    },
+  )
+
   await page.route("**/api/v1/v2/documents/**", async (route) => {
     const url = new URL(route.request().url())
     const pathname = url.pathname

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -61,6 +61,22 @@ async function mockTaskforceAuth(
 
     await route.fulfill({ json: { data, count: data.length } })
   })
+
+  await page.route(
+    "**/api/v1/v2/taskforce/documents/*/sessions**",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          scope: "organization",
+          organization_id: null,
+          total: 0,
+          limit: 6,
+          offset: 0,
+          rows: [],
+        },
+      })
+    },
+  )
 }
 
 async function dragSidebarRail(page: Page, deltaX: number) {

--- a/tests/v2-document-hash.spec.ts
+++ b/tests/v2-document-hash.spec.ts
@@ -98,6 +98,8 @@ test("V2 document viewer leaves summary mode unchanged without URL hash", async 
     "data-state",
     "inactive",
   )
+  await expect(page.getByText("Sessions / Reused by")).toBeVisible()
+  await expect(page.getByText("No sessions recorded yet")).toBeVisible()
   await expect
     .poll(() =>
       page.evaluate(

--- a/tests/v2-metrics-session.spec.ts
+++ b/tests/v2-metrics-session.spec.ts
@@ -51,6 +51,29 @@ function metricValue(total: string) {
   }
 }
 
+function crossBoundarySavingsValue() {
+  return {
+    total: "750",
+    delta_vs_prev_window: null,
+    series: [],
+    breakdown_by_source: [
+      {
+        key: "cross_boundary",
+        label: "Cross-boundary",
+        tokens: 750,
+        usd: "0.08",
+      },
+      {
+        key: "same_boundary",
+        label: "Same owner/tool",
+        tokens: 250,
+        usd: "0.03",
+      },
+    ],
+    top_models: null,
+  }
+}
+
 async function mockMetricsPage(
   page: Page,
   options: { experimental?: boolean } = {},
@@ -109,6 +132,18 @@ async function mockMetricsPage(
             "count",
             "count",
           ),
+          metricDefinition(
+            "cross_boundary_reuse_rate",
+            "Boundary-Crossing Reuse",
+            "ratio",
+            "ratio",
+          ),
+          metricDefinition(
+            "cross_boundary_tokens_saved",
+            "Boundary-Crossing Savings",
+            "compact-int",
+            "tokens",
+          ),
         ],
       },
     })
@@ -129,7 +164,22 @@ async function mockMetricsPage(
           tokens_consumed: metricValue("2000"),
           usd_consumed: metricValue("0.25"),
           documents_touched: metricValue("4"),
+          cross_boundary_reuse_rate: metricValue("0.25"),
+          cross_boundary_tokens_saved: crossBoundarySavingsValue(),
         },
+      },
+    })
+  })
+
+  await page.route("**/api/v1/v2/taskforce/ledger?*", async (route) => {
+    await route.fulfill({
+      json: {
+        scope: "organization",
+        organization_id: "org-1",
+        total: 0,
+        limit: 10,
+        offset: 0,
+        rows: [],
       },
     })
   })
@@ -273,6 +323,11 @@ test("metrics page keeps aggregate dashboard without session_id", async ({
   await expect(page.getByText("Reuse Rate", { exact: true })).toBeVisible()
   await expect(page.getByText("1K", { exact: true }).first()).toBeVisible()
   await expect(page.getByText("$1.23", { exact: true }).first()).toBeVisible()
+  await expect(page.getByTestId("cross-boundary-metric")).toContainText(
+    "Boundary-Crossing Reuse",
+  )
+  await page.getByTestId("cross-boundary-metric").click()
+  await expect(page).toHaveURL(/\/v2\/ledger\?cross_boundary=true$/)
   expect(sessionSavingsRequests).toBe(0)
 })
 
@@ -296,6 +351,9 @@ test("experimental mode shows expressive aggregate metrics", async ({
     page.getByRole("heading", { name: /you saved 1k tokens this week/i }),
   ).toBeVisible()
   await expect(page.getByText("Saved / used")).toBeVisible()
+  await expect(page.getByTestId("cross-boundary-metric")).toContainText(
+    "Boundary-Crossing Reuse",
+  )
   await expect(page.getByText("Top models by tokens used")).toBeVisible()
   await expect(page.getByText("Documents Touched")).toBeVisible()
   await expect(page.getByTestId("metrics-session-filter-banner")).toHaveCount(0)


### PR DESCRIPTION
## Summary
- Add document detail session provenance strip backed by the document-scoped ledger endpoint.
- Show profile origin and an Earned From provenance section with ledger drill-through.
- Add cross-boundary metrics card with a `/v2/ledger?cross_boundary=true` drill-through and route-aware ledger filters.

## Validation
- `npm run build`
- `npm run lint`

## Notes
- Targeted Playwright specs were attempted through `npm run test` and `npx playwright`, but this environment does not have `bun`; the configured Playwright web server exits with `bun: command not found`.