### PR TITLE
Profiles/Library scroll margins + Create profile dialog

### DIFF
--- a/src/api/v2Agents.ts
+++ b/src/api/v2Agents.ts
@@ -22,6 +22,13 @@ export interface AgentsListResponse {
   items: AgentSpecialistSummary[]
 }
 
+export interface AgentSpecialistCreate {
+  name: string
+  role: string
+  short_description?: string
+  domain_tags?: string[]
+}
+
 export interface AgentSpecialistLinkedDoc {
   document_id: string
   title: string
@@ -75,6 +82,20 @@ export function listAgents(
     query: {
       demo: options.demo || undefined,
     },
+  })
+}
+
+export function createAgent(
+  body: AgentSpecialistCreate,
+  options: { demo?: boolean } = {},
+): CancelablePromise<AgentSpecialistDetail> {
+  return request(OpenAPI, {
+    method: "POST",
+    url: "/api/v1/v2/agents",
+    query: {
+      demo: options.demo || undefined,
+    },
+    body,
   })
 }
 

--- a/src/components/V2/Agents/CreateProfileDialog.tsx
+++ b/src/components/V2/Agents/CreateProfileDialog.tsx
@@ -1,0 +1,137 @@
+import { Plus } from "lucide-react"
+import { type FormEvent, useEffect, useState } from "react"
+
+import type { AgentSpecialistCreate } from "@/api/v2Agents"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+
+function parseTags(raw: string): string[] {
+  return Array.from(
+    new Set(
+      raw
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+    ),
+  )
+}
+
+export function CreateProfileDialog({
+  open,
+  onOpenChange,
+  isCreating,
+  onSubmit,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  isCreating: boolean
+  onSubmit: (values: AgentSpecialistCreate) => void
+}) {
+  const [name, setName] = useState("")
+  const [role, setRole] = useState("")
+  const [description, setDescription] = useState("")
+  const [tags, setTags] = useState("")
+
+  useEffect(() => {
+    if (open) {
+      setName("")
+      setRole("")
+      setDescription("")
+      setTags("")
+    }
+  }, [open])
+
+  const canSubmit = name.trim().length > 0 && role.trim().length > 0
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    if (!canSubmit || isCreating) return
+    onSubmit({
+      name: name.trim(),
+      role: role.trim(),
+      short_description: description.trim() || undefined,
+      domain_tags: parseTags(tags),
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>New profile</DialogTitle>
+          <DialogDescription>
+            Create a specialist profile. You can refine its instructions and
+            linked knowledge after it's created.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="new-profile-name">Name</Label>
+            <Input
+              id="new-profile-name"
+              autoFocus
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Billing Specialist"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-profile-role">Role</Label>
+            <Input
+              id="new-profile-role"
+              value={role}
+              onChange={(event) => setRole(event.target.value)}
+              placeholder="Stripe billing & webhooks"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-profile-description">Focus</Label>
+            <Textarea
+              id="new-profile-description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="One line on what this profile owns."
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-profile-tags">Domain tags</Label>
+            <Input
+              id="new-profile-tags"
+              value={tags}
+              onChange={(event) => setTags(event.target.value)}
+              placeholder="billing, payments, webhooks"
+            />
+            <p className="text-xs text-muted-foreground">
+              Comma-separated. Used for routing and filtering.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={isCreating}
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!canSubmit || isCreating}>
+              <Plus className="size-4" />
+              {isCreating ? "Creating" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -1,11 +1,18 @@
-import { useQuery } from "@tanstack/react-query"
-import { createFileRoute, Outlet, useRouterState } from "@tanstack/react-router"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  createFileRoute,
+  Outlet,
+  useNavigate,
+  useRouterState,
+} from "@tanstack/react-router"
 import { Bot, Loader2 } from "lucide-react"
 import { useMemo, useState } from "react"
 
 import {
+  type AgentSpecialistCreate,
   type AgentSpecialistStatus,
   type AgentSpecialistSummary,
+  createAgent,
   listAgents,
 } from "@/api/v2Agents"
 import { useDemoMode } from "@/components/demo-mode-provider"
@@ -16,7 +23,9 @@ import {
   AGENT_EYEBROW_CLASS,
   AGENT_PAGE_TITLE_CLASS,
 } from "@/components/V2/Agents/agentsTypography"
+import { CreateProfileDialog } from "@/components/V2/Agents/CreateProfileDialog"
 import { V2_PAGE_CONTENT, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
+import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
 
 type AgentScope = "all" | AgentSpecialistStatus
@@ -125,13 +134,31 @@ function EmptyAgents({ isDemoMode }: { isDemoMode: boolean }) {
 
 function AgentsIndex() {
   const { isDemoMode } = useDemoMode()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
   const [scope, setScope] = useState<AgentScope>("all")
+  const [createProfileOpen, setCreateProfileOpen] = useState(false)
   const agentsQuery = useQuery({
     queryKey: ["v2-agents", isDemoMode],
     queryFn: () => listAgents({ demo: isDemoMode }),
   })
   const agents = agentsQuery.data?.items ?? []
   const activeCount = agents.filter((agent) => agent.status === "active").length
+
+  const createProfileMutation = useMutation({
+    mutationFn: (values: AgentSpecialistCreate) =>
+      createAgent(values, { demo: isDemoMode }),
+    onSuccess: (agent) => {
+      queryClient.invalidateQueries({ queryKey: ["v2-agents", isDemoMode] })
+      setCreateProfileOpen(false)
+      showSuccessToast("Profile created.")
+      navigate({ to: "/v2/agents/$slug", params: { slug: agent.slug } })
+    },
+    onError: () => {
+      showErrorToast("Could not create profile.")
+    },
+  })
 
   const visible = useMemo(() => {
     const filtered =
@@ -156,10 +183,22 @@ function AgentsIndex() {
             </div>
             <h1 className={cn("mt-1", AGENT_PAGE_TITLE_CLASS)}>Profiles</h1>
           </div>
-          <Button type="button" size="sm" className="w-fit">
+          <Button
+            type="button"
+            size="sm"
+            className="w-fit"
+            onClick={() => setCreateProfileOpen(true)}
+          >
             + Profile
           </Button>
         </header>
+
+        <CreateProfileDialog
+          open={createProfileOpen}
+          onOpenChange={setCreateProfileOpen}
+          isCreating={createProfileMutation.isPending}
+          onSubmit={(values) => createProfileMutation.mutate(values)}
+        />
 
         <ScopeFilterBar agents={agents} active={scope} onChange={setScope} />
 

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -143,7 +143,10 @@ function AgentsIndex() {
 
   return (
     <section
-      className={`${V2_PAGE_FRAME} bg-background font-sans text-foreground`}
+      className={cn(
+        V2_PAGE_FRAME,
+        "-mb-6 bg-background font-sans text-foreground md:-mb-8",
+      )}
     >
       <div className={V2_PAGE_CONTENT}>
         <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -677,7 +677,7 @@ function TaskforceLibrary() {
         onDelete: requestDeleteDocument,
       }}
     >
-      <section className={cn(V2_PAGE_FRAME, "overflow-hidden")}>
+      <section className={cn(V2_PAGE_FRAME, "-mt-6 overflow-hidden md:-mt-8")}>
         <div className={V2_PAGE_CONTENT}>
           <div className="sticky top-0 z-20 -mx-6 -mt-6 flex shrink-0 flex-col gap-4 border-b bg-background/95 px-6 pt-6 pb-4 backdrop-blur">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">


### PR DESCRIPTION
Three small follow-ups.

## Scroll margins
- **Profiles (agents):** cancel the shell's bottom padding so the card grid scrolls all the way to the viewport bottom (left/right/top margins unchanged)
- **Library:** cancel the shell's top padding so the sticky header sits flush below the global topbar instead of leaving a gap that scrolling content bled into

## Create profile
- `createAgent` client (`POST /api/v1/v2/agents`) + `AgentSpecialistCreate` type
- New `CreateProfileDialog` (name, role, focus, comma-separated domain tags)
- The **+ Profile** button now opens the dialog; on success it invalidates the agents list and navigates to the new profile's detail page
- **Note:** needs a backend `POST /api/v1/v2/agents` endpoint to persist; UI + client wiring are in place.

## Verification
- `tsc -p tsconfig.build.json --noEmit` clean
- Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)