### PR TITLE
Bump profiles page secondary font sizes ~10% and brighten muted gray

### DIFF
--- a/src/components/V2/Agents/AgentProfileCard.tsx
+++ b/src/components/V2/Agents/AgentProfileCard.tsx
@@ -47,7 +47,7 @@ function AgentStats({ stats }: { stats: Stat[] }) {
           >
             {stat.value}
           </div>
-          <div className="mt-[3px] font-mono text-[8.5px] uppercase tracking-[0.12em] text-muted-foreground/70">
+          <div className="mt-[3px] font-mono text-[9.5px] uppercase tracking-[0.12em] text-muted-foreground/90">
             {stat.label}
           </div>
         </div>
@@ -84,21 +84,21 @@ export function AgentProfileCard({ agent }: { agent: AgentSpecialistSummary }) {
           <div className="truncate text-sm font-semibold tracking-[-0.01em]">
             {agent.name}
           </div>
-          <div className="mt-[3px] font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground/70">
+          <div className="mt-[3px] font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground/90">
             {agent.role}
           </div>
         </div>
       </div>
 
       {agent.short_description && (
-        <p className="mt-3 line-clamp-2 text-[11px] leading-[1.45] text-muted-foreground">
+        <p className="mt-3 line-clamp-2 text-[12px] leading-[1.45] text-muted-foreground">
           {agent.short_description}
         </p>
       )}
 
       <AgentStats stats={stats} />
 
-      <div className="-mx-4 flex items-center justify-between gap-2 border-t border-border/60 px-4 py-[9px] font-mono text-[9.5px] tracking-[0.03em] text-muted-foreground/70">
+      <div className="-mx-4 flex items-center justify-between gap-2 border-t border-border/60 px-4 py-[9px] font-mono text-[10.5px] tracking-[0.03em] text-muted-foreground/90">
         <div className="flex items-center gap-1.5 whitespace-nowrap">
           <span
             className={cn(

--- a/src/components/V2/ScopeFilterBar.tsx
+++ b/src/components/V2/ScopeFilterBar.tsx
@@ -28,7 +28,7 @@ export function ScopeFilterBar<TKey extends string>({
   return (
     <div
       className={cn(
-        "flex flex-wrap items-stretch border-y border-border font-mono text-[10px] uppercase tracking-[0.1em]",
+        "flex flex-wrap items-stretch border-y border-border font-mono text-[11px] uppercase tracking-[0.1em]",
         className,
       )}
     >
@@ -47,7 +47,7 @@ export function ScopeFilterBar<TKey extends string>({
           >
             {item.label}
             {item.count !== undefined && (
-              <span className="text-muted-foreground/60">{item.count}</span>
+              <span className="text-muted-foreground/80">{item.count}</span>
             )}
           </button>
         )


### PR DESCRIPTION
## Summary
On the profiles list page (`/v2/agents`), the secondary gray text was small and hard to read in dark mode. This bumps all secondary font sizes ~10% and brightens the dimmed `muted-foreground`. Primary text (profile name) is unchanged.

## Changes
- **AgentProfileCard**: role line 9→10px, short description 11→12px, stat labels 8.5→9.5px, footer 9.5→10.5px; `text-muted-foreground/70` → `/90` for brighter gray.
- **ScopeFilterBar** (the All/Active/Draft/Archived bar): 10→11px; count badge `/60` → `/80`. Note: this component is shared with the Library page, so it stays visually consistent across both (its stated purpose).

## Test
- `npx tsc --noEmit` clean (CSS class string changes only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)