### PR TITLE
fix(ledger): match Profiles spacing below filter bar

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -390,7 +390,7 @@ export function LedgerPage({
           </header>
 
           <ScopeFilterBar
-            className="mx-6 mb-4"
+            className="mx-6 mb-6"
             items={HARNESS_OPTIONS.map((option) => ({
               key: option.value,
               label: option.label,


### PR DESCRIPTION
## Summary
The gap beneath the ledger filter bar (`mb-4` = 16px) didn't match the Profiles page, where the parent's `gap-6` yields 24px below the bar.

Bumps the ledger `ScopeFilterBar` bottom margin to `mb-6` (24px) so the spacing matches Profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)