### PR TITLE
feat(v2): Profiles people directory + hybrid Library recent reel

### DIFF
--- a/src/components/V2/Library/LibraryRecentReel.tsx
+++ b/src/components/V2/Library/LibraryRecentReel.tsx
@@ -1,0 +1,169 @@
+import { Link } from "@tanstack/react-router"
+import { Folder } from "lucide-react"
+import { useMemo } from "react"
+
+import type { V2DocumentPublic } from "@/api/v2Documents"
+import type { UserPublic } from "@/client"
+import { formatRelativeTime } from "@/components/V2/Agents/formatters"
+import {
+  DOCUMENT_SCOPE_LABEL,
+  DOCUMENT_SCOPE_TEXT,
+  getDocumentScope,
+  toInitials,
+} from "@/components/V2/Library/documentScope"
+import { cn } from "@/lib/utils"
+
+const MAX_CARDS = 4
+const MAX_AVATARS = 3
+
+function timestampOf(document: V2DocumentPublic): number {
+  const value = document.updated_at ?? document.created_at
+  const parsed = value ? new Date(value).getTime() : Number.NaN
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
+function buildAvatars(
+  document: V2DocumentPublic,
+  currentUser: UserPublic,
+): { labels: string[]; overflow: number } {
+  const labels: string[] = []
+  const seen = new Set<string>()
+  const push = (raw: string | null | undefined) => {
+    if (!raw) return
+    const label = toInitials(raw)
+    if (seen.has(label)) return
+    seen.add(label)
+    labels.push(label)
+  }
+
+  if (document.owner_id === currentUser.id) {
+    push(currentUser.full_name || currentUser.email)
+  }
+  for (const share of document.shared_with ?? []) {
+    push(share.full_name || share.email)
+  }
+  if (labels.length === 0) {
+    // Shared-to-you docs may not enumerate members; fall back to the title.
+    push(document.title)
+  }
+
+  return {
+    labels: labels.slice(0, MAX_AVATARS),
+    overflow: Math.max(0, labels.length - MAX_AVATARS),
+  }
+}
+
+function RecentCard({
+  document,
+  currentUser,
+}: {
+  document: V2DocumentPublic
+  currentUser: UserPublic
+}) {
+  const scope = getDocumentScope(document, currentUser.id)
+  const sharedByOther = document.owner_id !== currentUser.id
+  const { labels, overflow } = buildAvatars(document, currentUser)
+
+  return (
+    <Link
+      to="/v2/library/$documentId"
+      params={{ documentId: document.id }}
+      className="group flex min-h-[134px] flex-col border border-border bg-card p-3.5 text-card-foreground transition-colors hover:border-muted-foreground/40 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+    >
+      <div
+        className={cn(
+          "mb-1.5 font-mono text-[9px] uppercase tracking-[0.14em]",
+          DOCUMENT_SCOPE_TEXT[scope],
+        )}
+      >
+        {DOCUMENT_SCOPE_LABEL[scope]}
+      </div>
+      <h3 className="text-[13px] font-semibold leading-[1.25] tracking-[-0.01em]">
+        {document.title}
+      </h3>
+      {document.description && (
+        <p className="mt-[3px] line-clamp-2 text-[10.5px] leading-[1.45] text-muted-foreground">
+          {document.description}
+        </p>
+      )}
+      <div className="mt-[9px] font-mono text-[9.5px] text-muted-foreground/70">
+        {sharedByOther ? "Shared" : "Updated"} ·{" "}
+        <span className="font-medium text-foreground">
+          {formatRelativeTime(document.updated_at ?? document.created_at)}
+        </span>
+      </div>
+
+      <div className="mt-auto flex items-center justify-between gap-2 border-t border-border/60 pt-2.5">
+        <div className="flex min-w-0 items-center gap-1.5 font-mono text-[10px] text-muted-foreground">
+          <Folder
+            className="size-3 shrink-0 text-muted-foreground/70"
+            aria-hidden
+          />
+          <span className="truncate">{document.folder_name ?? "Unfiled"}</span>
+        </div>
+        <div className="flex shrink-0 items-center">
+          {labels.map((label, index) => (
+            <span
+              key={label}
+              className={cn(
+                "grid size-[18px] place-items-center border border-card bg-muted text-[9px] font-semibold outline outline-1 outline-border",
+                index > 0 && "-ml-1",
+              )}
+            >
+              {label}
+            </span>
+          ))}
+          {overflow > 0 && (
+            <span className="-ml-1 grid size-[18px] place-items-center border border-card bg-muted text-[9px] font-semibold outline outline-1 outline-border">
+              +{overflow}
+            </span>
+          )}
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+/**
+ * Expressive "Recently accessed" reel — the top half of the hybrid Library. Shows
+ * the most recently updated documents as cards above the folder/file list.
+ */
+export function LibraryRecentReel({
+  documents,
+  currentUser,
+}: {
+  documents: V2DocumentPublic[]
+  currentUser: UserPublic
+}) {
+  const recent = useMemo(
+    () =>
+      [...documents]
+        .sort((a, b) => timestampOf(b) - timestampOf(a))
+        .slice(0, MAX_CARDS),
+    [documents],
+  )
+
+  if (recent.length === 0) return null
+
+  return (
+    <section aria-label="Recently accessed" className="shrink-0">
+      <div className="mb-3 flex items-baseline gap-2.5">
+        <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-foreground">
+          Recently accessed
+        </span>
+        <span className="font-mono text-[9.5px] text-muted-foreground/70">
+          last opened across your library
+        </span>
+      </div>
+      <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
+        {recent.map((document) => (
+          <RecentCard
+            key={document.id}
+            document={document}
+            currentUser={currentUser}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/V2/Library/documentScope.ts
+++ b/src/components/V2/Library/documentScope.ts
@@ -1,0 +1,48 @@
+import type { V2DocumentPublic } from "@/api/v2Documents"
+
+/**
+ * The library-hybrid mockup spells visibility out as three states. The document
+ * model only stores `private | organization`, so "shared" is derived from
+ * ownership: a document you don't own that's reached you is shared with you.
+ */
+export type DocumentScope = "private" | "organization" | "shared"
+
+export function getDocumentScope(
+  document: V2DocumentPublic,
+  currentUserId: string,
+): DocumentScope {
+  if (document.owner_id !== currentUserId) return "shared"
+  if (document.visibility === "organization") return "organization"
+  return "private"
+}
+
+export const DOCUMENT_SCOPE_LABEL: Record<DocumentScope, string> = {
+  private: "Private",
+  organization: "Organization",
+  shared: "Shared",
+}
+
+/** Chip / text color per scope — purple org, green shared, muted private. */
+export const DOCUMENT_SCOPE_TEXT: Record<DocumentScope, string> = {
+  private: "text-muted-foreground",
+  organization: "text-[#8447ff]",
+  shared: "text-emerald-600 dark:text-emerald-400",
+}
+
+/** Status-dot background per scope. */
+export const DOCUMENT_SCOPE_DOT: Record<DocumentScope, string> = {
+  private: "bg-muted-foreground/60",
+  organization: "bg-[#8447ff]",
+  shared: "bg-emerald-600 dark:bg-emerald-400",
+}
+
+/** Build up to two uppercase initials from a name or email. */
+export function toInitials(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) return "?"
+  const handle = trimmed.includes("@") ? trimmed.split("@")[0] : trimmed
+  const parts = handle.split(/[\s._-]+/).filter(Boolean)
+  if (parts.length === 0) return handle.slice(0, 2).toUpperCase()
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[1][0]).toUpperCase()
+}

--- a/src/components/V2/Profiles/ProfileCard.tsx
+++ b/src/components/V2/Profiles/ProfileCard.tsx
@@ -1,0 +1,112 @@
+import { Folder } from "lucide-react"
+
+import { formatCompactNumber } from "@/components/V2/Agents/formatters"
+import type { Profile } from "@/components/V2/Profiles/peopleData"
+import { cn } from "@/lib/utils"
+
+type Stat = {
+  label: string
+  value: string
+  /** Lead metric is tinted purple. */
+  lead?: boolean
+}
+
+function ProfileStats({ stats }: { stats: Stat[] }) {
+  return (
+    <div className="mt-auto grid grid-cols-3 border-t border-border/60">
+      {stats.map((stat, index) => (
+        <div
+          key={stat.label}
+          className={cn(
+            "py-[11px]",
+            index > 0 && "border-l border-border/60 pl-3",
+          )}
+        >
+          <div
+            className={cn(
+              "font-mono text-[15px] font-semibold tabular-nums tracking-[-0.01em]",
+              stat.lead ? "text-[#8447ff]" : "text-foreground",
+            )}
+          >
+            {stat.value}
+          </div>
+          <div className="mt-[3px] font-mono text-[8.5px] uppercase tracking-[0.12em] text-muted-foreground/70">
+            {stat.label}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ProfileCard({ profile }: { profile: Profile }) {
+  const you = profile.isCurrentUser
+  const stats: Stat[] = [
+    { label: "Reuses", value: profile.reuses.toLocaleString(), lead: true },
+    { label: "Docs", value: profile.docs.toLocaleString() },
+    { label: "Saved", value: formatCompactNumber(profile.tokensSaved) },
+  ]
+
+  return (
+    <article
+      className={cn(
+        "relative flex min-h-[168px] flex-col border border-border bg-card px-4 pt-[15px]",
+        you && "border-t-2 border-t-[#8447ff]",
+      )}
+    >
+      {you && (
+        <span className="absolute right-3.5 top-3 font-mono text-[8.5px] uppercase tracking-[0.14em] text-[#8447ff]">
+          You
+        </span>
+      )}
+
+      <div className="flex items-center gap-[11px]">
+        <div
+          className={cn(
+            "grid size-[38px] shrink-0 place-items-center font-mono text-[13px] font-semibold outline outline-1",
+            you
+              ? "bg-[#8447ff] text-white outline-[#8447ff]"
+              : "bg-muted text-foreground outline-border",
+          )}
+        >
+          {profile.initials}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-semibold tracking-[-0.01em]">
+            {profile.name}
+          </div>
+          <div className="mt-[3px] font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground/70">
+            {profile.role}
+          </div>
+        </div>
+      </div>
+
+      <p className="mt-3 text-[11px] leading-[1.45] text-muted-foreground">
+        {profile.focus}
+      </p>
+
+      <ProfileStats stats={stats} />
+
+      <div className="-mx-4 flex items-center justify-between gap-2 border-t border-border/60 px-4 py-[9px] font-mono text-[9.5px] tracking-[0.03em] text-muted-foreground/70">
+        <div className="flex items-center gap-1.5 whitespace-nowrap">
+          <span
+            className={cn(
+              "size-1.5 shrink-0",
+              profile.active
+                ? "bg-emerald-600 dark:bg-emerald-400"
+                : "bg-border",
+            )}
+          />
+          {profile.lastActive}
+        </div>
+        <div className="flex items-center gap-1 whitespace-nowrap text-muted-foreground">
+          <Folder
+            className="size-[11px] text-muted-foreground/70"
+            aria-hidden
+          />
+          {profile.topFolder}
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/src/components/V2/Profiles/peopleData.ts
+++ b/src/components/V2/Profiles/peopleData.ts
@@ -1,0 +1,215 @@
+export type ProfileDepartment = "Engineering" | "Product" | "Design"
+
+export interface Profile {
+  id: string
+  name: string
+  initials: string
+  role: string
+  department: ProfileDepartment
+  isAdmin: boolean
+  isCurrentUser: boolean
+  /** One-line focus / what they own. */
+  focus: string
+  /** Lead metric — times this person's docs were reused. */
+  reuses: number
+  /** Documents authored. */
+  docs: number
+  /** Tokens saved via reuse. */
+  tokensSaved: number
+  /** Whether the person is active right now (drives the footer dot). */
+  active: boolean
+  /** Human-readable last-active label (e.g. "12m ago", "Yesterday"). */
+  lastActive: string
+  /** Their top library folder. */
+  topFolder: string
+}
+
+/**
+ * Seed teammates for the Profiles (People) directory. Mirrors the
+ * `mockups/profiles-minimal.html` handoff — the current user is pinned first.
+ */
+export const PROFILES: Profile[] = [
+  {
+    id: "alex-lin",
+    name: "Alex Lin",
+    initials: "AL",
+    role: "Staff Engineer · Billing",
+    department: "Engineering",
+    isAdmin: false,
+    isCurrentUser: true,
+    focus:
+      "Owns the Stripe billing surface and webhook idempotency work. Most-reused author this quarter.",
+    reuses: 41,
+    docs: 12,
+    tokensSaved: 142_000,
+    active: true,
+    lastActive: "12m ago",
+    topFolder: "Billing",
+  },
+  {
+    id: "nadia-osei",
+    name: "Nadia Osei",
+    initials: "NO",
+    role: "Backend · Data",
+    department: "Engineering",
+    isAdmin: false,
+    isCurrentUser: false,
+    focus:
+      "Postgres row-level security and tenant isolation. Maintains the RLS audit playbook.",
+    reuses: 18,
+    docs: 9,
+    tokensSaved: 71_000,
+    active: true,
+    lastActive: "1h ago",
+    topFolder: "Infra",
+  },
+  {
+    id: "jin-park",
+    name: "Jin Park",
+    initials: "JP",
+    role: "Product Eng · Auth",
+    department: "Product",
+    isAdmin: false,
+    isCurrentUser: false,
+    focus:
+      "Leads the Auth0 → Clerk migration. JWT mapping, session bridge, rollout sequencing.",
+    reuses: 22,
+    docs: 8,
+    tokensSaved: 63_000,
+    active: true,
+    lastActive: "3h ago",
+    topFolder: "Auth migration",
+  },
+  {
+    id: "ken-watanabe",
+    name: "Ken Watanabe",
+    initials: "KW",
+    role: "Security Eng",
+    department: "Engineering",
+    isAdmin: false,
+    isCurrentUser: false,
+    focus:
+      "Threat modeling and secrets handling. Reviews every doc touching auth or PII.",
+    reuses: 13,
+    docs: 6,
+    tokensSaved: 40_000,
+    active: true,
+    lastActive: "5h ago",
+    topFolder: "Infra",
+  },
+  {
+    id: "sofia-reyes",
+    name: "Sofia Reyes",
+    initials: "SR",
+    role: "Frontend Eng",
+    department: "Design",
+    isAdmin: false,
+    isCurrentUser: false,
+    focus:
+      "Design-system owner. Drove the Tailwind v4 token migration across the app.",
+    reuses: 14,
+    docs: 7,
+    tokensSaved: 33_000,
+    active: false,
+    lastActive: "2d ago",
+    topFolder: "Frontend",
+  },
+  {
+    id: "marco-diaz",
+    name: "Marco Diaz",
+    initials: "MD",
+    role: "Platform Eng",
+    department: "Engineering",
+    isAdmin: false,
+    isCurrentUser: false,
+    focus:
+      "CI shards, deploy tooling, and the seat-count reconciler. Keeps the pipeline green.",
+    reuses: 11,
+    docs: 6,
+    tokensSaved: 24_000,
+    active: false,
+    lastActive: "Yesterday",
+    topFolder: "Infra",
+  },
+  {
+    id: "priya-nair",
+    name: "Priya Nair",
+    initials: "PN",
+    role: "Eng Manager · Admin",
+    department: "Engineering",
+    isAdmin: true,
+    isCurrentUser: false,
+    focus:
+      "Runs the eng org. Owns roadmap docs and the library sharing rollout policy.",
+    reuses: 7,
+    docs: 4,
+    tokensSaved: 12_000,
+    active: false,
+    lastActive: "Yesterday",
+    topFolder: "Org-wide",
+  },
+  {
+    id: "theo-burns",
+    name: "Theo Burns",
+    initials: "TB",
+    role: "DevEx · CI",
+    department: "Engineering",
+    isAdmin: false,
+    isCurrentUser: false,
+    focus:
+      "Test infrastructure and flake triage. Maintains the Playwright quarantine list.",
+    reuses: 9,
+    docs: 5,
+    tokensSaved: 19_000,
+    active: false,
+    lastActive: "4d ago",
+    topFolder: "Frontend",
+  },
+  {
+    id: "rae-chen",
+    name: "Rae Chen",
+    initials: "RC",
+    role: "Product · Admin",
+    department: "Product",
+    isAdmin: true,
+    isCurrentUser: false,
+    focus:
+      "Billing PM. Writes the pricing specs that anchor the checkout and invoice work.",
+    reuses: 6,
+    docs: 5,
+    tokensSaved: 15_000,
+    active: true,
+    lastActive: "40m ago",
+    topFolder: "Billing",
+  },
+]
+
+export type ProfileFilterKey =
+  | "all"
+  | "engineering"
+  | "product"
+  | "design"
+  | "admins"
+
+export interface ProfileFilter {
+  key: ProfileFilterKey
+  label: string
+  match: (profile: Profile) => boolean
+}
+
+/** Scope facets for the filter bar. Counts are derived from {@link PROFILES}. */
+export const PROFILE_FILTERS: ProfileFilter[] = [
+  { key: "all", label: "All", match: () => true },
+  {
+    key: "engineering",
+    label: "Engineering",
+    match: (p) => p.department === "Engineering",
+  },
+  {
+    key: "product",
+    label: "Product",
+    match: (p) => p.department === "Product",
+  },
+  { key: "design", label: "Design", match: (p) => p.department === "Design" },
+  { key: "admins", label: "Admins", match: (p) => p.isAdmin },
+]

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -17,6 +17,7 @@ import {
   Rocket,
   Search,
   Shield,
+  Users,
 } from "lucide-react"
 import {
   Fragment,
@@ -70,6 +71,7 @@ type TaskforceNavItem = {
 const taskforceItems: TaskforceNavItem[] = [
   { icon: Search, title: "Search", path: "/v2/search" },
   { icon: Bot, title: "Profiles", path: "/v2/agents" },
+  { icon: Users, title: "People", path: "/v2/profiles" },
   { icon: BookOpen, title: "Library", path: "/v2/library" },
   { icon: ReceiptText, title: "Ledger", path: "/v2/ledger" },
   { icon: LineChart, title: "Metrics", path: "/v2/metrics" },

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as V2IndexRouteImport } from './routes/v2/index'
 import { Route as V2SettingsRouteImport } from './routes/v2/settings'
 import { Route as V2SearchRouteImport } from './routes/v2/search'
+import { Route as V2ProfilesRouteImport } from './routes/v2/profiles'
 import { Route as V2PricingRouteImport } from './routes/v2/pricing'
 import { Route as V2MetricsRouteImport } from './routes/v2/metrics'
 import { Route as V2LibraryRouteImport } from './routes/v2/library'
@@ -95,6 +96,11 @@ const V2SettingsRoute = V2SettingsRouteImport.update({
 const V2SearchRoute = V2SearchRouteImport.update({
   id: '/search',
   path: '/search',
+  getParentRoute: () => V2Route,
+} as any)
+const V2ProfilesRoute = V2ProfilesRouteImport.update({
+  id: '/profiles',
+  path: '/profiles',
   getParentRoute: () => V2Route,
 } as any)
 const V2PricingRoute = V2PricingRouteImport.update({
@@ -200,6 +206,7 @@ export interface FileRoutesByFullPath {
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2/pricing': typeof V2PricingRoute
+  '/v2/profiles': typeof V2ProfilesRoute
   '/v2/search': typeof V2SearchRoute
   '/v2/settings': typeof V2SettingsRoute
   '/v2/': typeof V2IndexRoute
@@ -228,6 +235,7 @@ export interface FileRoutesByTo {
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2/pricing': typeof V2PricingRoute
+  '/v2/profiles': typeof V2ProfilesRoute
   '/v2/search': typeof V2SearchRoute
   '/v2/settings': typeof V2SettingsRoute
   '/v2': typeof V2IndexRoute
@@ -259,6 +267,7 @@ export interface FileRoutesById {
   '/v2/library': typeof V2LibraryRouteWithChildren
   '/v2/metrics': typeof V2MetricsRouteWithChildren
   '/v2/pricing': typeof V2PricingRoute
+  '/v2/profiles': typeof V2ProfilesRoute
   '/v2/search': typeof V2SearchRoute
   '/v2/settings': typeof V2SettingsRoute
   '/v2/': typeof V2IndexRoute
@@ -290,6 +299,7 @@ export interface FileRouteTypes {
     | '/v2/library'
     | '/v2/metrics'
     | '/v2/pricing'
+    | '/v2/profiles'
     | '/v2/search'
     | '/v2/settings'
     | '/v2/'
@@ -318,6 +328,7 @@ export interface FileRouteTypes {
     | '/v2/library'
     | '/v2/metrics'
     | '/v2/pricing'
+    | '/v2/profiles'
     | '/v2/search'
     | '/v2/settings'
     | '/v2'
@@ -348,6 +359,7 @@ export interface FileRouteTypes {
     | '/v2/library'
     | '/v2/metrics'
     | '/v2/pricing'
+    | '/v2/profiles'
     | '/v2/search'
     | '/v2/settings'
     | '/v2/'
@@ -452,6 +464,13 @@ declare module '@tanstack/react-router' {
       path: '/search'
       fullPath: '/v2/search'
       preLoaderRoute: typeof V2SearchRouteImport
+      parentRoute: typeof V2Route
+    }
+    '/v2/profiles': {
+      id: '/v2/profiles'
+      path: '/profiles'
+      fullPath: '/v2/profiles'
+      preLoaderRoute: typeof V2ProfilesRouteImport
       parentRoute: typeof V2Route
     }
     '/v2/pricing': {
@@ -634,6 +653,7 @@ interface V2RouteChildren {
   V2LibraryRoute: typeof V2LibraryRouteWithChildren
   V2MetricsRoute: typeof V2MetricsRouteWithChildren
   V2PricingRoute: typeof V2PricingRoute
+  V2ProfilesRoute: typeof V2ProfilesRoute
   V2SearchRoute: typeof V2SearchRoute
   V2SettingsRoute: typeof V2SettingsRoute
   V2IndexRoute: typeof V2IndexRoute
@@ -647,6 +667,7 @@ const V2RouteChildren: V2RouteChildren = {
   V2LibraryRoute: V2LibraryRouteWithChildren,
   V2MetricsRoute: V2MetricsRouteWithChildren,
   V2PricingRoute: V2PricingRoute,
+  V2ProfilesRoute: V2ProfilesRoute,
   V2SearchRoute: V2SearchRoute,
   V2SettingsRoute: V2SettingsRoute,
   V2IndexRoute: V2IndexRoute,

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -69,10 +69,16 @@ import {
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
+  DOCUMENT_SCOPE_DOT,
+  DOCUMENT_SCOPE_LABEL,
+  getDocumentScope,
+} from "@/components/V2/Library/documentScope"
+import {
   FolderActionsMenu,
   FolderCreateDialog,
   FolderPickerDropdown,
 } from "@/components/V2/Library/FolderControls"
+import { LibraryRecentReel } from "@/components/V2/Library/LibraryRecentReel"
 import {
   V2_PAGE_CONTENT_FIXED,
   V2_PAGE_FRAME,
@@ -111,7 +117,14 @@ type FolderTreeNode = {
 }
 
 type DirectoryDropTargetId = "root" | "unfiled" | string
-type OwnershipFilter = "owned" | "shared"
+type LibraryScope = "all" | "mine" | "shared" | "org"
+
+const LIBRARY_SCOPES: { key: LibraryScope; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "mine", label: "Mine" },
+  { key: "shared", label: "Shared with me" },
+  { key: "org", label: "Org" },
+]
 type FavoriteUpdate = { documentId: string; favorite: boolean }
 
 function buildFolderTree(folders: V2DocumentFolderPublic[]): FolderTreeNode[] {
@@ -183,10 +196,13 @@ function TaskforceLibrary() {
     "files",
     { deserialize: enumDeserializer(["files", "folders"]) },
   )
-  const [ownershipFilter, setOwnershipFilter] =
-    usePersistentState<OwnershipFilter>("library.ownership", "owned", {
-      deserialize: enumDeserializer(["owned", "shared"]),
-    })
+  const [scopeFilter, setScopeFilter] = usePersistentState<LibraryScope>(
+    "library.scope",
+    "all",
+    {
+      deserialize: enumDeserializer(["all", "mine", "shared", "org"]),
+    },
+  )
   const [selectedFolderId, setSelectedFolderId] = useState("all")
   const [createFolderOpen, setCreateFolderOpen] = useState(false)
   const [createDocumentOpen, setCreateDocumentOpen] = useState(false)
@@ -455,15 +471,23 @@ function TaskforceLibrary() {
 
   const allDocuments = documentsQuery.data?.data ?? []
   const documents = useMemo(() => {
-    if (ownershipFilter === "owned") {
-      return allDocuments.filter(
-        (document) => document.owner_id === currentUser.id,
-      )
+    switch (scopeFilter) {
+      case "mine":
+        return allDocuments.filter(
+          (document) => document.owner_id === currentUser.id,
+        )
+      case "shared":
+        return allDocuments.filter(
+          (document) => document.owner_id !== currentUser.id,
+        )
+      case "org":
+        return allDocuments.filter(
+          (document) => document.visibility === "organization",
+        )
+      default:
+        return allDocuments
     }
-    return allDocuments.filter(
-      (document) => document.owner_id !== currentUser.id,
-    )
-  }, [allDocuments, currentUser.id, ownershipFilter])
+  }, [allDocuments, currentUser.id, scopeFilter])
   const folders = foldersQuery.data?.data ?? []
   const folderTree = useMemo(() => buildFolderTree(folders), [folders])
   const favoriteDocuments = useMemo(
@@ -665,6 +689,22 @@ function TaskforceLibrary() {
                 <h1 className="mt-1 text-2xl font-semibold">Library</h1>
               </div>
               <div className="flex flex-wrap items-center gap-2">
+                <div
+                  role="tablist"
+                  aria-label="Library view"
+                  className="inline-flex h-9 w-fit shrink-0 items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground"
+                >
+                  <LibraryViewToggle
+                    label="Files"
+                    active={libraryView === "files"}
+                    onClick={() => setLibraryView("files")}
+                  />
+                  <LibraryViewToggle
+                    label="Folders"
+                    active={libraryView === "folders"}
+                    onClick={() => setLibraryView("folders")}
+                  />
+                </div>
                 <Button
                   type="button"
                   size="sm"
@@ -684,44 +724,31 @@ function TaskforceLibrary() {
                 </Button>
               </div>
             </div>
-            <div className="flex flex-wrap items-center gap-2">
-              <div
-                role="tablist"
-                aria-label="Document ownership"
-                className="inline-flex h-9 w-fit shrink-0 items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground"
-              >
-                <LibraryViewToggle
-                  label="Owned by you"
-                  active={ownershipFilter === "owned"}
-                  onClick={() => {
-                    setOwnershipFilter("owned")
-                    setSelectedFolderId("all")
-                  }}
-                />
-                <LibraryViewToggle
-                  label="Shared with you"
-                  active={ownershipFilter === "shared"}
-                  onClick={() => {
-                    setOwnershipFilter("shared")
-                    setSelectedFolderId("all")
-                  }}
-                />
-              </div>
-              <div
-                role="tablist"
-                aria-label="Library view"
-                className="inline-flex h-9 w-fit shrink-0 items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground"
-              >
-                <LibraryViewToggle
-                  label="Files"
-                  active={libraryView === "files"}
-                  onClick={() => setLibraryView("files")}
-                />
-                <LibraryViewToggle
-                  label="Folders"
-                  active={libraryView === "folders"}
-                  onClick={() => setLibraryView("folders")}
-                />
+            <div className="flex flex-wrap items-stretch border-t font-mono text-[10px] uppercase tracking-[0.1em]">
+              {LIBRARY_SCOPES.map((scope) => {
+                const isActive = scope.key === scopeFilter
+                return (
+                  <button
+                    key={scope.key}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    onClick={() => {
+                      setScopeFilter(scope.key)
+                      setSelectedFolderId("all")
+                    }}
+                    className={cn(
+                      "border-r px-3 py-2 text-muted-foreground transition-colors hover:text-foreground",
+                      isActive &&
+                        "text-foreground shadow-[inset_0_-2px_0_#8447ff]",
+                    )}
+                  >
+                    {scope.label}
+                  </button>
+                )
+              })}
+              <div className="ml-auto px-3 py-2 text-muted-foreground">
+                Sort: recent ↓
               </div>
             </div>
           </div>
@@ -762,6 +789,13 @@ function TaskforceLibrary() {
             <div className="border bg-card p-6 text-sm text-muted-foreground">
               No documents yet.
             </div>
+          )}
+
+          {!isLoading && documents.length > 0 && (
+            <LibraryRecentReel
+              documents={documents}
+              currentUser={currentUser}
+            />
           )}
 
           {!isLoading && documents.length > 0 && libraryView === "files" && (
@@ -1112,6 +1146,7 @@ function FolderDirectory({
         dragOver={false}
         canMoveItems={false}
         canFavorite={canFavorite}
+        currentUserId={currentUserId}
         onToggle={() => onToggleFolder("favorites")}
         onDocumentDragStart={onDocumentDragStart}
         onDocumentDragEnd={onDocumentDragEnd}
@@ -1128,6 +1163,7 @@ function FolderDirectory({
         dragOver={dragOverFolderId === "unfiled"}
         canMoveItems={canMoveItems}
         canFavorite={canFavorite}
+        currentUserId={currentUserId}
         onToggle={() => onToggleFolder("unfiled")}
         onDocumentDragStart={onDocumentDragStart}
         onDocumentDragEnd={onDocumentDragEnd}
@@ -1266,6 +1302,7 @@ function DirectoryUnfiled({
   dragOver,
   canMoveItems,
   canFavorite,
+  currentUserId,
   onToggle,
   onDocumentDragStart,
   onDocumentDragEnd,
@@ -1281,6 +1318,7 @@ function DirectoryUnfiled({
   dragOver: boolean
   canMoveItems: boolean
   canFavorite: boolean
+  currentUserId: string
   onToggle: () => void
   onDocumentDragStart: (
     event: DragEvent<HTMLAnchorElement>,
@@ -1330,6 +1368,7 @@ function DirectoryUnfiled({
               depth={0}
               draggable={canMoveItems}
               canFavorite={canFavorite}
+              currentUserId={currentUserId}
               onDragStart={onDocumentDragStart}
               onDragEnd={onDocumentDragEnd}
               onToggleFavorite={onToggleFavorite}
@@ -1459,6 +1498,7 @@ function DirectoryFolder({
               depth={depth + 1}
               draggable={canMoveItems}
               canFavorite={canFavorite}
+              currentUserId={currentUserId}
               onDragStart={onDocumentDragStart}
               onDragEnd={onDocumentDragEnd}
               onToggleFavorite={onToggleFavorite}
@@ -1475,6 +1515,7 @@ function DirectoryDocumentRow({
   depth,
   draggable,
   canFavorite,
+  currentUserId,
   onDragStart,
   onDragEnd,
   onToggleFavorite,
@@ -1483,6 +1524,7 @@ function DirectoryDocumentRow({
   depth: number
   draggable: boolean
   canFavorite: boolean
+  currentUserId: string
   onDragStart: (
     event: DragEvent<HTMLAnchorElement>,
     document: V2DocumentPublic,
@@ -1491,6 +1533,7 @@ function DirectoryDocumentRow({
   onToggleFavorite: (document: V2DocumentPublic) => void
 }) {
   const { canDelete, onDelete } = useDocumentDelete()
+  const scope = getDocumentScope(document, currentUserId)
   return (
     <div className="flex items-center hover:bg-muted">
       <Link
@@ -1509,8 +1552,12 @@ function DirectoryDocumentRow({
           <FileText className="size-4 shrink-0 text-muted-foreground" />
           <span className="truncate font-medium">{document.title}</span>
         </span>
-        <span className="truncate text-xs text-muted-foreground max-md:hidden">
-          {document.visibility === "organization" ? "Organization" : "Private"}
+        <span className="flex items-center gap-2 truncate text-xs text-muted-foreground max-md:hidden">
+          <span
+            className={cn("size-1.5 shrink-0", DOCUMENT_SCOPE_DOT[scope])}
+            aria-hidden
+          />
+          {DOCUMENT_SCOPE_LABEL[scope]}
         </span>
         <span className="truncate text-xs text-muted-foreground max-md:hidden">
           {formatDateOnly(document.updated_at)}

--- a/src/routes/v2/profiles.tsx
+++ b/src/routes/v2/profiles.tsx
@@ -1,0 +1,116 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { useMemo, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { ProfileCard } from "@/components/V2/Profiles/ProfileCard"
+import {
+  PROFILE_FILTERS,
+  PROFILES,
+  type ProfileFilterKey,
+} from "@/components/V2/Profiles/peopleData"
+import {
+  V2_PAGE_CONTENT,
+  V2_PAGE_FRAME,
+  V2_TAB_EYEBROW_CLASS,
+} from "@/components/V2/v2PageShell"
+import { cn } from "@/lib/utils"
+
+export const Route = createFileRoute("/v2/profiles")({
+  component: TaskforceProfiles,
+  head: () => ({
+    meta: [
+      {
+        title: "Taskforce | People",
+      },
+    ],
+  }),
+})
+
+function FilterBar({
+  active,
+  onChange,
+}: {
+  active: ProfileFilterKey
+  onChange: (key: ProfileFilterKey) => void
+}) {
+  return (
+    <div className="flex flex-wrap items-stretch border-y border-border font-mono text-[10px] uppercase tracking-[0.1em]">
+      {PROFILE_FILTERS.map((filter) => {
+        const count = PROFILES.filter(filter.match).length
+        const isActive = filter.key === active
+        return (
+          <button
+            key={filter.key}
+            type="button"
+            aria-pressed={isActive}
+            onClick={() => onChange(filter.key)}
+            className={cn(
+              "flex items-center gap-1.5 border-r border-border px-3 py-2 text-muted-foreground transition-colors hover:text-foreground",
+              isActive && "text-foreground shadow-[inset_0_-2px_0_#8447ff]",
+            )}
+          >
+            {filter.label}
+            <span className="text-muted-foreground/60">{count}</span>
+          </button>
+        )
+      })}
+      <div className="ml-auto border-l border-border px-3 py-2 text-muted-foreground">
+        Sort: reuses driven ↓
+      </div>
+    </div>
+  )
+}
+
+function TaskforceProfiles() {
+  const [activeFilter, setActiveFilter] = useState<ProfileFilterKey>("all")
+
+  const matcher =
+    PROFILE_FILTERS.find((filter) => filter.key === activeFilter)?.match ??
+    (() => true)
+  const visible = useMemo(() => PROFILES.filter(matcher), [matcher])
+  const activeNow = PROFILES.filter((profile) => profile.active).length
+
+  return (
+    <section
+      className={`${V2_PAGE_FRAME} bg-background font-sans text-foreground`}
+    >
+      <div className={V2_PAGE_CONTENT}>
+        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <div className={V2_TAB_EYEBROW_CLASS}>
+              People · {PROFILES.length} members · {activeNow} active now
+            </div>
+            <h1 className="mt-1 text-2xl font-semibold tracking-tight">
+              Profiles
+            </h1>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button type="button" variant="outline" size="sm">
+              Manage roles
+            </Button>
+            <Button type="button" size="sm">
+              + Invite
+            </Button>
+          </div>
+        </header>
+
+        <FilterBar active={activeFilter} onChange={setActiveFilter} />
+
+        <div
+          data-testid="profiles-card-grid"
+          className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+        >
+          {visible.map((profile) => (
+            <ProfileCard key={profile.id} profile={profile} />
+          ))}
+        </div>
+
+        {visible.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No teammates match this filter.
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
Implements two Claude Design handoffs into the Taskforce v2 surface.

## Profiles (People) — `mockups/profiles-minimal.html`
- New `/v2/profiles` route: header, scope filter bar (counts derived), responsive card grid
- `ProfileCard` + `peopleData` seed — current user pinned with purple top accent + "You" tag, purple-lead stat triplet (Reuses/Docs/Saved), live/idle footer + folder tag
- New **People** nav item in `TaskforceShell`; `routeTree.gen.ts` regenerated

## Library (hybrid, additive) — `mockups/library-hybrid.html`
- `LibraryRecentReel`: expressive "Recently accessed" cards (top-4 by recency)
- Replaced the Owned/Shared toggle with the mockup's **All / Mine / Shared with me / Org** scope bar + Sort label; moved Files/Folders into the actions cluster
- Spelled-out **Private / Organization / Shared** visibility with colored dots on folder rows
- Shared `documentScope` helper
- **All existing functionality preserved**: drag-drop filing, create/delete/favorite, infinite scroll, folder nav

## Notes
- Mockups' forced-dark `--tf-*` tokens mapped onto the app's theme-aware semantic tokens (work in light + dark)
- The mockup cards show "142K saved / 14 reuses" — those metrics don't exist on the document model, so the reel uses real signals (recency, scope, folder, shared-member avatars) instead of fabricated numbers

## Verification
- `tsc -p tsconfig.build.json --noEmit` clean
- Biome clean
- No existing Playwright tests reference removed toggle labels; nav assertions are name-specific

🤖 Generated with [Claude Code](https://claude.com/claude-code)