### PR TITLE
Fix invalid Taskforce session redirect

### DIFF
--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -37,7 +37,6 @@ import {
   ExperimentalModeToggle,
 } from "@/components/Sidebar/ModeSwitches"
 import { User } from "@/components/Sidebar/User"
-import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
   Sidebar,
@@ -658,24 +657,5 @@ export function TaskforcePlaceholder({
         </p>
       </div>
     </section>
-  )
-}
-
-export function TaskforceNoAccess() {
-  return (
-    <main className="flex min-h-svh items-center justify-center bg-background p-6">
-      <section className="w-full max-w-lg border-l border-border pl-6">
-        <p className="mb-3 text-xs font-medium uppercase text-muted-foreground">
-          Taskforce
-        </p>
-        <h1 className="text-2xl font-semibold tracking-tight">No access</h1>
-        <p className="mt-3 text-sm leading-6 text-muted-foreground">
-          Taskforce is not available for this account.
-        </p>
-        <Button asChild className="mt-6">
-          <RouterLink to="/v2/pricing">View membership</RouterLink>
-        </Button>
-      </section>
-    </main>
   )
 }

--- a/src/routes/v2.tsx
+++ b/src/routes/v2.tsx
@@ -1,12 +1,10 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
 import { ApiError } from "@/client"
-import {
-  TaskforceNoAccess,
-  TaskforceShell,
-} from "@/components/V2/TaskforceShell"
+import { TaskforceShell } from "@/components/V2/TaskforceShell"
 import { isLoggedIn } from "@/hooks/useAuth"
 import {
+  invalidateTaskforceSession,
   peekTaskforceSession,
   readTaskforceSession,
 } from "@/lib/taskforceSession"
@@ -24,11 +22,7 @@ function V2Pending() {
   return <TaskforceShell currentUser={currentUser} />
 }
 
-function V2RouteError({ error }: { error: unknown }) {
-  if (error instanceof ApiError && error.status === 403) {
-    return <TaskforceNoAccess />
-  }
-
+function V2RouteError() {
   const currentUser = peekTaskforceSession()
   if (currentUser) {
     return <TaskforceShell currentUser={currentUser} />
@@ -48,8 +42,12 @@ export const Route = createFileRoute("/v2")({
       const currentUser = await readTaskforceSession()
       return { currentUser }
     } catch (error) {
-      if (error instanceof ApiError && error.status === 401) {
+      if (
+        error instanceof ApiError &&
+        (error.status === 401 || error.status === 403)
+      ) {
         localStorage.removeItem("access_token")
+        invalidateTaskforceSession()
         throw redirect({ to: "/login" })
       }
 

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -213,6 +213,31 @@ test("v2 route transient session errors do not render membership no-access", asy
   )
 })
 
+test("v2 route invalid session redirects to login instead of membership no-access", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "expired-token")
+  })
+
+  await page.route("**/api/v1/users/me", async (route) => {
+    await route.fulfill({
+      status: 403,
+      json: { detail: "Could not validate credentials" },
+    })
+  })
+
+  await page.goto("/v2/agents")
+
+  await expect(page).toHaveURL(/\/login$/)
+  await expect(
+    page.getByRole("heading", { name: "No access", exact: true }),
+  ).toHaveCount(0)
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("access_token")))
+    .toBeNull()
+})
+
 test("agents grid links to specialist detail and session metrics", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- treat 401 and 403 responses from the Taskforce session read as invalid authentication
- clear the stale access token and in-memory session before redirecting to login
- remove the obsolete Taskforce membership no-access screen
- add regression coverage for expired credentials while preserving transient-error behavior

## Root cause
The backend returns `403 Could not validate credentials` for invalid or expired JWTs. The `/v2` route interpreted every 403 as a Taskforce membership denial, trapping users on a no-access screen even though the product-level V2 access gate had already been removed.

## User impact
Users with stale sessions are returned to login instead of seeing a false membership denial. The broken `View membership` path is no longer presented for an authentication failure.

## Validation
- `bun run build`
- `bunx biome check src/routes/v2.tsx src/components/V2/TaskforceShell.tsx tests/agents-routing.spec.ts`
- focused Playwright tests for invalid and transient session responses: 2 passed