### PR TITLE
fix(ledger): inset filter bar to match Profiles exactly

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -390,7 +390,7 @@ export function LedgerPage({
           </header>
 
           <ScopeFilterBar
-            className="mb-4 px-6"
+            className="mx-6 mb-4"
             items={HARNESS_OPTIONS.map((option) => ({
               key: option.value,
               label: option.label,


### PR DESCRIPTION
## Summary
The ledger filter bar looked different from the Profiles filter bar: its border lines ran edge-to-edge (full-bleed) making it appear longer horizontally and proportionally flatter.

Both pages render the same shared `ScopeFilterBar`. The only divergence was that the ledger passed `px-6` (padding — insets content but lets the border-y run full width), while the Profiles bar lives inside a `p-6` container so its borders are inset 24px.

This swaps `px-6` → `mx-6` so the entire ledger bar (border lines included) is inset 24px, matching Profiles exactly. Buttons still align with the "Ledger" header text above.

## Changes
- `LedgerPage.tsx`: `className="mb-4 px-6"` → `className="mx-6 mb-4"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)