### PR TITLE
Add scroll-end bottom padding on settings tabs

### DIFF
--- a/src/components/UserSettings/UserSettingsPage.tsx
+++ b/src/components/UserSettings/UserSettingsPage.tsx
@@ -91,7 +91,7 @@ export function UserSettingsPage({
           <TabsContent
             key={tab.value}
             value={tab.value}
-            className="min-h-0 flex-1 overflow-y-auto pr-1"
+            className="min-h-0 flex-1 overflow-y-auto pr-1 pb-6 md:pb-8"
           >
             <tab.component />
           </TabsContent>


### PR DESCRIPTION
## Summary
- Add `pb-6 md:pb-8` to settings tab scroll areas so content has intentional bottom breathing room when scrolled all the way down.
- Keeps the existing `-mb-6 md:-mb-8` shell bleed so there is no dead gap below the scroll container.

## Test plan
- [ ] Scroll to bottom on `/v2/settings?tab=connect-agent` — last card should sit slightly above the viewport edge, not flush against it


Made with [Cursor](https://cursor.com)