### PR TITLE
feat(ledger): pin eyebrow, title, and filter bar on scroll

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -65,6 +65,16 @@
   overflow: auto;
 }
 
+/* Pin the eyebrow, title, and filter bar to the top while the list scrolls.
+   flow-root keeps the filter bar's bottom margin inside the opaque background. */
+.stickyHead {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flow-root;
+  background: var(--tf-bg);
+}
+
 .head {
   padding: 24px 24px 16px;
   display: grid;

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -366,50 +366,52 @@ export function LedgerPage({
           className={styles.scroll}
           style={{ "--grid": GRID } as CSSProperties}
         >
-          <header className={styles.head}>
-            <div>
-              <div className={styles.crumb}>
-                Ledger
-                {typeof ledgerQuery.data?.total === "number"
-                  ? ` · ${ledgerQuery.data.total} sessions archived`
-                  : ""}
+          <div className={styles.stickyHead}>
+            <header className={styles.head}>
+              <div>
+                <div className={styles.crumb}>
+                  Ledger
+                  {typeof ledgerQuery.data?.total === "number"
+                    ? ` · ${ledgerQuery.data.total} sessions archived`
+                    : ""}
+                </div>
+                <h1 className={styles.h1}>Ledger</h1>
               </div>
-              <h1 className={styles.h1}>Ledger</h1>
-            </div>
-            <div className={styles.tools}>
-              <form className={styles.search} onSubmit={onSearchSubmit}>
-                <input
-                  className={styles.searchInput}
-                  placeholder="/ Search transcripts, commands, files…"
-                  value={search}
-                  onChange={(event) => setSearch(event.target.value)}
-                  aria-label="Search the ledger"
-                />
-              </form>
-            </div>
-          </header>
+              <div className={styles.tools}>
+                <form className={styles.search} onSubmit={onSearchSubmit}>
+                  <input
+                    className={styles.searchInput}
+                    placeholder="/ Search transcripts, commands, files…"
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    aria-label="Search the ledger"
+                  />
+                </form>
+              </div>
+            </header>
 
-          <ScopeFilterBar
-            className="mx-6 mb-6"
-            items={HARNESS_OPTIONS.map((option) => ({
-              key: option.value,
-              label: option.label,
-            }))}
-            active={client ?? "all"}
-            onChange={(value) =>
-              setLedgerSearch({
-                client: value === "all" ? undefined : value,
-                session_id: undefined,
-              })
-            }
-            sortLabel={`recent ${sort === "newest" ? "↓" : "↑"}`}
-            onSortToggle={() =>
-              setLedgerSearch({
-                session_id: undefined,
-                sort: sort === "newest" ? "oldest" : undefined,
-              })
-            }
-          />
+            <ScopeFilterBar
+              className="mx-6 mb-6"
+              items={HARNESS_OPTIONS.map((option) => ({
+                key: option.value,
+                label: option.label,
+              }))}
+              active={client ?? "all"}
+              onChange={(value) =>
+                setLedgerSearch({
+                  client: value === "all" ? undefined : value,
+                  session_id: undefined,
+                })
+              }
+              sortLabel={`recent ${sort === "newest" ? "↓" : "↑"}`}
+              onSortToggle={() =>
+                setLedgerSearch({
+                  session_id: undefined,
+                  sort: sort === "newest" ? "oldest" : undefined,
+                })
+              }
+            />
+          </div>
 
           <div className={styles.cols}>
             <div>Time</div>


### PR DESCRIPTION
## Summary
Makes the ledger's eyebrow, page title, and filter bar sticky to the top of the scroll area so they stay visible while the session list scrolls underneath.

## Changes
- Wrap the `<header>` (eyebrow + title + search) and `<ScopeFilterBar>` in a `.stickyHead` container.
- `.stickyHead`: `position: sticky; top: 0; z-index: 20; background: var(--tf-bg)`, plus `display: flow-root` so the filter bar's `mb-6` margin stays inside the opaque sticky background (no list bleed-through in the gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)