### PR TITLE
Profile edit/delete + ledger polish + earned-from sessions

### DIFF
--- a/src/api/v2Agents.ts
+++ b/src/api/v2Agents.ts
@@ -29,6 +29,13 @@ export interface AgentSpecialistCreate {
   domain_tags?: string[]
 }
 
+export interface AgentSpecialistUpdate {
+  name?: string
+  role?: string
+  short_description?: string
+  domain_tags?: string[]
+}
+
 export interface AgentSpecialistLinkedDoc {
   document_id: string
   title: string
@@ -62,6 +69,7 @@ export interface AgentSpecialistDetail {
   slug: string
   name: string
   role: string
+  short_description: string
   description: string
   created_from: string
   domain_tags: string[]
@@ -105,6 +113,40 @@ export function getAgent(
 ): CancelablePromise<AgentSpecialistDetail> {
   return request(OpenAPI, {
     method: "GET",
+    url: "/api/v1/v2/agents/{slug}",
+    path: {
+      slug,
+    },
+    query: {
+      demo: options.demo || undefined,
+    },
+  })
+}
+
+export function updateAgent(
+  slug: string,
+  body: AgentSpecialistUpdate,
+  options: { demo?: boolean } = {},
+): CancelablePromise<AgentSpecialistDetail> {
+  return request(OpenAPI, {
+    method: "PATCH",
+    url: "/api/v1/v2/agents/{slug}",
+    path: {
+      slug,
+    },
+    query: {
+      demo: options.demo || undefined,
+    },
+    body,
+  })
+}
+
+export function deleteAgent(
+  slug: string,
+  options: { demo?: boolean } = {},
+): CancelablePromise<void> {
+  return request(OpenAPI, {
+    method: "DELETE",
     url: "/api/v1/v2/agents/{slug}",
     path: {
       slug,

--- a/src/components/V2/Agents/EditProfileDialog.tsx
+++ b/src/components/V2/Agents/EditProfileDialog.tsx
@@ -1,0 +1,183 @@
+import { Save, Trash2 } from "lucide-react"
+import { type FormEvent, useEffect, useState } from "react"
+
+import type {
+  AgentSpecialistDetail,
+  AgentSpecialistUpdate,
+} from "@/api/v2Agents"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+
+function parseTags(raw: string): string[] {
+  return Array.from(
+    new Set(
+      raw
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+    ),
+  )
+}
+
+export function EditProfileDialog({
+  open,
+  onOpenChange,
+  agent,
+  isSaving,
+  isDeleting,
+  onSubmit,
+  onDelete,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  agent: AgentSpecialistDetail
+  isSaving: boolean
+  isDeleting: boolean
+  onSubmit: (values: AgentSpecialistUpdate) => void
+  onDelete: () => void
+}) {
+  const [name, setName] = useState(agent.name)
+  const [role, setRole] = useState(agent.role)
+  const [description, setDescription] = useState(agent.short_description)
+  const [tags, setTags] = useState(agent.domain_tags.join(", "))
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+
+  // Re-seed the form from the current profile each time the dialog opens.
+  useEffect(() => {
+    if (open) {
+      setName(agent.name)
+      setRole(agent.role)
+      setDescription(agent.short_description)
+      setTags(agent.domain_tags.join(", "))
+      setConfirmingDelete(false)
+    }
+  }, [open, agent])
+
+  const busy = isSaving || isDeleting
+  const canSubmit = name.trim().length > 0 && role.trim().length > 0 && !busy
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    if (!canSubmit) return
+    onSubmit({
+      name: name.trim(),
+      role: role.trim(),
+      short_description: description.trim(),
+      domain_tags: parseTags(tags),
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !busy && onOpenChange(next)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit profile</DialogTitle>
+          <DialogDescription>
+            Update this specialist profile, or delete it permanently.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="edit-profile-name">Name</Label>
+            <Input
+              id="edit-profile-name"
+              autoFocus
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Billing Specialist"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-profile-role">Role</Label>
+            <Input
+              id="edit-profile-role"
+              value={role}
+              onChange={(event) => setRole(event.target.value)}
+              placeholder="Stripe billing & webhooks"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-profile-description">Focus</Label>
+            <Textarea
+              id="edit-profile-description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="One line on what this profile owns."
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-profile-tags">Domain tags</Label>
+            <Input
+              id="edit-profile-tags"
+              value={tags}
+              onChange={(event) => setTags(event.target.value)}
+              placeholder="billing, payments, webhooks"
+            />
+            <p className="text-xs text-muted-foreground">
+              Comma-separated. Used for routing and filtering.
+            </p>
+          </div>
+          <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-between">
+            {confirmingDelete ? (
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="destructive"
+                  disabled={busy}
+                  onClick={onDelete}
+                >
+                  <Trash2 className="size-4" />
+                  {isDeleting ? "Deleting" : "Confirm delete"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  disabled={busy}
+                  onClick={() => setConfirmingDelete(false)}
+                >
+                  Keep
+                </Button>
+              </div>
+            ) : (
+              <Button
+                type="button"
+                variant="ghost"
+                className="text-destructive hover:text-destructive"
+                disabled={busy}
+                onClick={() => setConfirmingDelete(true)}
+              >
+                <Trash2 className="size-4" />
+                Delete
+              </Button>
+            )}
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={busy}
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!canSubmit}>
+                <Save className="size-4" />
+                {isSaving ? "Saving" : "Save"}
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/V2/Agents/agentDetailPlaceholder.ts
+++ b/src/components/V2/Agents/agentDetailPlaceholder.ts
@@ -12,6 +12,7 @@ export function agentSummaryToDetailPlaceholder(
     slug: summary.slug,
     name: summary.name,
     role: summary.role,
+    short_description: summary.short_description,
     description: summary.short_description,
     created_from: summary.created_from,
     domain_tags: summary.domain_tags,

--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -75,6 +75,8 @@
 .crumb {
   font-family: var(--font-mono);
   font-size: 12px;
+  /* Match Tailwind text-xs (16px) so the title stacks identically to Profiles. */
+  line-height: 1rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--tf-muted-fg);
@@ -82,6 +84,9 @@
 .h1 {
   margin: 4px 0 0;
   font-size: 24px;
+  /* Match Tailwind text-2xl line-height so the title baseline lines up with the
+     Profiles page title (which inherits Tailwind's controlled line-heights). */
+  line-height: 2rem;
   letter-spacing: -0.018em;
   font-weight: 600;
 }

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -406,7 +406,7 @@ export function LedgerPage({
           </header>
 
           <ScopeFilterBar
-            className="px-6"
+            className="mb-4 px-6"
             items={HARNESS_OPTIONS.map((option) => ({
               key: option.value,
               label: option.label,

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -1,11 +1,15 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { createFileRoute, Link } from "@tanstack/react-router"
-import { ArrowUpRight, Copy, Loader2, Pencil } from "lucide-react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { Copy, Loader2, Pencil } from "lucide-react"
+import { useState } from "react"
 
 import {
   type AgentSpecialistDetail,
+  type AgentSpecialistUpdate,
   type AgentsListResponse,
+  deleteAgent,
   getAgent,
+  updateAgent,
 } from "@/api/v2Agents"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Button } from "@/components/ui/button"
@@ -26,6 +30,7 @@ import {
   AGENT_SECTION_TITLE_CLASS,
   AGENT_STAT_LABEL_CLASS,
 } from "@/components/V2/Agents/agentsTypography"
+import { EditProfileDialog } from "@/components/V2/Agents/EditProfileDialog"
 import {
   formatCompactNumber,
   formatRelativeTime,
@@ -36,6 +41,7 @@ import {
   V2_PAGE_FRAME,
   V2_STICKY_HEADER_CLASS,
 } from "@/components/V2/v2PageShell"
+import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
 
 export const Route = createFileRoute("/v2/agents/$slug")({
@@ -172,45 +178,82 @@ function Instructions({ instructions }: { instructions: string[] }) {
 }
 
 function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
-  const originLabel =
-    agent.created_from === "earned" ? "Earned profile" : "Seeded profile"
-
   return (
     <section className="pt-5">
       <SectionHeader
         title="Earned from"
-        meta={`${agent.linked_knowledge.length} documents`}
+        meta={`${agent.recent_invocations.length} sessions · ${agent.linked_knowledge.length} documents`}
       />
-      <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
-        <span className="inline-flex h-7 items-center border border-black/10 px-2.5 font-mono text-[0.66rem] uppercase tracking-[0.12em] text-muted-foreground dark:border-white/12">
-          {originLabel}
-        </span>
-        <Link
-          to="/v2/ledger"
-          search={{ specialist: agent.slug }}
-          className="inline-flex h-7 items-center gap-1.5 border border-black/10 px-2.5 text-xs font-medium text-foreground hover:bg-zinc-50 dark:border-white/12 dark:hover:bg-white/5"
-        >
-          Sessions
-          <ArrowUpRight className="size-3.5" />
-        </Link>
+
+      <div className="mt-2 overflow-x-auto">
+        <table className="w-full min-w-[42rem] border-collapse text-sm">
+          <thead>
+            <tr className="border-b border-black/10 text-xs uppercase tracking-wide text-zinc-400 dark:border-white/12 dark:text-zinc-500">
+              <th className="py-2 pr-3 text-left font-medium">Session</th>
+              <th className="px-3 text-left font-medium">Repo</th>
+              <th className="px-3 text-right font-medium">Saved</th>
+              <th className="py-2 pl-3 text-right font-medium">When</th>
+            </tr>
+          </thead>
+          <tbody>
+            {agent.recent_invocations.length === 0 ? (
+              <tr className="border-b border-black/5 dark:border-white/10">
+                <td
+                  colSpan={4}
+                  className="py-3 text-sm text-zinc-500 dark:text-zinc-400"
+                >
+                  No sessions yet.
+                </td>
+              </tr>
+            ) : (
+              agent.recent_invocations.map((invocation) => (
+                <tr
+                  key={invocation.id}
+                  className="group relative cursor-pointer border-b border-black/5 transition-colors hover:bg-zinc-50 dark:border-white/10 dark:hover:bg-white/5"
+                >
+                  <td className="py-3 pr-3 align-top text-sm text-zinc-950 dark:text-white">
+                    {invocation.session_id && (
+                      <Link
+                        to="/v2/ledger"
+                        search={{ session_id: invocation.session_id }}
+                        aria-label={`Open session "${invocation.prompt}"`}
+                        className="absolute inset-0 z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+                      />
+                    )}
+                    <div className="font-semibold">"{invocation.prompt}"</div>
+                  </td>
+                  <td className="px-3 py-3 align-top text-sm text-zinc-500 dark:text-zinc-400">
+                    {invocation.repo ?? "Taskforce"}
+                  </td>
+                  <td className="px-3 py-3 text-right align-top text-sm font-semibold text-[#8447ff]">
+                    +{formatCompactNumber(invocation.tokens_saved)}
+                  </td>
+                  <td className="py-3 pl-3 text-right align-top text-xs text-zinc-400 dark:text-zinc-500">
+                    {formatRelativeTime(invocation.created_at)}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
       </div>
+
       <div className="mt-2 overflow-x-auto">
         <table className="w-full min-w-[42rem] border-collapse text-sm">
           <thead>
             <tr className="border-b border-black/10 text-xs uppercase tracking-wide text-zinc-400 dark:border-white/12 dark:text-zinc-500">
               <th className="py-2 pr-3 text-left font-medium">Document</th>
               <th className="px-3 text-left font-medium">Anchor</th>
-              <th className="px-3 text-right font-medium">Reason</th>
-              <th className="py-2 pl-3 text-right font-medium">Open</th>
+              <th className="py-2 px-3 text-right font-medium">Reason</th>
             </tr>
           </thead>
           <tbody>
             {agent.linked_knowledge.map((document) => (
               <tr
                 key={`${document.document_id}-${document.anchor_id ?? "summary"}`}
-                className="group relative border-b border-black/5 transition-colors hover:bg-zinc-50 dark:border-white/10 dark:hover:bg-white/5"
+                className="group relative cursor-pointer border-b border-black/5 transition-colors hover:bg-zinc-50 dark:border-white/10 dark:hover:bg-white/5"
               >
-                <td className="relative py-3 pr-3 align-top">
+                <td className="py-3 pr-3 align-top">
                   <a
                     href={document.href}
                     className="absolute inset-0 z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
@@ -229,12 +272,6 @@ function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
                 </td>
                 <td className="px-3 py-3 text-right align-top text-xs text-zinc-500 dark:text-zinc-400">
                   {document.reason ?? "Pinned knowledge"}
-                </td>
-                <td className="py-3 pl-3 text-right align-top">
-                  <span className="inline-flex items-center justify-end gap-1 text-xs font-medium text-[#8447ff]">
-                    Open
-                    <ArrowUpRight className="size-4" />
-                  </span>
                 </td>
               </tr>
             ))}
@@ -301,6 +338,35 @@ function AgentDetailPage() {
   const { slug } = Route.useParams()
   const { isDemoMode } = useDemoMode()
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const [editOpen, setEditOpen] = useState(false)
+  const updateMutation = useMutation({
+    mutationFn: (values: AgentSpecialistUpdate) =>
+      updateAgent(slug, values, { demo: isDemoMode }),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["v2-agent", slug, isDemoMode], updated)
+      queryClient.invalidateQueries({ queryKey: ["v2-agents", isDemoMode] })
+      setEditOpen(false)
+      showSuccessToast("Profile updated.")
+    },
+    onError: () => {
+      showErrorToast("Could not update profile.")
+    },
+  })
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteAgent(slug, { demo: isDemoMode }),
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: ["v2-agent", slug, isDemoMode] })
+      queryClient.invalidateQueries({ queryKey: ["v2-agents", isDemoMode] })
+      setEditOpen(false)
+      showSuccessToast("Profile deleted.")
+      navigate({ to: "/v2/agents" })
+    },
+    onError: () => {
+      showErrorToast("Could not delete profile.")
+    },
+  })
   const agentQuery = useQuery({
     queryKey: ["v2-agent", slug, isDemoMode],
     queryFn: () => getAgent(slug, { demo: isDemoMode }),
@@ -406,15 +472,31 @@ function AgentDetailPage() {
               <span className="size-1.5 rounded-full bg-emerald-500" />
               Active
             </span>
-            <span className="inline-flex h-8 items-center gap-2 rounded-md border border-black/10 px-3 text-xs font-medium text-foreground dark:border-white/12">
-              {agent.created_from === "earned" ? "Earned" : "Seeded"}
-            </span>
-            <span className="inline-flex h-8 items-center gap-2 rounded-md border border-black/10 px-3 text-xs font-medium text-foreground dark:border-white/12">
+            {agent.created_from === "earned" ? (
+              <span className="inline-flex h-8 items-center gap-2 rounded-md border border-black/10 px-3 text-xs font-medium text-foreground dark:border-white/12">
+                Earned
+              </span>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => setEditOpen(true)}
+              className="inline-flex h-8 items-center gap-2 rounded-md border border-black/10 px-3 text-xs font-medium text-foreground transition-colors hover:bg-zinc-50 dark:border-white/12 dark:hover:bg-white/5"
+            >
               <Pencil className="size-3.5" aria-hidden />
               Edit
-            </span>
+            </button>
           </div>
         </header>
+
+        <EditProfileDialog
+          open={editOpen}
+          onOpenChange={setEditOpen}
+          agent={agent}
+          isSaving={updateMutation.isPending}
+          isDeleting={deleteMutation.isPending}
+          onSubmit={(values) => updateMutation.mutate(values)}
+          onDelete={() => deleteMutation.mutate()}
+        />
 
         {agent.description ? (
           <p className={cn("max-w-3xl", AGENT_DESCRIPTION_CLASS)}>


### PR DESCRIPTION
## Summary
Frontend changes across the Profiles and Ledger surfaces. Depends on the matching backend PR (al-exe/EnderAI) that adds `PATCH`/`DELETE /v2/agents/{slug}` and exposes `short_description` on the detail response.

### Profile detail (`/v2/agents/$slug`)
- The **Edit** button (previously a static `<span>`) now opens a new `EditProfileDialog` to edit name / role / focus / domain tags — mirroring the create flow — and to **delete** the profile via an inline confirm step. Wired with `updateAgent` (PATCH) and `deleteAgent` (DELETE) mutations + toasts; delete navigates back to the profiles list.
- Removed the **"Seeded"** badge from the header.
- **"Earned from"** now lists **Sessions** as a list (styled like the documents list) with full-row links to the ledger session; **document rows are fully clickable** and the **"Open"** column was dropped.

### Ledger (`/v2/ledger`)
- Page title now lines up with the Profiles title (matched Tailwind line-heights on the crumb/h1 — it sat a few px low).
- Added spacing between the harness filter bar and the column headers.

## Testing
- `tsc -p tsconfig.build.json --noEmit` — clean
- `biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)