### PR TITLE
Use receipt-text icon for Ledger surfaces

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -2,12 +2,12 @@ import { useQuery } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
 import {
   ArrowLeft,
-  ArrowLeftRight,
   ChevronRight,
   Copy,
   ExternalLink,
   FileText,
   Loader2,
+  ReceiptText,
   Search,
   Terminal,
 } from "lucide-react"
@@ -431,7 +431,7 @@ function LedgerToolbar({
         onClick={onCrossChange}
         aria-pressed={crossOnly}
       >
-        <ArrowLeftRight className="size-4" />
+        <ReceiptText className="size-4" />
         Cross
       </Button>
       {specialist ? (

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
-import { ArrowLeftRight } from "lucide-react"
+import { ReceiptText } from "lucide-react"
 import { useMemo, useState } from "react"
 import {
   type MetricDefinitionPublic,
@@ -270,7 +270,7 @@ function CrossBoundaryReusePanel({
           </p>
         </div>
         <span className="inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground group-hover:text-foreground">
-          <ArrowLeftRight className="size-4" />
+          <ReceiptText className="size-4" />
         </span>
       </div>
 

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -6,7 +6,6 @@ import {
   useRouterState,
 } from "@tanstack/react-router"
 import {
-  ArrowLeftRight,
   BookOpen,
   Bot,
   ChevronDown,
@@ -14,6 +13,7 @@ import {
   GripHorizontal,
   LineChart,
   MessageCircle,
+  ReceiptText,
   Rocket,
   Search,
   Shield,
@@ -71,7 +71,7 @@ const taskforceItems: TaskforceNavItem[] = [
   { icon: Search, title: "Search", path: "/v2/search" },
   { icon: Bot, title: "Profiles", path: "/v2/agents" },
   { icon: BookOpen, title: "Library", path: "/v2/library" },
-  { icon: ArrowLeftRight, title: "Ledger", path: "/v2/ledger" },
+  { icon: ReceiptText, title: "Ledger", path: "/v2/ledger" },
   { icon: LineChart, title: "Metrics", path: "/v2/metrics" },
   { icon: Rocket, title: "Upgrade", path: "/v2/pricing" },
 ]

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -13,6 +13,7 @@ import {
   Heading3,
   Italic,
   Link as LinkIcon,
+  ReceiptText,
   Pencil,
   Pilcrow,
   Search,
@@ -1143,7 +1144,7 @@ function DocumentProvenanceStrip({
           className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
         >
           Open ledger
-          <ExternalLink className="size-3.5" />
+          <ReceiptText className="size-3.5" />
         </Link>
       </div>
 


### PR DESCRIPTION
## Summary
- Replace Ledger navigation icons with Lucide `ReceiptText` in the sidebar, Metrics cross-boundary link, document provenance strip, and Ledger toolbar.

## Test plan
- [x] Verified icon imports compile cleanly
- [ ] Confirm Ledger tab and linked surfaces show receipt-text icon in the UI


Made with [Cursor](https://cursor.com)