### PR TITLE
Fix build: remove unused import and ledger search types

### DIFF
--- a/src/routes/v2/ledger.tsx
+++ b/src/routes/v2/ledger.tsx
@@ -3,16 +3,17 @@ import { z } from "zod"
 
 import { LedgerPage } from "@/components/V2/Ledger/LedgerPage"
 
-const boolSearchParam = z.preprocess((value) => {
-  if (value === true || value === "true") return true
-  if (value === false || value === "false") return false
-  return undefined
-}, z.boolean().optional())
-
 const searchSchema = z.object({
   actor_id: z.string().optional(),
   client: z.string().optional(),
-  cross_boundary: boolSearchParam,
+  cross_boundary: z
+    .union([z.boolean(), z.literal("true"), z.literal("false")])
+    .optional()
+    .transform((value) => {
+      if (value === true || value === "true") return true
+      if (value === false || value === "false") return false
+      return undefined
+    }),
   q: z.string().optional(),
   session_id: z.string().optional(),
   specialist: z.string().optional(),

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -5,7 +5,6 @@ import {
   ArrowLeftRight,
   Bold,
   Clock,
-  ExternalLink,
   Eye,
   Folder,
   Heading1,


### PR DESCRIPTION
## Summary
- Remove unused `ExternalLink` import from the document detail page.
- Replace `z.preprocess` on the ledger `cross_boundary` search param so TanStack Router treats it as optional again.

## Test plan
- [x] `npm run build`


Made with [Cursor](https://cursor.com)