### PR TITLE
feat(v2): consolidate Profiles + Library onto one ScopeFilterBar

### DIFF
--- a/src/components/V2/ScopeFilterBar.tsx
+++ b/src/components/V2/ScopeFilterBar.tsx
@@ -1,0 +1,60 @@
+import { cn } from "@/lib/utils"
+
+export type ScopeFilterItem<TKey extends string> = {
+  key: TKey
+  label: string
+  /** Optional trailing count badge (omit to render the label alone). */
+  count?: number
+}
+
+/**
+ * Shared horizontal scope/filter bar used across v2 pages (Profiles, Library).
+ * Single source of truth for the bordered tab strip + trailing sort chip so the
+ * two pages can't drift apart visually.
+ */
+export function ScopeFilterBar<TKey extends string>({
+  items,
+  active,
+  onChange,
+  sortLabel,
+  className,
+}: {
+  items: ScopeFilterItem<TKey>[]
+  active: TKey
+  onChange: (key: TKey) => void
+  sortLabel: string
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-stretch border-y border-border font-mono text-[10px] uppercase tracking-[0.1em]",
+        className,
+      )}
+    >
+      {items.map((item) => {
+        const isActive = item.key === active
+        return (
+          <button
+            key={item.key}
+            type="button"
+            aria-pressed={isActive}
+            onClick={() => onChange(item.key)}
+            className={cn(
+              "flex items-center gap-1.5 border-r border-border px-3 py-2 text-muted-foreground transition-colors hover:text-foreground",
+              isActive && "text-foreground shadow-[inset_0_-2px_0_#8447ff]",
+            )}
+          >
+            {item.label}
+            {item.count !== undefined && (
+              <span className="text-muted-foreground/60">{item.count}</span>
+            )}
+          </button>
+        )
+      })}
+      <div className="ml-auto border-l border-border px-3 py-2 text-muted-foreground">
+        Sort: {sortLabel}
+      </div>
+    </div>
+  )
+}

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -11,7 +11,6 @@ import { useMemo, useState } from "react"
 import {
   type AgentSpecialistCreate,
   type AgentSpecialistStatus,
-  type AgentSpecialistSummary,
   createAgent,
   listAgents,
 } from "@/api/v2Agents"
@@ -24,6 +23,7 @@ import {
   AGENT_PAGE_TITLE_CLASS,
 } from "@/components/V2/Agents/agentsTypography"
 import { CreateProfileDialog } from "@/components/V2/Agents/CreateProfileDialog"
+import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
 import { V2_PAGE_CONTENT, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
 import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
@@ -72,46 +72,6 @@ function AgentsLoading() {
           </div>
         </div>
       ))}
-    </div>
-  )
-}
-
-function ScopeFilterBar({
-  agents,
-  active,
-  onChange,
-}: {
-  agents: AgentSpecialistSummary[]
-  active: AgentScope
-  onChange: (scope: AgentScope) => void
-}) {
-  return (
-    <div className="flex flex-wrap items-stretch border-y border-border font-mono text-[10px] uppercase tracking-[0.1em]">
-      {AGENT_SCOPES.map((scope) => {
-        const count =
-          scope.key === "all"
-            ? agents.length
-            : agents.filter((agent) => agent.status === scope.key).length
-        const isActive = scope.key === active
-        return (
-          <button
-            key={scope.key}
-            type="button"
-            aria-pressed={isActive}
-            onClick={() => onChange(scope.key)}
-            className={cn(
-              "flex items-center gap-1.5 border-r border-border px-3 py-2 text-muted-foreground transition-colors hover:text-foreground",
-              isActive && "text-foreground shadow-[inset_0_-2px_0_#8447ff]",
-            )}
-          >
-            {scope.label}
-            <span className="text-muted-foreground/60">{count}</span>
-          </button>
-        )
-      })}
-      <div className="ml-auto border-l border-border px-3 py-2 text-muted-foreground">
-        Sort: tokens saved ↓
-      </div>
     </div>
   )
 }
@@ -200,7 +160,20 @@ function AgentsIndex() {
           onSubmit={(values) => createProfileMutation.mutate(values)}
         />
 
-        <ScopeFilterBar agents={agents} active={scope} onChange={setScope} />
+        <ScopeFilterBar
+          items={AGENT_SCOPES.map((agentScope) => ({
+            key: agentScope.key,
+            label: agentScope.label,
+            count:
+              agentScope.key === "all"
+                ? agents.length
+                : agents.filter((agent) => agent.status === agentScope.key)
+                    .length,
+          }))}
+          active={scope}
+          onChange={setScope}
+          sortLabel="tokens saved ↓"
+        />
 
         {agentsQuery.isLoading ? (
           <AgentsLoading />

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -79,6 +79,7 @@ import {
   FolderPickerDropdown,
 } from "@/components/V2/Library/FolderControls"
 import { LibraryRecentReel } from "@/components/V2/Library/LibraryRecentReel"
+import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
 import {
   V2_PAGE_CONTENT,
   V2_PAGE_FRAME,
@@ -488,6 +489,21 @@ function TaskforceLibrary() {
         return allDocuments
     }
   }, [allDocuments, currentUser.id, scopeFilter])
+  const scopeDocumentCounts = useMemo<Record<LibraryScope, number>>(
+    () => ({
+      all: allDocuments.length,
+      mine: allDocuments.filter(
+        (document) => document.owner_id === currentUser.id,
+      ).length,
+      shared: allDocuments.filter(
+        (document) => document.owner_id !== currentUser.id,
+      ).length,
+      org: allDocuments.filter(
+        (document) => document.visibility === "organization",
+      ).length,
+    }),
+    [allDocuments, currentUser.id],
+  )
   const folders = foldersQuery.data?.data ?? []
   const folderTree = useMemo(() => buildFolderTree(folders), [folders])
   const favoriteDocuments = useMemo(
@@ -679,7 +695,7 @@ function TaskforceLibrary() {
     >
       <section className={cn(V2_PAGE_FRAME, "-mt-6 overflow-hidden md:-mt-8")}>
         <div className={V2_PAGE_CONTENT}>
-          <div className="sticky top-0 z-20 -mx-6 -mt-6 flex shrink-0 flex-col gap-4 border-b bg-background/95 px-6 pt-6 pb-4 backdrop-blur">
+          <div className="sticky top-0 z-20 -mx-6 -mt-6 flex shrink-0 flex-col gap-4 bg-background/95 px-6 pt-6 pb-4 backdrop-blur">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
               <div>
                 <div className={V2_TAB_EYEBROW_CLASS}>
@@ -724,33 +740,20 @@ function TaskforceLibrary() {
                 </Button>
               </div>
             </div>
-            <div className="flex flex-wrap items-stretch border-t font-mono text-[10px] uppercase tracking-[0.1em]">
-              {LIBRARY_SCOPES.map((scope) => {
-                const isActive = scope.key === scopeFilter
-                return (
-                  <button
-                    key={scope.key}
-                    type="button"
-                    role="tab"
-                    aria-selected={isActive}
-                    onClick={() => {
-                      setScopeFilter(scope.key)
-                      setSelectedFolderId("all")
-                    }}
-                    className={cn(
-                      "border-r px-3 py-2 text-muted-foreground transition-colors hover:text-foreground",
-                      isActive &&
-                        "text-foreground shadow-[inset_0_-2px_0_#8447ff]",
-                    )}
-                  >
-                    {scope.label}
-                  </button>
-                )
-              })}
-              <div className="ml-auto px-3 py-2 text-muted-foreground">
-                Sort: recent ↓
-              </div>
-            </div>
+            <ScopeFilterBar
+              className="border-b-0"
+              items={LIBRARY_SCOPES.map((scope) => ({
+                key: scope.key,
+                label: scope.label,
+                count: scopeDocumentCounts[scope.key],
+              }))}
+              active={scopeFilter}
+              onChange={(key) => {
+                setScopeFilter(key)
+                setSelectedFolderId("all")
+              }}
+              sortLabel="recent ↓"
+            />
           </div>
 
           <FolderCreateDialog


### PR DESCRIPTION
## What

The Profiles page and Library page each had their own horizontal scope/filter bar. The Profiles one was well implemented; the Library one was a worse copy. This consolidates them onto a single shared component.

## Changes

- **New `src/components/V2/ScopeFilterBar.tsx`** — extracted from the Profiles bar's styling (`border-y border-border` frame, `border-r border-border` cells, count badges, purple inset active indicator, `border-l border-border` sort chip). Generic over scope key, with optional per-item counts.
- **Profiles (`routes/v2/agents.tsx`)** — removed the local `ScopeFilterBar`, now renders the shared one. No visual change.
- **Library (`routes/v2/library.tsx`)** — replaced the inline bar (bare `border-t`/`border-r`, no `border-border` token, no counts) with the shared component. Scope tabs now show counts (All / Mine / Shared with me / Org) to match Profiles.
- **Library divider removed** — dropped the hairline between the scope bar and the folders/files block (sticky-header `border-b` + the bar's bottom border via `border-b-0`).

## Notes

Adopting the Profiles bar brings count badges to Library — that's part of the Profiles design. The `count` field is optional on the shared component if we ever want labels-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)