### PR TITLE
Disable Taskforce Search navigation

### DIFF
--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -64,10 +64,9 @@ type TaskforceNavItem = {
 }
 
 // Ordered by the pipeline's distillation altitude (TF-206): most-distilled
-// first (Profiles ← Library ← Ledger), then Metrics as the rollup. Search stays
-// on top as the entry point; Upgrade stays at the bottom.
+// first (Profiles ← Library ← Ledger), then Metrics as the rollup. Upgrade
+// stays at the bottom.
 const taskforceItems: TaskforceNavItem[] = [
-  { icon: Search, title: "Search", path: "/v2/search" },
   { icon: Bot, title: "Profiles", path: "/v2/agents" },
   { icon: BookOpen, title: "Library", path: "/v2/library" },
   { icon: ReceiptText, title: "Ledger", path: "/v2/ledger" },

--- a/src/routes/v2/search.tsx
+++ b/src/routes/v2/search.tsx
@@ -1,19 +1,7 @@
-import { createFileRoute } from "@tanstack/react-router"
-
-import { SearchPage } from "@/components/V2/Search/SearchPage"
+import { createFileRoute, redirect } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/v2/search")({
-  component: TaskforceSearch,
-  head: () => ({
-    meta: [
-      {
-        title: "Taskforce | Search",
-      },
-    ],
-  }),
+  beforeLoad: () => {
+    throw redirect({ to: "/v2/library" })
+  },
 })
-
-function TaskforceSearch() {
-  const { currentUser } = Route.useRouteContext()
-  return <SearchPage currentUser={currentUser} />
-}

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -56,7 +56,7 @@ test("Sidebar raises the Taskforce V2 workspace", async ({ page }) => {
 
   await page.waitForURL("/v2/library")
 
-  await expect(page.getByRole("link", { name: "Search" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "Search" })).toHaveCount(0)
   await expect(page.getByRole("link", { name: "Library" })).toBeVisible()
   await expect(page.getByRole("link", { name: "Agents" })).toBeVisible()
   await expect(page.getByRole("link", { name: "Metrics" })).toBeVisible()

--- a/tests/taskforce-routing.spec.ts
+++ b/tests/taskforce-routing.spec.ts
@@ -57,9 +57,22 @@ for (const path of ["/", "/home", "/topics", "/cases", "/skills", "/v2/home"]) {
     await expect(page.getByRole("link", { name: "Topics" })).toHaveCount(0)
     await expect(page.getByRole("link", { name: "Cases" })).toHaveCount(0)
     await expect(page.getByRole("link", { name: "Skills" })).toHaveCount(0)
+    await expect(page.getByRole("link", { name: "Search" })).toHaveCount(0)
     await expect(page.getByTestId("v2-mode-switch")).toHaveCount(0)
   })
 }
+
+test("disabled Search route redirects to Library and stays out of the sidebar", async ({
+  page,
+}) => {
+  await mockAuth(page)
+
+  await page.goto("/v2/search")
+
+  await expect(page).toHaveURL(/\/v2\/library$/)
+  await expect(page.getByRole("heading", { name: "Library" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "Search" })).toHaveCount(0)
+})
 
 test("legacy settings route redirects into the Taskforce shell", async ({
   page,


### PR DESCRIPTION
## Summary
- remove the Search item from the Taskforce sidebar
- redirect direct `/v2/search` visits to `/v2/library`
- keep all Search components, API clients, and backend integration code intact
- add regression coverage for the redirect and hidden navigation item

## User impact
Search is temporarily unavailable through the Taskforce UI. Existing bookmarks to `/v2/search` land on Library instead of rendering the Search page.

## Validation
- `bun run build`
- `bunx biome check src/components/V2/TaskforceShell.tsx src/routes/v2/search.tsx tests/login.spec.ts tests/taskforce-routing.spec.ts`
- focused Playwright test: `disabled Search route redirects to Library and stays out of the sidebar`