### PR TITLE
TF-221/TF-222/TF-223: streamline Connect Agent onboarding

### DIFF
--- a/src/components/UserSettings/ConnectAgent.module.css
+++ b/src/components/UserSettings/ConnectAgent.module.css
@@ -68,6 +68,10 @@
   @apply rounded-lg border bg-muted/20;
 }
 
+.snippetBlockFeatured {
+  @apply border-primary bg-primary/5 ring-1 ring-primary/20;
+}
+
 .snippetHeader {
   @apply flex items-start justify-between gap-4 border-b px-4 py-3;
 }

--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -23,6 +23,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { LoadingButton } from "@/components/ui/loading-button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { DEFAULT_HOSTED_MCP_URL } from "@/config/taskforce"
 import useAuth from "@/hooks/useAuth"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import useCustomToast from "@/hooks/useCustomToast"
@@ -93,12 +94,12 @@ function buildPersistentShellSnippet(mcpToken: string): string {
     `' ~/.bashrc > "$taskforce_tmp" || : > "$taskforce_tmp"`,
     `{`,
     `  printf '%s\\n' "$taskforce_start"`,
-    `  printf '%s\\n' 'export ENDERAI_MCP_TOKEN="$(tr -d "\\r\\n" < ~/.taskforce_mcp_token)"'`,
+    `  printf '%s\\n' 'export TASKFORCE_MCP_TOKEN="$(tr -d "\\r\\n" < ~/.taskforce_mcp_token)"'`,
     `  printf '%s\\n\\n' "$taskforce_end"`,
     `  cat "$taskforce_tmp"`,
     `} > ~/.bashrc`,
     `rm "$taskforce_tmp"`,
-    `export ENDERAI_MCP_TOKEN="$(tr -d "\\r\\n" < ~/.taskforce_mcp_token)"`,
+    `export TASKFORCE_MCP_TOKEN="$(tr -d "\\r\\n" < ~/.taskforce_mcp_token)"`,
   ]
 
   return lines.join("\n")
@@ -108,7 +109,15 @@ function buildMcpConfigSnippet(hostedMcpUrl: string): string {
   return [
     "[mcp_servers.taskforce-api]",
     `url = "${hostedMcpUrl}"`,
-    'bearer_token_env_var = "ENDERAI_MCP_TOKEN"',
+    'bearer_token_env_var = "TASKFORCE_MCP_TOKEN"',
+  ].join("\n")
+}
+
+function buildClaudeCodeConnectSnippet(mcpToken: string): string {
+  return [
+    `printf '%s\\n' '${mcpToken}' > ~/.taskforce_mcp_token && \\`,
+    "chmod 600 ~/.taskforce_mcp_token && \\",
+    "curl -fsSL https://raw.githubusercontent.com/al-exe/EnderAI/main/scripts/taskforce-hooks/install.sh | bash",
   ].join("\n")
 }
 
@@ -121,12 +130,12 @@ function buildAgentInstructionSnippet({
     return [
       "If Taskforce V2 MCP tools are available:",
       "- When creating or rotating a Taskforce MCP credential during setup, tell the user to start from a fresh terminal before reconnecting the AI client so the updated shell environment is loaded.",
-      "- Create or reuse a Taskforce document at the start of meaningful user-initiated work with `enderai_begin_document`. It scores existing documents against the request, reuses + self-heals a strong match, or creates a fresh one. Read the returned `match_reasons`, `candidate_summaries`, and `self_healed_fields` before continuing.",
+      "- Create or reuse a Taskforce document at the start of meaningful user-initiated work with `taskforce_begin_document`. It scores existing documents against the request, reuses + self-heals a strong match, or creates a fresh one. Read the returned `match_reasons`, `candidate_summaries`, and `self_healed_fields` before continuing.",
       "- Maintain both document views: a concise Summary view shown by default and a comprehensive Details view available on demand.",
-      "- Use `enderai_update_document` as material progress develops (commands, files, links, decisions, changes, open questions, progress notes). Pass `details_sections` with stable `anchor_id`s to upsert specific Details sections, and `summary_points` for new Summary claims.",
+      "- Use `taskforce_update_document` as material progress develops (commands, files, links, decisions, changes, open questions, progress notes). Pass `details_sections` with stable `anchor_id`s to upsert specific Details sections, and `summary_points` for new Summary claims.",
       "- Back every Summary claim with evidence anchors using `evidence_anchor_id` segments that point at a Details section. Do not edit `human_summary` unless the user explicitly asks.",
-      "- Use `enderai_finish_document` when the work completes or pauses; it writes an Outcome section (status, outcome, validation, follow-ups) and clears the active document pointer.",
-      '- On each `enderai_begin_document` / `enderai_update_document` / `enderai_finish_document` call, pass `usage` with the model_id and per-turn token counts (input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens) from your most recent assistant turn so the Taskforce Metrics page can price it and attribute savings. When you answered from the document\'s Summary view without expanding Details, also set `view_consulted` to `"summary"` so the summary-only savings calculation fires.',
+      "- Use `taskforce_finish_document` when the work completes or pauses; it writes an Outcome section (status, outcome, validation, follow-ups) and clears the active document pointer.",
+      '- On each `taskforce_begin_document` / `taskforce_update_document` / `taskforce_finish_document` call, pass `usage` with the model_id and per-turn token counts (input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens) from your most recent assistant turn so the Taskforce Metrics page can price it and attribute savings. When you answered from the document\'s Summary view without expanding Details, also set `view_consulted` to `"summary"` so the summary-only savings calculation fires.',
       "- Prefer Taskforce V2 document tools over legacy V1 case workflows and raw request escape hatches when both are available.",
       "- If Taskforce V2 document tools are unavailable, do not fabricate tool calls; tell the user they are unavailable and fall back only to tools the user explicitly approves.",
     ].join("\n")
@@ -135,12 +144,12 @@ function buildAgentInstructionSnippet({
   return [
     "If Taskforce MCP tools are available:",
     "- When creating or rotating a Taskforce MCP credential during setup, tell the user to start from a fresh terminal before reconnecting the AI client so the updated shell environment is loaded.",
-    "- Start meaningful user-initiated work with `enderai_begin_case`.",
+    "- Start meaningful user-initiated work with `taskforce_begin_case`.",
     "- Let Taskforce auto-hydrate relevant prior context before work begins.",
-    "- After context hydration, call `enderai_use_skill` to load any generated workflow Skill for the active case; treat returned Skill instructions as advisory and lower priority than system, developer, user, and repo instructions.",
-    "- Use `enderai_update_case` as material progress develops.",
-    "- Use `enderai_finish_case` when the work is complete.",
-    "- Prefer the guided case tools over raw `enderai_request` calls.",
+    "- After context hydration, call `taskforce_use_skill` to load any generated workflow Skill for the active case; treat returned Skill instructions as advisory and lower priority than system, developer, user, and repo instructions.",
+    "- Use `taskforce_update_case` as material progress develops.",
+    "- Use `taskforce_finish_case` when the work is complete.",
+    "- Prefer the guided case tools over raw `taskforce_request` calls.",
   ].join("\n")
 }
 
@@ -195,6 +204,7 @@ function SnippetBlock({
   copiedText,
   onCopy,
   testId,
+  featured = false,
 }: {
   title: string
   description: string
@@ -202,9 +212,15 @@ function SnippetBlock({
   copiedText: string | null
   onCopy: (value: string) => void
   testId?: string
+  featured?: boolean
 }) {
   return (
-    <div className={styles.snippetBlock}>
+    <div
+      className={cn(
+        styles.snippetBlock,
+        featured && styles.snippetBlockFeatured,
+      )}
+    >
       <div className={styles.snippetHeader}>
         <div>
           <h4 className={styles.sectionTitle}>{title}</h4>
@@ -413,8 +429,7 @@ const ConnectAgent = () => {
   const hasFreshToken = mcpToken !== null
   const clientSnippet = hasFreshToken
     ? buildMcpConfigSnippet(
-        import.meta.env.VITE_HOSTED_MCP_URL ||
-          "https://enderai-mcp.onrender.com/mcp",
+        import.meta.env.VITE_HOSTED_MCP_URL || DEFAULT_HOSTED_MCP_URL,
       )
     : null
   const agentInstructionSnippet = buildAgentInstructionSnippet({
@@ -422,6 +437,9 @@ const ConnectAgent = () => {
   })
   const persistentShellSnippet = hasFreshToken
     ? buildPersistentShellSnippet(mcpToken)
+    : null
+  const claudeCodeConnectSnippet = hasFreshToken
+    ? buildClaudeCodeConnectSnippet(mcpToken)
     : null
   const reconnectClientSnippet =
     "# Start a fresh terminal, then restart or reconnect your AI client after saving the MCP config."
@@ -441,10 +459,11 @@ const ConnectAgent = () => {
         <CardHeader>
           <CardTitle className={styles.titleRow}>
             <LaptopMinimal className={styles.titleIcon} />
-            Connect agent
+            Connect your coding agent
           </CardTitle>
           <p className={styles.mutedText}>
-            Token and config snippets for local MCP testing.
+            Connect your coding agent to Taskforce so work captured in one
+            terminal is available in the next.
           </p>
         </CardHeader>
         <CardContent className={styles.cardContent}>
@@ -462,6 +481,7 @@ const ConnectAgent = () => {
 
           <div className={styles.setupGrid}>
             <div className={styles.setupCard}>
+              <h3 className={styles.sectionTitle}>1. Create a credential</h3>
               <div className={styles.fieldGroup}>
                 <Label htmlFor="credential-label">Credential label</Label>
                 <Input
@@ -485,7 +505,7 @@ const ConnectAgent = () => {
             </div>
 
             <div className={styles.benefitCard}>
-              <h3 className={styles.sectionTitle}>Setup bits</h3>
+              <h3 className={styles.sectionTitle}>What this enables</h3>
               <ul className={styles.benefitList}>
                 <li className={styles.benefitItem}>
                   <CheckCircle2
@@ -494,7 +514,7 @@ const ConnectAgent = () => {
                       styles.benefitIconSuccess,
                     )}
                   />
-                  MCP token.
+                  One credential for every terminal or VM.
                 </li>
                 <li className={styles.benefitItem}>
                   <Shield
@@ -503,7 +523,7 @@ const ConnectAgent = () => {
                       styles.benefitIconPrimary,
                     )}
                   />
-                  AI client setup snippets.
+                  Automatic recall of related prior work.
                 </li>
                 <li className={styles.benefitItem}>
                   <RotateCw
@@ -512,7 +532,7 @@ const ConnectAgent = () => {
                       styles.benefitIconPrimary,
                     )}
                   />
-                  Rotate and revoke controls.
+                  Automatic capture as connected agents work.
                 </li>
                 <li className={styles.benefitItem}>
                   <LaptopMinimal
@@ -521,7 +541,7 @@ const ConnectAgent = () => {
                       styles.benefitIconPrimary,
                     )}
                   />
-                  Agent instruction snippet.
+                  Advanced MCP setup when you need explicit control.
                 </li>
               </ul>
             </div>
@@ -529,31 +549,59 @@ const ConnectAgent = () => {
 
           {clientSnippet && persistentShellSnippet ? (
             <div className={styles.tokenSection}>
+              <div>
+                <h3 className={styles.sectionTitle}>2. Connect Claude Code</h3>
+                <p className={styles.mutedText}>
+                  Run this once in every terminal or VM you want Taskforce to
+                  remember. The installer is idempotent, preserves existing
+                  Claude Code settings, and takes effect after restart.
+                </p>
+              </div>
+
+              <Alert>
+                <CheckCircle2 className={styles.icon} />
+                <AlertTitle>Fresh token ready</AlertTitle>
+                <AlertDescription>
+                  This token is only shown right now. Run the command below or
+                  save it before leaving this page.
+                </AlertDescription>
+              </Alert>
+
+              <SnippetBlock
+                title="Connect Claude Code"
+                description="Persists the credential and installs Taskforce discovery and capture hooks."
+                snippet={claudeCodeConnectSnippet ?? ""}
+                copiedText={copiedText}
+                onCopy={(value) => {
+                  void copy(value)
+                }}
+                testId="connect-agent-claude-code"
+                featured
+              />
+
+              <div>
+                <h3 className={styles.sectionTitle}>3. Advanced MCP setup</h3>
+                <p className={styles.mutedText}>
+                  Use this explicit path for other MCP clients or when you want
+                  the agent to manage Taskforce documents directly.
+                </p>
+              </div>
+
               <Tabs defaultValue="ai-assisted" className={styles.setupTabs}>
                 <TabsList className={styles.setupTabsList}>
                   <TabsTrigger
                     value="ai-assisted"
                     className={styles.setupTabTrigger}
                   >
-                    AI assisted setup
+                    AI-assisted MCP
                   </TabsTrigger>
                   <TabsTrigger
                     value="manual"
                     className={styles.setupTabTrigger}
                   >
-                    Manual setup
+                    Manual MCP
                   </TabsTrigger>
                 </TabsList>
-
-                <Alert>
-                  <CheckCircle2 className={styles.icon} />
-                  <AlertTitle>Fresh token ready</AlertTitle>
-                  <AlertDescription>
-                    This token is only shown right now. Save it now if you need
-                    it for setup. After saving the shell config, start from a
-                    fresh terminal before reconnecting your AI client.
-                  </AlertDescription>
-                </Alert>
 
                 <TabsContent value="ai-assisted" className={styles.setupTab}>
                   <SnippetBlock
@@ -620,8 +668,8 @@ const ConnectAgent = () => {
               <KeyRound className={styles.icon} />
               <AlertTitle>Create your first agent credential</AlertTitle>
               <AlertDescription>
-                Create a credential to generate the token, MCP config, and
-                instruction snippet.
+                Create a credential, then connect each Claude Code terminal or
+                VM with one command.
               </AlertDescription>
             </Alert>
           )}

--- a/src/config/taskforce.ts
+++ b/src/config/taskforce.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_HOSTED_MCP_URL = "https://enderai-mcp.onrender.com/mcp"

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -800,11 +800,30 @@ function TaskforceLibrary() {
 
           {isLoading && <LibraryLoadingSkeleton view={libraryView} />}
 
-          {isEmpty && (
-            <div className="border bg-card p-6 text-sm text-muted-foreground">
-              No documents yet.
-            </div>
-          )}
+          {isEmpty &&
+            (isDemoMode ? (
+              <div className="border bg-card p-6 text-sm text-muted-foreground">
+                No documents yet.
+              </div>
+            ) : (
+              <div className="flex flex-col items-start gap-4 border bg-card p-6">
+                <div>
+                  <h2 className="font-medium text-foreground">
+                    Connect a terminal to start capturing work
+                  </h2>
+                  <p className="mt-1 max-w-xl text-sm leading-6 text-muted-foreground">
+                    Taskforce creates documents automatically as your connected
+                    coding agents work, so context carries across terminals and
+                    VMs.
+                  </p>
+                </div>
+                <Button asChild>
+                  <Link to="/v2/settings" search={{ tab: "connect-agent" }}>
+                    Connect agent
+                  </Link>
+                </Button>
+              </div>
+            ))}
 
           {!isLoading && documents.length > 0 && (
             <LibraryRecentReel

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -334,23 +334,41 @@ test("Taskforce v2 library shows document demo data only in demo mode", async ({
   await expect(page.getByText("Latest Stale Network Bridge Issue")).toHaveCount(
     0,
   )
-  await expect(page.getByText("No documents yet.")).toBeVisible()
+  await expect(
+    page.getByRole("heading", {
+      name: "Connect a terminal to start capturing work",
+    }),
+  ).toBeVisible()
+  const connectAgentLink = page.getByRole("link", { name: "Connect agent" })
+  await expect(connectAgentLink).toHaveAttribute(
+    "href",
+    /\/v2\/settings\?tab=connect-agent$/,
+  )
+  await connectAgentLink.click()
+  await expect(page).toHaveURL(/\/v2\/settings\?tab=connect-agent$/)
+  await expect(
+    page.getByRole("tab", { name: "Connect agent" }),
+  ).toHaveAttribute("aria-selected", "true")
+
+  await page.goto("/v2/library")
 
   await page.getByTestId("demo-mode-toggle").click()
 
   await expect(
-    page.getByText("Latest Stale Network Bridge Issue"),
+    page.getByText("Latest Stale Network Bridge Issue").first(),
   ).toBeVisible()
-  await expect(page.getByText("V2 Document Evidence Contract")).toBeVisible()
   await expect(
-    page.getByText("Hosted MCP Credential Setup Refresh"),
+    page.getByText("V2 Document Evidence Contract").first(),
+  ).toBeVisible()
+  await expect(
+    page.getByText("Hosted MCP Credential Setup Refresh").first(),
   ).toBeVisible()
   await expect(page.getByText("AI detail seed")).toHaveCount(0)
   await expect(page.getByText("Resolved", { exact: true })).toHaveCount(0)
   await expect(page.getByText("Ready", { exact: true })).toHaveCount(0)
   await expect(page.getByText("Draft", { exact: true })).toHaveCount(0)
 
-  await page.getByText("Latest Stale Network Bridge Issue").click()
+  await page.getByText("Latest Stale Network Bridge Issue").first().click()
   await expect(page).toHaveURL(
     /\/v2\/library\/8c9b0f48-2f3f-4e8d-9f7d-b4f0607d6a32$/,
   )

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -675,7 +675,7 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   await expect(
     page
       .locator('[data-slot="card-title"]')
-      .filter({ hasText: "Connect agent" }),
+      .filter({ hasText: "Connect your coding agent" }),
   ).toBeVisible()
   await expect(page.getByLabel("Credential label")).toBeVisible()
   await expect(page.getByLabel("Credential label")).toHaveValue(
@@ -683,7 +683,9 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   )
   await expect(page.getByText("Revoked install")).toHaveCount(0)
   await expect(
-    page.getByText("Token and config snippets for local MCP testing."),
+    page.getByText(
+      "Connect your coding agent to Taskforce so work captured in one terminal is available in the next.",
+    ),
   ).toBeVisible()
   await expect(page.getByText("Hosted MCP URL")).toHaveCount(0)
   await expect(
@@ -702,17 +704,29 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   await expect(
     page.getByText("Optional: persist the token across new terminals"),
   ).toHaveCount(0)
+  await expect(page.getByText("2. Connect Claude Code")).toBeVisible()
+  const claudeCodeSetup = page.getByTestId("connect-agent-claude-code")
+  await expect(claudeCodeSetup).toContainText(
+    "printf '%s\\n' 'mcp-token-abc' > ~/.taskforce_mcp_token",
+  )
+  await expect(claudeCodeSetup).toContainText(
+    "chmod 600 ~/.taskforce_mcp_token",
+  )
+  await expect(claudeCodeSetup).toContainText(
+    "scripts/taskforce-hooks/install.sh | bash",
+  )
+  await expect(page.getByText("3. Advanced MCP setup")).toBeVisible()
   await expect(
-    page.getByRole("tab", { name: "AI assisted setup" }),
+    page.getByRole("tab", { name: "AI-assisted MCP" }),
   ).toHaveAttribute("aria-selected", "true")
-  await expect(page.getByRole("tab", { name: "Manual setup" })).toBeVisible()
+  await expect(page.getByRole("tab", { name: "Manual MCP" })).toBeVisible()
   await expect(page.getByText("Ask an agent to wire it up")).toBeVisible()
   await expect(
     page.getByText("Paste this into the agent doing setup."),
   ).toBeVisible()
   await expect(
     page.getByText(
-      "After saving the shell config, start from a fresh terminal",
+      "Run this once in every terminal or VM you want Taskforce to remember.",
     ),
   ).toBeVisible()
   await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
@@ -728,13 +742,13 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
     "# Set up MCP config",
   )
   await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
-    'bearer_token_env_var = "ENDERAI_MCP_TOKEN"',
+    'bearer_token_env_var = "TASKFORCE_MCP_TOKEN"',
   )
   await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
     "# Add agent instruction",
   )
   await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
-    "enderai_begin_case",
+    "taskforce_begin_case",
   )
   await expect(page.getByTestId("connect-agent-ai-setup")).toContainText(
     "# Reconnect the AI client",
@@ -746,7 +760,16 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
     "token environment",
   )
 
-  await page.getByRole("tab", { name: "Manual setup" }).click()
+  const primarySetupTop = await page
+    .getByText("Connect Claude Code", { exact: true })
+    .first()
+    .boundingBox()
+  const advancedSetupTop = await page
+    .getByText("3. Advanced MCP setup")
+    .boundingBox()
+  expect(primarySetupTop?.y).toBeLessThan(advancedSetupTop?.y ?? 0)
+
+  await page.getByRole("tab", { name: "Manual MCP" }).click()
   await expect(page.getByText("Persist token")).toBeVisible()
   await expect(
     page.getByTestId("connect-agent-persistent-shell"),
@@ -765,12 +788,12 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   ).toContainText("awk -v start=")
   await expect(
     page.getByTestId("connect-agent-persistent-shell"),
-  ).toContainText('export ENDERAI_MCP_TOKEN="$(tr -d')
+  ).toContainText('export TASKFORCE_MCP_TOKEN="$(tr -d')
   await expect(
     page.getByTestId("connect-agent-persistent-shell"),
-  ).not.toContainText("ENDERAI_BACKEND_TOKEN")
+  ).not.toContainText("ENDERAI_MCP_TOKEN")
   await expect(page.getByTestId("connect-agent-config")).toContainText(
-    'bearer_token_env_var = "ENDERAI_MCP_TOKEN"',
+    'bearer_token_env_var = "TASKFORCE_MCP_TOKEN"',
   )
   await expect(
     page.getByText("Add this block to your AI client's MCP config."),
@@ -797,7 +820,7 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
     ),
   ).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-instructions")).toContainText(
-    "enderai_begin_case",
+    "taskforce_begin_case",
   )
   await expect(page.getByTestId("connect-agent-instructions")).toContainText(
     "creating or rotating a Taskforce MCP credential",
@@ -809,10 +832,10 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
     "auto-hydrate relevant prior context",
   )
   await expect(page.getByTestId("connect-agent-instructions")).toContainText(
-    "enderai_finish_case",
+    "taskforce_finish_case",
   )
   await expect(page.getByTestId("connect-agent-instructions")).toContainText(
-    "Prefer the guided case tools over raw `enderai_request` calls.",
+    "Prefer the guided case tools over raw `taskforce_request` calls.",
   )
   const instructionStepTop = await page
     .getByText("Minimal agent instruction")
@@ -831,16 +854,17 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
 
   await expect(page.getByText("Persist token")).toHaveCount(0)
   await expect(
-    page.getByText('export ENDERAI_MCP_TOKEN="PASTE_MCP_TOKEN_HERE"'),
+    page.getByText('export TASKFORCE_MCP_TOKEN="PASTE_MCP_TOKEN_HERE"'),
   ).toHaveCount(0)
+  await expect(page.getByTestId("connect-agent-claude-code")).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-persistent-shell")).toHaveCount(
     0,
   )
   await expect(page.getByTestId("connect-agent-config")).toHaveCount(0)
-  await expect(
-    page.getByRole("tab", { name: "AI assisted setup" }),
-  ).toHaveCount(0)
-  await expect(page.getByRole("tab", { name: "Manual setup" })).toHaveCount(0)
+  await expect(page.getByRole("tab", { name: "AI-assisted MCP" })).toHaveCount(
+    0,
+  )
+  await expect(page.getByRole("tab", { name: "Manual MCP" })).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-ai-setup")).toHaveCount(0)
   await expect(page.getByText("Reconnect AI client")).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-reconnect-client")).toHaveCount(
@@ -849,8 +873,8 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   await expect(page.getByTestId("connect-agent-instructions")).toHaveCount(0)
   await expect(page.getByText("Minimal agent instruction")).toHaveCount(0)
   await expect(page.getByText("Ask an agent to wire it up")).toHaveCount(0)
-  await expect(page.getByText("enderai_finish_case")).toHaveCount(0)
-  await expect(page.getByText("enderai_begin_case")).toHaveCount(0)
+  await expect(page.getByText("taskforce_finish_case")).toHaveCount(0)
+  await expect(page.getByText("taskforce_begin_case")).toHaveCount(0)
   await expect(page.getByText("# Add agent instruction")).toHaveCount(0)
   await expect(page.getByText("# Reconnect the AI client")).toHaveCount(0)
   await expect(page.getByText("# Set up MCP config")).toHaveCount(0)
@@ -947,10 +971,13 @@ test("Connect agent shows V2 document instructions for V2-enabled users", async 
   await expect(aiSetup).toContainText("Details view")
   await expect(aiSetup).toContainText("evidence anchors")
   await expect(aiSetup).toContainText("Prefer Taskforce V2 document tools")
-  await expect(aiSetup).not.toContainText("enderai_begin_case")
+  await expect(aiSetup).toContainText("taskforce_begin_document")
+  await expect(aiSetup).not.toContainText("taskforce_begin_case")
+  await expect(aiSetup).not.toContainText("enderai_")
 
-  await page.getByRole("tab", { name: "Manual setup" }).click()
+  await page.getByRole("tab", { name: "Manual MCP" }).click()
   const instructions = page.getByTestId("connect-agent-instructions")
   await expect(instructions).toContainText("Taskforce V2 MCP tools")
-  await expect(instructions).not.toContainText("enderai_finish_case")
+  await expect(instructions).toContainText("taskforce_finish_document")
+  await expect(instructions).not.toContainText("enderai_")
 })


### PR DESCRIPTION
## Summary
- make the Claude Code hook installer the primary Connect Agent action after credential creation
- reframe onboarding around cross-terminal continuity and rename generated MCP instructions/env configuration to Taskforce-only names
- add a first-run live Library empty state that routes directly to the Connect Agent settings tab
- preserve demo-mode and folder-empty Library behavior

## Decisions
- explicit MCP setup remains available as an advanced path below the primary hook installer
- generated shell/config snippets use `TASKFORCE_MCP_TOKEN` and `taskforce_*` tool names
- the hosted MCP endpoint remains unchanged and is centralized outside the onboarding component

## Validation
- `bun run build`
- Biome checks on changed files
- focused Playwright coverage for Connect Agent V1/V2 instructions and live/demo Library empty states: 3 passed
- `git diff --check`

Jira: [TF-221](https://alexlee4190.atlassian.net/browse/TF-221), [TF-222](https://alexlee4190.atlassian.net/browse/TF-222), [TF-223](https://alexlee4190.atlassian.net/browse/TF-223)
Epic: [TF-219](https://alexlee4190.atlassian.net/browse/TF-219)