### PR TITLE
Fix extra bottom spacing on settings pages

### DIFF
--- a/src/components/UserSettings/UserSettingsPage.tsx
+++ b/src/components/UserSettings/UserSettingsPage.tsx
@@ -64,7 +64,7 @@ export function UserSettingsPage({
     invitationsQuery.data?.count ?? invitationsQuery.data?.data.length ?? 0
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden">
+    <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden -mb-6 md:-mb-8">
       <div className="shrink-0">
         <h1 className="text-2xl font-bold">Settings</h1>
       </div>


### PR DESCRIPTION
## Summary
- Apply `-mb-6 md:-mb-8` to the settings page shell so tab content bleeds into the TaskforceShell main padding, matching Agents and Library.
- Removes the ugly empty gap below scrollable settings tab content.

## Test plan
- [x] Verified pattern matches existing v2 pages (`agents.tsx`, `library.tsx`)
- [ ] Scroll to bottom on `/v2/settings?tab=connect-agent` — content should sit flush with no extra bottom gap


Made with [Cursor](https://cursor.com)