### PR TITLE
Brighten profiles card key reading text (~20%)

### DIFF
--- a/src/components/V2/Agents/AgentProfileCard.tsx
+++ b/src/components/V2/Agents/AgentProfileCard.tsx
@@ -47,7 +47,7 @@ function AgentStats({ stats }: { stats: Stat[] }) {
           >
             {stat.value}
           </div>
-          <div className="mt-[3px] font-mono text-[9.5px] uppercase tracking-[0.12em] text-muted-foreground/90">
+          <div className="mt-[3px] font-mono text-[9.5px] uppercase tracking-[0.12em] text-foreground/70">
             {stat.label}
           </div>
         </div>
@@ -84,14 +84,14 @@ export function AgentProfileCard({ agent }: { agent: AgentSpecialistSummary }) {
           <div className="truncate text-sm font-semibold tracking-[-0.01em]">
             {agent.name}
           </div>
-          <div className="mt-[3px] font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground/90">
+          <div className="mt-[3px] font-mono text-[10px] uppercase tracking-[0.12em] text-foreground/70">
             {agent.role}
           </div>
         </div>
       </div>
 
       {agent.short_description && (
-        <p className="mt-3 line-clamp-2 text-[12px] leading-[1.45] text-muted-foreground">
+        <p className="mt-3 line-clamp-2 text-[12px] leading-[1.45] text-foreground/80">
           {agent.short_description}
         </p>
       )}


### PR DESCRIPTION
## Summary
Follow-up to #231. The key reading text on the profiles cards was still a bit dim in dark mode. These lines now use `foreground` with opacity instead of `muted-foreground`, so they're brighter in dark mode and higher-contrast in light mode.

## Changes (AgentProfileCard)
- Summary/description line (e.g. "Stripe webhook subscriptions, retries…"): `muted-foreground` → `foreground/80`
- Role line + stat labels (Invocations / Docs / Saved): `muted-foreground/90` → `foreground/70`
- Footer ("Xh ago", hashtag tag) intentionally left dimmer per request.

## Test
- `npx tsc --noEmit` clean (CSS class string changes only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)