### PR TITLE
[codex] Redesign ledger session UI

### DIFF
--- a/src/api/v2Ledger.ts
+++ b/src/api/v2Ledger.ts
@@ -17,6 +17,30 @@ export interface LedgerDocRef {
   document_id: string
   title: string
   href: string
+  state?: "fresh" | "stale" | "new" | "unknown"
+}
+
+export type LedgerTranscriptEventKind =
+  | "prompt"
+  | "reply"
+  | "command"
+  | "edit"
+  | "note"
+
+export interface LedgerTranscriptEvent {
+  kind: LedgerTranscriptEventKind
+  occurred_at: string | null
+  role: string | null
+  who: string | null
+  text: string | null
+  cmd: string | null
+  exit_code: number | null
+  output: string | null
+  file: string | null
+  added: number | null
+  removed: number | null
+  note: string | null
+  repo: string | null
 }
 
 export interface LedgerSessionRow {
@@ -35,6 +59,34 @@ export interface LedgerSessionRow {
   cross_boundary: boolean
   occurred_at_first: string
   occurred_at_last: string
+  title: string | null
+  short_session_id: string | null
+  actor_handle: string | null
+  harness_label: string | null
+  harness_version: string | null
+  model_id: string | null
+  repo: string | null
+  branch: string | null
+  cwd: string | null
+  started_at: string | null
+  ended_at: string | null
+  duration_ms: number
+  imported_at: string | null
+  message_count: number
+  command_count: number
+  edit_count: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_write_tokens: number
+  source: string | null
+  transcript_available: boolean
+}
+
+export interface LedgerSessionDetail extends LedgerSessionRow {
+  transcript_events: LedgerTranscriptEvent[]
+  raw_transcript_available: boolean
+  source_metadata: Record<string, unknown>
 }
 
 export interface LedgerResponse {
@@ -55,6 +107,7 @@ export interface ReadLedgerArgs {
   since?: string
   until?: string
   q?: string
+  sort?: "newest" | "oldest"
   limit?: number
   offset?: number
 }
@@ -74,8 +127,25 @@ export function readLedger(
       since: args.since || undefined,
       until: args.until || undefined,
       q: args.q || undefined,
+      sort: args.sort || undefined,
       limit: args.limit ?? undefined,
       offset: args.offset ?? undefined,
+    },
+  })
+}
+
+export function readLedgerSessionDetail(
+  sessionId: string,
+  args: Pick<ReadLedgerArgs, "demo"> = {},
+): CancelablePromise<LedgerSessionDetail> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/taskforce/ledger/{session_id}",
+    path: {
+      session_id: sessionId,
+    },
+    query: {
+      demo: args.demo || undefined,
     },
   })
 }

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -1,26 +1,44 @@
 import { useQuery } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
-import { ArrowLeftRight, Loader2, Search } from "lucide-react"
-import { useEffect, useState } from "react"
+import {
+  ArrowLeft,
+  ArrowLeftRight,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  FileText,
+  Loader2,
+  Search,
+  Terminal,
+} from "lucide-react"
+import {
+  type FormEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 
-import { readLedger } from "@/api/v2Ledger"
+import {
+  type LedgerSessionDetail,
+  type LedgerSessionRow,
+  type LedgerTranscriptEvent,
+  readLedger,
+  readLedgerSessionDetail,
+} from "@/api/v2Ledger"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
-import {
-  formatCompactNumber,
-  formatRelativeTime,
-  formatUsd,
-} from "@/components/V2/Agents/formatters"
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { formatCompactNumber } from "@/components/V2/Agents/formatters"
 import {
   V2_PAGE_CONTENT,
   V2_PAGE_FRAME,
@@ -34,16 +52,26 @@ const CLIENT_LABELS: Record<string, string> = {
   cursor: "Cursor",
 }
 
+type LedgerSort = "newest" | "oldest"
+
 type LedgerSearchFilters = {
   actor_id?: string
   client?: string
   cross_boundary?: boolean
   q?: string
+  session_id?: string
   specialist?: string
+  sort?: LedgerSort
 }
 
-function clientLabel(value: string | null): string {
-  if (!value) return "—"
+type DayGroup = {
+  key: string
+  label: string
+  rows: LedgerSessionRow[]
+}
+
+function clientLabel(value: string | null | undefined): string {
+  if (!value) return "Unknown"
   return CLIENT_LABELS[value] ?? value
 }
 
@@ -53,8 +81,118 @@ function cleanLedgerSearch(filters: LedgerSearchFilters): LedgerSearchFilters {
     client: filters.client || undefined,
     cross_boundary: filters.cross_boundary || undefined,
     q: filters.q || undefined,
+    session_id: filters.session_id || undefined,
     specialist: filters.specialist || undefined,
+    sort: filters.sort === "oldest" ? "oldest" : undefined,
   }
+}
+
+function dateFrom(value: string | null | undefined): Date | null {
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function formatClock(value: string | null | undefined): string {
+  const date = dateFrom(value)
+  if (!date) return "—"
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date)
+}
+
+function formatDateTime(value: string | null | undefined): string {
+  const date = dateFrom(value)
+  if (!date) return "—"
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date)
+}
+
+function formatDuration(durationMs: number): string {
+  if (!durationMs) return "—"
+  const minutes = Math.max(1, Math.round(durationMs / 60000))
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const remainder = minutes % 60
+  return remainder ? `${hours}h ${remainder}m` : `${hours}h`
+}
+
+function dayKey(value: string): string {
+  const date = dateFrom(value)
+  if (!date) return "unknown"
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+function dayLabel(key: string): string {
+  if (key === "unknown") return "Undated"
+  const today = dayKey(new Date().toISOString())
+  const yesterday = new Date()
+  yesterday.setDate(yesterday.getDate() - 1)
+  const yesterdayKey = dayKey(yesterday.toISOString())
+  if (key === today) return "Today"
+  if (key === yesterdayKey) return "Yesterday"
+  const date = new Date(`${key}T00:00:00`)
+  if (Number.isNaN(date.getTime())) return key
+  return new Intl.DateTimeFormat(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(date)
+}
+
+function groupRows(rows: LedgerSessionRow[]): DayGroup[] {
+  const groups = new Map<string, LedgerSessionRow[]>()
+  for (const row of rows) {
+    const key = dayKey(row.started_at ?? row.occurred_at_last)
+    groups.set(key, [...(groups.get(key) ?? []), row])
+  }
+  return Array.from(groups.entries()).map(([key, groupRows]) => ({
+    key,
+    label: dayLabel(key),
+    rows: groupRows,
+  }))
+}
+
+function sessionTitle(row: LedgerSessionRow): string {
+  return (
+    row.title ||
+    row.documents[0]?.title ||
+    `Session ${row.short_session_id ?? row.session_id.slice(0, 8)}`
+  )
+}
+
+function agentLabel(row: LedgerSessionRow): string {
+  return row.model_id || row.specialist_name || row.specialist_slug || "Agent"
+}
+
+function buildMarkdown(detail: LedgerSessionDetail): string {
+  const lines = [
+    `# ${sessionTitle(detail)}`,
+    "",
+    `Session: ${detail.session_id}`,
+    `Harness: ${clientLabel(detail.harness_label ?? detail.client)}`,
+    `Agent: ${agentLabel(detail)}`,
+    `Started: ${formatDateTime(detail.started_at ?? detail.occurred_at_first)}`,
+    "",
+    "## Transcript",
+    "",
+  ]
+  for (const event of detail.transcript_events) {
+    const label = event.kind.toUpperCase()
+    const body = event.text || event.cmd || event.file || event.note || ""
+    lines.push(`### ${label} · ${formatDateTime(event.occurred_at)}`)
+    lines.push(body)
+    lines.push("")
+  }
+  return lines.join("\n")
 }
 
 export function LedgerPage({
@@ -69,23 +207,36 @@ export function LedgerPage({
   const specialist = searchFilters.specialist?.trim() || undefined
   const client = searchFilters.client?.trim() || undefined
   const actorId = searchFilters.actor_id?.trim() || undefined
+  const selectedSessionId = searchFilters.session_id?.trim() || undefined
+  const sort = searchFilters.sort === "oldest" ? "oldest" : "newest"
   const [search, setSearch] = useState(query)
 
   useEffect(() => {
     setSearch(query)
   }, [query])
 
-  const setLedgerSearch = (next: Partial<LedgerSearchFilters>) => {
-    void navigate({
-      to: "/v2/ledger",
-      search: cleanLedgerSearch({ ...searchFilters, ...next }),
-    })
-  }
+  const setLedgerSearch = useCallback(
+    (next: Partial<LedgerSearchFilters>) => {
+      void navigate({
+        to: "/v2/ledger",
+        search: cleanLedgerSearch({ ...searchFilters, ...next }),
+      })
+    },
+    [navigate, searchFilters],
+  )
 
   const ledgerQuery = useQuery({
     queryKey: [
       "v2-ledger",
-      { actorId, client, crossOnly, demo: isDemoMode, q: query, specialist },
+      {
+        actorId,
+        client,
+        crossOnly,
+        demo: isDemoMode,
+        q: query,
+        sort,
+        specialist,
+      },
     ],
     queryFn: () =>
       readLedger({
@@ -95,200 +246,617 @@ export function LedgerPage({
         q: query || undefined,
         crossBoundary: crossOnly || undefined,
         specialist,
+        sort,
       }),
   })
 
-  const data = ledgerQuery.data
-  const rows = data?.rows ?? []
+  const detailQuery = useQuery({
+    enabled: Boolean(selectedSessionId),
+    queryKey: ["v2-ledger-detail", selectedSessionId, isDemoMode],
+    queryFn: () =>
+      readLedgerSessionDetail(selectedSessionId ?? "", { demo: isDemoMode }),
+  })
 
-  const onSearchSubmit = (event: React.FormEvent) => {
+  useEffect(() => {
+    if (!selectedSessionId) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setLedgerSearch({ session_id: undefined })
+      }
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [selectedSessionId, setLedgerSearch])
+
+  const rows = ledgerQuery.data?.rows ?? []
+  const groups = useMemo(() => groupRows(rows), [rows])
+
+  const onSearchSubmit = (event: FormEvent) => {
     event.preventDefault()
-    setLedgerSearch({ q: search.trim() || undefined })
+    setLedgerSearch({ q: search.trim() || undefined, session_id: undefined })
   }
 
   const hasActiveFilters = Boolean(
-    actorId || client || crossOnly || query || specialist,
+    actorId || client || crossOnly || query || specialist || sort === "oldest",
   )
 
   return (
     <section
       className={cn(V2_PAGE_FRAME, "bg-background font-sans text-foreground")}
     >
-      <div className={V2_PAGE_CONTENT}>
-        <header className="flex flex-col gap-2">
-          <span className={V2_TAB_EYEBROW_CLASS}>
-            Ledger{data ? ` · ${data.total} sessions` : ""}
-          </span>
-          <h1 className="text-2xl font-semibold tracking-tight">Ledger</h1>
-          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-            Every session your team runs through a Taskforce-enabled tool — what
-            was done, what it reused, and what it saved. The raw record the
-            Library and Profiles are distilled from.
-          </p>
-        </header>
-
-        <div className="flex flex-wrap items-center gap-3">
-          <form onSubmit={onSearchSubmit} className="relative max-w-sm flex-1">
-            <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              className="pl-9"
-              placeholder="Search sessions (prompt or document)"
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-            />
-          </form>
-          <Button
-            type="button"
-            variant={crossOnly ? "default" : "outline"}
-            size="sm"
-            onClick={() =>
-              setLedgerSearch({ cross_boundary: crossOnly ? undefined : true })
-            }
-            aria-pressed={crossOnly}
-          >
-            <ArrowLeftRight className="size-4" />
-            Cross-boundary only
-          </Button>
-          {specialist ? (
-            <Badge variant="outline">Profile · {specialist}</Badge>
-          ) : null}
-          {client ? (
-            <Badge variant="outline">Tool · {clientLabel(client)}</Badge>
-          ) : null}
-          {query ? <Badge variant="outline">Search · {query}</Badge> : null}
-          {hasActiveFilters ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() =>
+      <div className={cn(V2_PAGE_CONTENT, "gap-5")}>
+        {selectedSessionId ? (
+          <LedgerDetailView
+            detail={detailQuery.data}
+            isError={detailQuery.isError}
+            isLoading={detailQuery.isLoading}
+            onBack={() => setLedgerSearch({ session_id: undefined })}
+          />
+        ) : (
+          <>
+            <LedgerHeader total={ledgerQuery.data?.total} />
+            <LedgerToolbar
+              client={client}
+              crossOnly={crossOnly}
+              hasActiveFilters={hasActiveFilters}
+              isFetching={ledgerQuery.isFetching && !ledgerQuery.isLoading}
+              onClear={() =>
                 setLedgerSearch({
                   actor_id: undefined,
                   client: undefined,
                   cross_boundary: undefined,
                   q: undefined,
+                  session_id: undefined,
                   specialist: undefined,
+                  sort: undefined,
                 })
               }
-            >
-              Clear
-            </Button>
-          ) : null}
-        </div>
-
-        {ledgerQuery.isError ? (
-          <div className="rounded-lg border border-dashed border-border bg-background p-8 text-sm text-muted-foreground">
-            Couldn't load the ledger. This view is organization-scoped — you
-            need to belong to an organization.
-          </div>
-        ) : ledgerQuery.isLoading ? (
-          <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="size-4 animate-spin" />
-            Loading sessions…
-          </div>
-        ) : rows.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-border bg-background p-10 text-center">
-            <h2 className="text-base font-semibold">No sessions yet</h2>
-            <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-muted-foreground">
-              {crossOnly
-                ? "No cross-boundary sessions match. Clear the filter to see all sessions."
-                : "Sessions appear here as your team works through Taskforce-enabled tools."}
-            </p>
-          </div>
-        ) : (
-          <div className="overflow-hidden rounded-lg border border-border">
-            <Table>
-              <TableHeader>
-                <TableRow className="bg-muted">
-                  <TableHead>Who · tool</TableHead>
-                  <TableHead>Worked on</TableHead>
-                  <TableHead>Specialist</TableHead>
-                  <TableHead className="text-right">Saved</TableHead>
-                  <TableHead className="text-right">When</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {rows.map((row) => (
-                  <TableRow key={row.session_id}>
-                    <TableCell>
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium">{row.actor_name}</span>
-                        {row.cross_boundary ? (
-                          <Badge
-                            variant="secondary"
-                            className="gap-1 normal-case"
-                            title="Crossed a person or tool boundary"
-                          >
-                            <ArrowLeftRight className="size-3" />
-                            cross
-                          </Badge>
-                        ) : null}
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        {clientLabel(row.client)}
-                      </div>
-                    </TableCell>
-                    <TableCell className="max-w-xs">
-                      {row.documents.length > 0 ? (
-                        <div className="flex flex-col gap-0.5">
-                          {row.documents.slice(0, 3).map((doc) => (
-                            <Link
-                              key={doc.document_id}
-                              to="/v2/library/$documentId"
-                              params={{ documentId: doc.document_id }}
-                              className="truncate text-sm text-foreground hover:underline"
-                            >
-                              {doc.title}
-                            </Link>
-                          ))}
-                          {row.documents.length > 3 ? (
-                            <span className="text-xs text-muted-foreground">
-                              +{row.documents.length - 3} more
-                            </span>
-                          ) : null}
-                        </div>
-                      ) : (
-                        <span className="text-sm text-muted-foreground">—</span>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      {row.specialist_slug ? (
-                        <Link
-                          to="/v2/agents/$slug"
-                          params={{ slug: row.specialist_slug }}
-                          className="text-sm text-foreground hover:underline"
-                        >
-                          {row.specialist_name ?? row.specialist_slug}
-                        </Link>
-                      ) : (
-                        <span className="text-sm text-muted-foreground">—</span>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <div className="text-sm tabular-nums">
-                        {formatCompactNumber(row.net_saved_tokens)} tok
-                      </div>
-                      <div className="text-xs tabular-nums text-muted-foreground">
-                        {formatUsd(row.usd_amount)}
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-right text-xs tabular-nums text-muted-foreground">
-                      {formatRelativeTime(row.occurred_at_last)}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
+              onClientChange={(value) =>
+                setLedgerSearch({
+                  client: value === "all" ? undefined : value,
+                  session_id: undefined,
+                })
+              }
+              onCrossChange={() =>
+                setLedgerSearch({
+                  cross_boundary: crossOnly ? undefined : true,
+                  session_id: undefined,
+                })
+              }
+              onSearchSubmit={onSearchSubmit}
+              onSearchValueChange={setSearch}
+              onSortChange={(value) =>
+                setLedgerSearch({
+                  session_id: undefined,
+                  sort: value as LedgerSort,
+                })
+              }
+              query={query}
+              search={search}
+              sort={sort}
+              specialist={specialist}
+            />
+            <LedgerIndex
+              groups={groups}
+              isError={ledgerQuery.isError}
+              isLoading={ledgerQuery.isLoading}
+              onOpenSession={(sessionId) =>
+                setLedgerSearch({ session_id: sessionId })
+              }
+            />
+          </>
         )}
-
-        {ledgerQuery.isFetching && !ledgerQuery.isLoading ? (
-          <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="size-3 animate-spin" />
-            Refreshing
-          </div>
-        ) : null}
       </div>
     </section>
+  )
+}
+
+function LedgerHeader({ total }: { total?: number }) {
+  return (
+    <header className="flex flex-col gap-1">
+      <span className={V2_TAB_EYEBROW_CLASS}>
+        Ledger{typeof total === "number" ? ` · ${total} sessions archived` : ""}
+      </span>
+      <h1 className="text-2xl font-semibold tracking-tight">Ledger</h1>
+    </header>
+  )
+}
+
+function LedgerToolbar({
+  client,
+  crossOnly,
+  hasActiveFilters,
+  isFetching,
+  onClear,
+  onClientChange,
+  onCrossChange,
+  onSearchSubmit,
+  onSearchValueChange,
+  onSortChange,
+  query,
+  search,
+  sort,
+  specialist,
+}: {
+  client?: string
+  crossOnly: boolean
+  hasActiveFilters: boolean
+  isFetching: boolean
+  onClear: () => void
+  onClientChange: (value: string) => void
+  onCrossChange: () => void
+  onSearchSubmit: (event: FormEvent) => void
+  onSearchValueChange: (value: string) => void
+  onSortChange: (value: string) => void
+  query: string
+  search: string
+  sort: LedgerSort
+  specialist?: string
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <form onSubmit={onSearchSubmit} className="relative min-w-64 flex-1">
+        <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          className="h-9 pl-9 font-mono text-sm"
+          placeholder="/ Search transcripts, commands, files..."
+          value={search}
+          onChange={(event) => onSearchValueChange(event.target.value)}
+        />
+      </form>
+      <Select value={client ?? "all"} onValueChange={onClientChange}>
+        <SelectTrigger className="h-9 w-40">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All harnesses</SelectItem>
+          <SelectItem value="codex">Codex</SelectItem>
+          <SelectItem value="claude-code">Claude Code</SelectItem>
+          <SelectItem value="cursor">Cursor</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select value={sort} onValueChange={onSortChange}>
+        <SelectTrigger className="h-9 w-32">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="newest">Newest</SelectItem>
+          <SelectItem value="oldest">Oldest</SelectItem>
+        </SelectContent>
+      </Select>
+      <Button
+        type="button"
+        variant={crossOnly ? "default" : "outline"}
+        size="sm"
+        onClick={onCrossChange}
+        aria-pressed={crossOnly}
+      >
+        <ArrowLeftRight className="size-4" />
+        Cross
+      </Button>
+      {specialist ? (
+        <Badge variant="outline">Profile · {specialist}</Badge>
+      ) : null}
+      {query ? <Badge variant="outline">Search · {query}</Badge> : null}
+      {hasActiveFilters ? (
+        <Button type="button" variant="ghost" size="sm" onClick={onClear}>
+          Clear
+        </Button>
+      ) : null}
+      {isFetching ? (
+        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+          <Loader2 className="size-3 animate-spin" />
+          Refreshing
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+function LedgerIndex({
+  groups,
+  isError,
+  isLoading,
+  onOpenSession,
+}: {
+  groups: DayGroup[]
+  isError: boolean
+  isLoading: boolean
+  onOpenSession: (sessionId: string) => void
+}) {
+  if (isError) {
+    return (
+      <div className="rounded-md border border-dashed border-border bg-background p-8 text-sm text-muted-foreground">
+        Couldn't load the organization ledger.
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+        Loading sessions...
+      </div>
+    )
+  }
+
+  if (groups.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border bg-background p-10 text-center text-sm text-muted-foreground">
+        No sessions match.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-md border border-border">
+      <div className="min-w-[960px]">
+        <div className="sticky top-0 z-10 grid grid-cols-[86px_minmax(220px,1.6fr)_168px_150px_minmax(160px,1fr)_32px] border-b border-border bg-muted/80 px-4 py-2 text-[11px] font-medium uppercase text-muted-foreground">
+          <div>Time</div>
+          <div>Session</div>
+          <div>Harness · agent</div>
+          <div>Activity</div>
+          <div>Referenced by</div>
+          <div />
+        </div>
+        {groups.map((group) => (
+          <div key={group.key}>
+            <div className="border-b border-border bg-background px-4 py-2 text-xs font-medium text-muted-foreground">
+              {group.label} · {group.rows.length}
+            </div>
+            {group.rows.map((row) => (
+              <LedgerRow
+                key={row.session_id}
+                row={row}
+                onOpen={() => onOpenSession(row.session_id)}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function LedgerRow({
+  onOpen,
+  row,
+}: {
+  onOpen: () => void
+  row: LedgerSessionRow
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="grid w-full grid-cols-[86px_minmax(220px,1.6fr)_168px_150px_minmax(160px,1fr)_32px] items-center border-b border-border px-4 py-3 text-left transition-colors hover:bg-muted/45"
+    >
+      <div className="min-w-0">
+        <div className="text-sm font-medium tabular-nums">
+          {formatClock(row.started_at ?? row.occurred_at_last)}
+        </div>
+        <div className="truncate text-[11px] text-muted-foreground">
+          {row.started_at ? "local" : "latest"}
+        </div>
+      </div>
+      <div className="min-w-0 pr-4">
+        <div className="truncate text-sm font-medium">{sessionTitle(row)}</div>
+        <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+          <span className="shrink-0 font-mono">
+            {row.short_session_id ?? row.session_id.slice(0, 8)}
+          </span>
+          <span className="truncate">{row.actor_handle ?? row.actor_name}</span>
+          {row.branch ? <span className="truncate">· {row.branch}</span> : null}
+        </div>
+      </div>
+      <div className="min-w-0 pr-4">
+        <div className="truncate text-sm">
+          {clientLabel(row.harness_label ?? row.client)}
+        </div>
+        <div className="truncate text-xs text-muted-foreground">
+          {agentLabel(row)}
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-1 pr-4 text-xs text-muted-foreground">
+        <ActivityPill
+          count={row.message_count || row.event_count}
+          label="msg"
+        />
+        <ActivityPill count={row.command_count} label="cmd" />
+        <ActivityPill count={row.edit_count} label="edit" />
+      </div>
+      <div className="min-w-0 pr-4">
+        {row.documents.length > 0 ? (
+          <div className="flex min-w-0 items-center gap-1">
+            <span className="truncate text-sm">{row.documents[0].title}</span>
+            {row.documents.length > 1 ? (
+              <Badge variant="outline" className="h-5 px-1 text-[10px]">
+                +{row.documents.length - 1}
+              </Badge>
+            ) : null}
+          </div>
+        ) : (
+          <span className="text-sm text-muted-foreground">None</span>
+        )}
+      </div>
+      <ChevronRight className="size-4 text-muted-foreground" />
+    </button>
+  )
+}
+
+function ActivityPill({ count, label }: { count: number; label: string }) {
+  return (
+    <span className="rounded border border-border bg-background px-1.5 py-0.5 tabular-nums">
+      {formatCompactNumber(count)} {label}
+    </span>
+  )
+}
+
+function LedgerDetailView({
+  detail,
+  isError,
+  isLoading,
+  onBack,
+}: {
+  detail?: LedgerSessionDetail
+  isError: boolean
+  isLoading: boolean
+  onBack: () => void
+}) {
+  if (isLoading) {
+    return (
+      <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+        Loading session...
+      </div>
+    )
+  }
+
+  if (isError || !detail) {
+    return (
+      <div className="flex flex-col gap-3">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="w-fit"
+          onClick={onBack}
+        >
+          <ArrowLeft className="size-4" />
+          Back to Ledger
+        </Button>
+        <div className="rounded-md border border-dashed border-border bg-background p-8 text-sm text-muted-foreground">
+          Couldn't load this session.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border pb-3">
+        <Button type="button" variant="ghost" size="sm" onClick={onBack}>
+          <ArrowLeft className="size-4" />
+          Back to Ledger
+        </Button>
+        <span className="font-mono text-xs text-muted-foreground">
+          {detail.session_id}
+        </span>
+        <Badge variant="outline">
+          {clientLabel(detail.harness_label ?? detail.client)}
+        </Badge>
+        <Badge variant="secondary">{agentLabel(detail)}</Badge>
+      </div>
+
+      <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_296px]">
+        <main className="min-w-0">
+          <div className="mb-4">
+            <span className={V2_TAB_EYEBROW_CLASS}>
+              {formatDateTime(detail.started_at ?? detail.occurred_at_first)}
+            </span>
+            <h1 className="mt-1 text-2xl font-semibold tracking-tight">
+              {sessionTitle(detail)}
+            </h1>
+          </div>
+          <div className="flex flex-col gap-3">
+            {detail.transcript_events.length > 0 ? (
+              detail.transcript_events.map((event, index) => (
+                <TranscriptEventCard
+                  key={`${event.kind}-${event.occurred_at ?? index}-${index}`}
+                  event={event}
+                />
+              ))
+            ) : (
+              <div className="rounded-md border border-dashed border-border p-8 text-sm text-muted-foreground">
+                Transcript archive is not available for this older session.
+              </div>
+            )}
+          </div>
+        </main>
+        <SessionRail detail={detail} />
+      </div>
+    </div>
+  )
+}
+
+function TranscriptEventCard({ event }: { event: LedgerTranscriptEvent }) {
+  const title =
+    event.kind === "command"
+      ? "Command"
+      : event.kind === "edit"
+        ? "Edit"
+        : event.kind === "note"
+          ? "Note"
+          : event.kind === "prompt"
+            ? "Prompt"
+            : "Reply"
+
+  return (
+    <article className="rounded-md border border-border bg-background p-4">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          {event.kind === "command" ? (
+            <Terminal className="size-4 text-muted-foreground" />
+          ) : event.kind === "edit" ? (
+            <FileText className="size-4 text-muted-foreground" />
+          ) : null}
+          <span>{title}</span>
+        </div>
+        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+          {formatClock(event.occurred_at)}
+        </span>
+      </div>
+      {event.kind === "command" ? (
+        <div className="space-y-2">
+          <pre className="overflow-x-auto rounded bg-muted p-3 font-mono text-xs">
+            {event.cmd}
+          </pre>
+          <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+            {event.exit_code === null ? null : (
+              <Badge
+                variant={event.exit_code === 0 ? "secondary" : "destructive"}
+              >
+                exit {event.exit_code}
+              </Badge>
+            )}
+            {event.repo ? <span>{event.repo}</span> : null}
+          </div>
+          {event.output ? (
+            <pre className="overflow-x-auto rounded border border-border p-3 font-mono text-xs text-muted-foreground">
+              {event.output}
+            </pre>
+          ) : null}
+        </div>
+      ) : event.kind === "edit" ? (
+        <div className="space-y-2">
+          <div className="font-mono text-sm">{event.file}</div>
+          {event.note ? (
+            <p className="text-sm leading-6 text-muted-foreground">
+              {event.note}
+            </p>
+          ) : null}
+        </div>
+      ) : (
+        <p className="whitespace-pre-wrap text-sm leading-6">
+          {event.text || event.note || "—"}
+        </p>
+      )}
+    </article>
+  )
+}
+
+function SessionRail({ detail }: { detail: LedgerSessionDetail }) {
+  const copyMarkdown = () => {
+    void navigator.clipboard?.writeText(buildMarkdown(detail))
+  }
+
+  return (
+    <aside className="flex flex-col gap-4">
+      <RailSection title="Session">
+        <RailRow
+          label="ID"
+          value={detail.short_session_id ?? detail.session_id.slice(0, 8)}
+        />
+        <RailRow
+          label="Actor"
+          value={detail.actor_handle ?? detail.actor_name}
+        />
+        <RailRow
+          label="Harness"
+          value={clientLabel(detail.harness_label ?? detail.client)}
+        />
+        <RailRow label="Agent" value={agentLabel(detail)} />
+        <RailRow label="Repo" value={detail.repo ?? "—"} />
+      </RailSection>
+      <RailSection title="Timing">
+        <RailRow
+          label="Started"
+          value={formatDateTime(detail.started_at ?? detail.occurred_at_first)}
+        />
+        <RailRow
+          label="Ended"
+          value={formatDateTime(detail.ended_at ?? detail.occurred_at_last)}
+        />
+        <RailRow label="Duration" value={formatDuration(detail.duration_ms)} />
+      </RailSection>
+      <RailSection title="Activity">
+        <RailRow
+          label="Messages"
+          value={String(detail.message_count || detail.event_count)}
+        />
+        <RailRow label="Commands" value={String(detail.command_count)} />
+        <RailRow label="Edits" value={String(detail.edit_count)} />
+        <RailRow
+          label="Tokens"
+          value={`${formatCompactNumber(detail.input_tokens + detail.output_tokens)}`}
+        />
+      </RailSection>
+      <RailSection title="Referenced by">
+        {detail.documents.length > 0 ? (
+          <div className="flex flex-col gap-2">
+            {detail.documents.map((doc) => (
+              <Link
+                key={doc.document_id}
+                to="/v2/library/$documentId"
+                params={{ documentId: doc.document_id }}
+                className="flex items-center justify-between gap-2 rounded border border-border px-2 py-1.5 text-sm hover:bg-muted"
+              >
+                <span className="truncate">{doc.title}</span>
+                <ExternalLink className="size-3 shrink-0 text-muted-foreground" />
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <span className="text-sm text-muted-foreground">None</span>
+        )}
+      </RailSection>
+      <div className="flex flex-col gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!detail.raw_transcript_available}
+        >
+          <ExternalLink className="size-4" />
+          Open raw transcript
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={copyMarkdown}
+        >
+          <Copy className="size-4" />
+          Copy as Markdown
+        </Button>
+      </div>
+    </aside>
+  )
+}
+
+function RailSection({
+  children,
+  title,
+}: {
+  children: ReactNode
+  title: string
+}) {
+  return (
+    <section className="border-b border-border pb-4">
+      <h2 className="mb-2 text-xs font-medium uppercase text-muted-foreground">
+        {title}
+      </h2>
+      <div className="flex flex-col gap-1.5">{children}</div>
+    </section>
+  )
+}
+
+function RailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[88px_minmax(0,1fr)] gap-2 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="truncate text-right">{value}</span>
+    </div>
   )
 }

--- a/src/routes/v2/ledger.tsx
+++ b/src/routes/v2/ledger.tsx
@@ -14,7 +14,9 @@ const searchSchema = z.object({
   client: z.string().optional(),
   cross_boundary: boolSearchParam,
   q: z.string().optional(),
+  session_id: z.string().optional(),
   specialist: z.string().optional(),
+  sort: z.enum(["newest", "oldest"]).optional(),
 })
 
 export const Route = createFileRoute("/v2/ledger")({


### PR DESCRIPTION
Implements the frontend group for TF-216, TF-217, and the frontend portion of TF-218.

Changes:
- Extends the Ledger API wrapper with enriched summary fields, transcript event types, sort support, and the new session detail endpoint.
- Adds `session_id` and `sort` route search params.
- Replaces the table with a dense grouped session archive layout matching `docs/ledger-target.html`.
- Adds URL-driven session detail, Escape/back behavior, transcript event rendering, a right-side session rail, and copy-as-markdown.
- Keeps partial old-session fallback when transcript events are unavailable.

Validation:
- `npx biome check src/api/v2Ledger.ts src/routes/v2/ledger.tsx src/components/V2/Ledger/LedgerPage.tsx`
- `npm run build` completed successfully. Vite emitted the existing Node warning because local Node is 22.11.0 and Vite prefers 22.12+.
- Vite dev server served `/v2/ledger` at `http://127.0.0.1:5173/v2/ledger`.