### PR TITLE
Standardize on shared ScopeFilterBar across v2 pages

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/api/v2Ledger"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { formatCompactNumber } from "@/components/V2/Agents/formatters"
+import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
 import { cn } from "@/lib/utils"
 
 import styles from "./LedgerPage.module.css"
@@ -61,13 +62,6 @@ type DayGroup = {
 function clientLabel(value: string | null | undefined): string {
   if (!value) return "Unknown"
   return CLIENT_LABELS[value] ?? value
-}
-
-function harnessDisplay(value: string | undefined): string {
-  return (
-    HARNESS_OPTIONS.find((option) => option.value === (value ?? "all"))
-      ?.label ?? "All harnesses"
-  )
 }
 
 function cleanLedgerSearch(filters: LedgerSearchFilters): LedgerSearchFilters {
@@ -393,18 +387,6 @@ export function LedgerPage({
                 />
               </form>
               <FilterChip
-                ariaLabel="Filter by harness"
-                display={harnessDisplay(client)}
-                onChange={(value) =>
-                  setLedgerSearch({
-                    client: value === "all" ? undefined : value,
-                    session_id: undefined,
-                  })
-                }
-                options={HARNESS_OPTIONS}
-                value={client ?? "all"}
-              />
-              <FilterChip
                 ariaLabel="Sort sessions"
                 caret={sort === "newest" ? "↓" : "↑"}
                 display={sort === "newest" ? "Newest" : "Oldest"}
@@ -422,6 +404,21 @@ export function LedgerPage({
               />
             </div>
           </header>
+
+          <ScopeFilterBar
+            className="border-b-0 px-7"
+            items={HARNESS_OPTIONS.map((option) => ({
+              key: option.value,
+              label: option.label,
+            }))}
+            active={client ?? "all"}
+            onChange={(value) =>
+              setLedgerSearch({
+                client: value === "all" ? undefined : value,
+                session_id: undefined,
+              })
+            }
+          />
 
           <div className={styles.cols}>
             <div>Time</div>

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -27,6 +27,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
 import {
   V2_PAGE_CONTENT,
   V2_PAGE_FRAME,
@@ -40,6 +41,12 @@ import { MetricBreakdown } from "./MetricBreakdown"
 import { MetricCard } from "./MetricCard"
 import { MetricsTimeRange } from "./MetricsTimeRange"
 import { MetricTrendChart } from "./MetricTrendChart"
+
+const METRICS_WINDOWS: { key: MetricsWindow; label: string }[] = [
+  { key: "7d", label: "7 days" },
+  { key: "30d", label: "30 days" },
+  { key: "all", label: "All time" },
+]
 
 type Props = {
   currentUser: UserPublic
@@ -443,14 +450,14 @@ export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
   return (
     <section className={V2_PAGE_FRAME}>
       <div className={V2_PAGE_CONTENT}>
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h1 className="text-2xl font-semibold">Metrics</h1>
-          </div>
-          <div className="flex flex-wrap items-center gap-3">
-            <MetricsTimeRange value={window} onChange={setWindow} />
-          </div>
+        <div>
+          <h1 className="text-2xl font-semibold">Metrics</h1>
         </div>
+        <ScopeFilterBar
+          items={METRICS_WINDOWS}
+          active={window}
+          onChange={setWindow}
+        />
 
         {scopedSessionId && (
           <div

--- a/src/components/V2/ScopeFilterBar.tsx
+++ b/src/components/V2/ScopeFilterBar.tsx
@@ -8,9 +8,12 @@ export type ScopeFilterItem<TKey extends string> = {
 }
 
 /**
- * Shared horizontal scope/filter bar used across v2 pages (Profiles, Library).
- * Single source of truth for the bordered tab strip + trailing sort chip so the
- * two pages can't drift apart visually.
+ * Shared horizontal scope/filter bar used across Taskforce v2 pages (Profiles,
+ * Library, Metrics, Ledger). Single source of truth for the bordered tab strip
+ * (+ optional trailing sort chip) so the pages can't drift apart visually.
+ *
+ * Omit `sortLabel` when a page filters but doesn't sort — the trailing chip is
+ * then dropped so the bar works as a pure scope selector.
  */
 export function ScopeFilterBar<TKey extends string>({
   items,
@@ -22,7 +25,7 @@ export function ScopeFilterBar<TKey extends string>({
   items: ScopeFilterItem<TKey>[]
   active: TKey
   onChange: (key: TKey) => void
-  sortLabel: string
+  sortLabel?: string
   className?: string
 }) {
   return (
@@ -52,9 +55,11 @@ export function ScopeFilterBar<TKey extends string>({
           </button>
         )
       })}
-      <div className="ml-auto border-l border-border px-3 py-2 text-muted-foreground">
-        Sort: {sortLabel}
-      </div>
+      {sortLabel !== undefined && (
+        <div className="ml-auto border-l border-border px-3 py-2 text-muted-foreground">
+          Sort: {sortLabel}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -139,7 +139,7 @@ function AgentsIndex() {
         <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div>
             <div className={AGENT_EYEBROW_CLASS}>
-              Agents · {activeCount} active across team
+              Profiles · {activeCount} active across team
             </div>
             <h1 className={cn("mt-1", AGENT_PAGE_TITLE_CLASS)}>Profiles</h1>
           </div>


### PR DESCRIPTION
## What

Makes `ScopeFilterBar` (the horizontal All/Active/Draft/Archived strip on Profiles) the single shared filter-bar component across Taskforce v2 pages.

- **ScopeFilterBar**: `sortLabel` is now optional — the trailing "Sort:" chip only renders when provided, so the bar can act as a pure scope selector.
- **Metrics**: replaced the inline time-range pill toggle with a `ScopeFilterBar` window strip (7 days / 30 days / All time) placed below the title, matching the Profiles/Library layout.
- **Ledger**: replaced the harness dropdown with a `ScopeFilterBar` harness strip (All harnesses / Claude Code / Codex / Cursor). Search + sort controls unchanged.
- **Profiles**: eyebrow now reads `Profiles ·` instead of `Agents ·`.

Library already consumed `ScopeFilterBar` (landed in a prior merge); Metrics and Ledger now match it.

## Notes

- The flag-gated Experimental metrics dashboards still use the `MetricsTimeRange` pill (different hero layout); left untouched to avoid breaking them.
- `MetricsScopeToggle` and `AgentStatsRail` remain unused dead code, out of scope here.

## Validation

- `tsc -p tsconfig.build.json` ✅
- `biome check` ✅
- `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)