### PR TITLE
fix(ledger): match title-to-bar gap and remove bottom dead space

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -76,7 +76,8 @@
 }
 
 .head {
-  padding: 24px 24px 16px;
+  /* 24px bottom matches the Profiles gap-6 between the title block and the bar. */
+  padding: 24px 24px 24px;
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 14px;

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -353,7 +353,7 @@ export function LedgerPage({
   }
 
   return (
-    <div className={styles.app}>
+    <div className={cn(styles.app, "-mb-6 md:-mb-8")}>
       {selectedSessionId ? (
         <LedgerDetail
           detail={detailQuery.data}


### PR DESCRIPTION
## Summary
Two ledger fixes to align with the Profiles page and clean up vertical scroll:

1. **Title-to-bar gap** — `.head` bottom padding was 16px; the Profiles page has 24px (`gap-6`) between the title block and the filter bar. Bumped to 24px so they match.

2. **Bottom dead space** — the ledger `.app` sat inside the shell's `p-6 md:p-8` padding with no offset, leaving a gap at the bottom and preventing the list from scrolling to the bottom edge. Added `-mb-6 md:-mb-8` (mirroring the Profiles page) to cancel that bottom padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)