### PR TITLE
Reduce sidebar tab label size by 15%

### DIFF
--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -76,6 +76,8 @@ const taskforceItems: TaskforceNavItem[] = [
   { icon: Rocket, title: "Upgrade", path: "/v2/pricing" },
 ]
 
+const SIDEBAR_TAB_LABEL_CLASS = "text-[calc(18px*0.85)]"
+
 const TASKFORCE_DISCORD_URL = ""
 const EXTRAS_DRAWER_COLLAPSED_STORAGE_KEY = "taskforce.sidebar.extras.collapsed"
 
@@ -158,7 +160,7 @@ function TaskforceNav({ currentUser }: TaskforceShellProps) {
             <SidebarMenuButton tooltip={item.title} isActive={isActive} asChild>
               <RouterLink to={item.path} onClick={handleMenuClick}>
                 <item.icon className="size-[18px]" />
-                <span>{item.title}</span>
+                <span className={SIDEBAR_TAB_LABEL_CLASS}>{item.title}</span>
               </RouterLink>
             </SidebarMenuButton>
           </SidebarMenuItem>


### PR DESCRIPTION
## Summary
- Shrink Taskforce sidebar nav tab labels to 85% of their previous size (15.3px vs 18px).
- Leave nav icons unchanged at 18px.

## Test plan
- [ ] Open any `/v2/*` page and confirm sidebar tab text is slightly smaller while icons stay the same size


Made with [Cursor](https://cursor.com)