### PR TITLE
fix(filter-bar): working sort toggle + unify ledger bar with profiles

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -386,22 +386,6 @@ export function LedgerPage({
                   aria-label="Search the ledger"
                 />
               </form>
-              <FilterChip
-                ariaLabel="Sort sessions"
-                caret={sort === "newest" ? "↓" : "↑"}
-                display={sort === "newest" ? "Newest" : "Oldest"}
-                onChange={(value) =>
-                  setLedgerSearch({
-                    session_id: undefined,
-                    sort: value === "oldest" ? "oldest" : undefined,
-                  })
-                }
-                options={[
-                  { value: "newest", label: "Newest" },
-                  { value: "oldest", label: "Oldest" },
-                ]}
-                value={sort}
-              />
             </div>
           </header>
 
@@ -416,6 +400,13 @@ export function LedgerPage({
               setLedgerSearch({
                 client: value === "all" ? undefined : value,
                 session_id: undefined,
+              })
+            }
+            sortLabel={`recent ${sort === "newest" ? "↓" : "↑"}`}
+            onSortToggle={() =>
+              setLedgerSearch({
+                session_id: undefined,
+                sort: sort === "newest" ? "oldest" : undefined,
               })
             }
           />
@@ -440,43 +431,6 @@ export function LedgerPage({
         </div>
       )}
     </div>
-  )
-}
-
-function FilterChip({
-  ariaLabel,
-  caret = "▾",
-  display,
-  onChange,
-  options,
-  value,
-}: {
-  ariaLabel: string
-  caret?: string
-  display: string
-  onChange: (value: string) => void
-  options: Array<{ value: string; label: string }>
-  value: string
-}) {
-  return (
-    <label className={styles.sel}>
-      <span>{display}</span>
-      <span aria-hidden className={styles.selCaret}>
-        {caret}
-      </span>
-      <select
-        aria-label={ariaLabel}
-        className={styles.selNative}
-        onChange={(event) => onChange(event.target.value)}
-        value={value}
-      >
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </label>
   )
 }
 

--- a/src/components/V2/ScopeFilterBar.tsx
+++ b/src/components/V2/ScopeFilterBar.tsx
@@ -20,12 +20,15 @@ export function ScopeFilterBar<TKey extends string>({
   active,
   onChange,
   sortLabel,
+  onSortToggle,
   className,
 }: {
   items: ScopeFilterItem<TKey>[]
   active: TKey
   onChange: (key: TKey) => void
   sortLabel?: string
+  /** When provided, the trailing sort chip becomes a clickable toggle. */
+  onSortToggle?: () => void
   className?: string
 }) {
   return (
@@ -55,11 +58,20 @@ export function ScopeFilterBar<TKey extends string>({
           </button>
         )
       })}
-      {sortLabel !== undefined && (
-        <div className="ml-auto border-l border-border px-3 py-2 text-muted-foreground">
-          Sort: {sortLabel}
-        </div>
-      )}
+      {sortLabel !== undefined &&
+        (onSortToggle ? (
+          <button
+            type="button"
+            onClick={onSortToggle}
+            className="ml-auto border-l border-border px-3 py-2 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Sort: {sortLabel}
+          </button>
+        ) : (
+          <div className="ml-auto border-l border-border px-3 py-2 text-muted-foreground">
+            Sort: {sortLabel}
+          </div>
+        ))}
     </div>
   )
 }

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -98,6 +98,7 @@ function AgentsIndex() {
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const [scope, setScope] = useState<AgentScope>("all")
+  const [sortDir, setSortDir] = useState<"desc" | "asc">("desc")
   const [createProfileOpen, setCreateProfileOpen] = useState(false)
   const agentsQuery = useQuery({
     queryKey: ["v2-agents", isDemoMode],
@@ -125,8 +126,9 @@ function AgentsIndex() {
       scope === "all"
         ? agents
         : agents.filter((agent) => agent.status === scope)
-    return [...filtered].sort((a, b) => b.tokens_saved - a.tokens_saved)
-  }, [agents, scope])
+    const sorted = [...filtered].sort((a, b) => b.tokens_saved - a.tokens_saved)
+    return sortDir === "asc" ? sorted.reverse() : sorted
+  }, [agents, scope, sortDir])
 
   return (
     <section
@@ -172,7 +174,10 @@ function AgentsIndex() {
           }))}
           active={scope}
           onChange={setScope}
-          sortLabel="tokens saved ↓"
+          sortLabel={`tokens saved ${sortDir === "desc" ? "↓" : "↑"}`}
+          onSortToggle={() =>
+            setSortDir((dir) => (dir === "desc" ? "asc" : "desc"))
+          }
         />
 
         {agentsQuery.isLoading ? (

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -205,6 +205,7 @@ function TaskforceLibrary() {
     },
   )
   const [selectedFolderId, setSelectedFolderId] = useState("all")
+  const [sortDir, setSortDir] = useState<"desc" | "asc">("desc")
   const [createFolderOpen, setCreateFolderOpen] = useState(false)
   const [createDocumentOpen, setCreateDocumentOpen] = useState(false)
   const [deleteDocumentTarget, setDeleteDocumentTarget] =
@@ -472,23 +473,29 @@ function TaskforceLibrary() {
 
   const allDocuments = documentsQuery.data?.data ?? []
   const documents = useMemo(() => {
-    switch (scopeFilter) {
-      case "mine":
-        return allDocuments.filter(
-          (document) => document.owner_id === currentUser.id,
-        )
-      case "shared":
-        return allDocuments.filter(
-          (document) => document.owner_id !== currentUser.id,
-        )
-      case "org":
-        return allDocuments.filter(
-          (document) => document.visibility === "organization",
-        )
-      default:
-        return allDocuments
-    }
-  }, [allDocuments, currentUser.id, scopeFilter])
+    const scoped = (() => {
+      switch (scopeFilter) {
+        case "mine":
+          return allDocuments.filter(
+            (document) => document.owner_id === currentUser.id,
+          )
+        case "shared":
+          return allDocuments.filter(
+            (document) => document.owner_id !== currentUser.id,
+          )
+        case "org":
+          return allDocuments.filter(
+            (document) => document.visibility === "organization",
+          )
+        default:
+          return allDocuments
+      }
+    })()
+    const recencyOf = (document: V2DocumentPublic) =>
+      new Date(document.updated_at ?? document.created_at ?? 0).getTime()
+    const sorted = [...scoped].sort((a, b) => recencyOf(b) - recencyOf(a))
+    return sortDir === "asc" ? sorted.reverse() : sorted
+  }, [allDocuments, currentUser.id, scopeFilter, sortDir])
   const scopeDocumentCounts = useMemo<Record<LibraryScope, number>>(
     () => ({
       all: allDocuments.length,
@@ -755,7 +762,10 @@ function TaskforceLibrary() {
               setScopeFilter(key)
               setSelectedFolderId("all")
             }}
-            sortLabel="recent ↓"
+            sortLabel={`recent ${sortDir === "desc" ? "↓" : "↑"}`}
+            onSortToggle={() =>
+              setSortDir((dir) => (dir === "desc" ? "asc" : "desc"))
+            }
           />
 
           <FolderCreateDialog


### PR DESCRIPTION
## Summary
The trailing **"Sort: …"** chip in `ScopeFilterBar` was a static `<div>` on every page, so the sort/recency controls did nothing. This makes them work and unifies the Ledger bar with Profiles.

- **ScopeFilterBar**: the sort chip is now a real toggle `<button>` when an `onSortToggle` handler is provided (falls back to the static chip otherwise).
- **Profiles**: chip toggles tokens-saved ↓/↑.
- **Library**: chip toggles recency ↓/↑ and the list now **actually sorts** by `updated_at` — previously "recent ↓" was purely decorative.
- **Ledger**: adopts the shared filter-bar sort chip (recent ↓/↑, driven by the existing `newest`/`oldest` search param) and **drops the bespoke header sort dropdown**, so its filter bar matches Profiles. Removed the now-unused `FilterChip`.

## Testing
- `tsc -p tsconfig.build.json --noEmit` — clean
- `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)