### PR TITLE
Reorder settings tabs and merge password into Account

### DIFF
--- a/src/components/UserSettings/ChangePassword.tsx
+++ b/src/components/UserSettings/ChangePassword.tsx
@@ -84,7 +84,7 @@ const ChangePassword = () => {
 
   return (
     <div className="max-w-md">
-      <h3 className="text-lg font-semibold py-4">Change Password</h3>
+      <h3 className="py-4 text-lg font-semibold">Password</h3>
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}

--- a/src/components/UserSettings/UserInformation.tsx
+++ b/src/components/UserSettings/UserInformation.tsx
@@ -19,6 +19,7 @@ import { LoadingButton } from "@/components/ui/loading-button"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
+import ChangePassword from "@/components/UserSettings/ChangePassword"
 import { handleError } from "@/utils"
 
 const formSchema = z.object({
@@ -78,13 +79,14 @@ const UserInformation = () => {
   }
 
   return (
-    <div className="max-w-md">
-      <h3 className="text-lg font-semibold py-4">User Information</h3>
-      <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit(onSubmit)}
-          className="flex flex-col gap-4"
-        >
+    <div className="flex max-w-md flex-col gap-8">
+      <section>
+        <h3 className="py-4 text-lg font-semibold">Profile</h3>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="flex flex-col gap-4"
+          >
           <FormField
             control={form.control}
             name="full_name"
@@ -149,8 +151,12 @@ const UserInformation = () => {
               </Button>
             )}
           </div>
-        </form>
-      </Form>
+          </form>
+        </Form>
+      </section>
+      <section className="border-t">
+        <ChangePassword />
+      </section>
     </div>
   )
 }

--- a/src/components/UserSettings/UserSettingsPage.tsx
+++ b/src/components/UserSettings/UserSettingsPage.tsx
@@ -5,7 +5,6 @@ import { readMyOrganizationInvitations } from "@/api/organizations"
 import { PendingInvitationBadge } from "@/components/Common/PendingInvitationBadge"
 import AppearanceSettings from "@/components/UserSettings/Appearance"
 import Billing from "@/components/UserSettings/Billing"
-import ChangePassword from "@/components/UserSettings/ChangePassword"
 import ConnectAgent from "@/components/UserSettings/ConnectAgent"
 import DeleteAccount from "@/components/UserSettings/DeleteAccount"
 import Organization from "@/components/UserSettings/Organization"
@@ -14,28 +13,40 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import useAuth from "@/hooks/useAuth"
 
 export const settingsTabValues = [
-  "my-profile",
+  "account",
   "organization",
-  "appearance",
   "connect-agent",
   "billing",
-  "password",
+  "appearance",
   "danger-zone",
 ] as const
 
 export type SettingsTab = (typeof settingsTabValues)[number]
+
+/** @deprecated Old tab slugs kept for URL redirects. */
+export const legacySettingsTabValues = ["my-profile", "password"] as const
+
+export type LegacySettingsTab = (typeof legacySettingsTabValues)[number]
+
+export function normalizeSettingsTab(
+  tab: SettingsTab | LegacySettingsTab | undefined,
+): SettingsTab {
+  if (tab === "my-profile" || tab === "password") {
+    return "account"
+  }
+  return tab ?? "account"
+}
 
 const tabsConfig: Array<{
   value: SettingsTab
   title: string
   component: ComponentType
 }> = [
-  { value: "my-profile", title: "My profile", component: UserInformation },
+  { value: "account", title: "Account", component: UserInformation },
   { value: "organization", title: "Organization", component: Organization },
-  { value: "appearance", title: "Appearance", component: AppearanceSettings },
   { value: "connect-agent", title: "Connect agent", component: ConnectAgent },
   { value: "billing", title: "Billing", component: Billing },
-  { value: "password", title: "Password", component: ChangePassword },
+  { value: "appearance", title: "Appearance", component: AppearanceSettings },
   { value: "danger-zone", title: "Danger zone", component: DeleteAccount },
 ]
 

--- a/src/routes/_layout/settings.tsx
+++ b/src/routes/_layout/settings.tsx
@@ -1,10 +1,16 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 import { z } from "zod"
 
-import { settingsTabValues } from "@/components/UserSettings/UserSettingsPage"
+import {
+  legacySettingsTabValues,
+  normalizeSettingsTab,
+  settingsTabValues,
+} from "@/components/UserSettings/UserSettingsPage"
 
 const searchSchema = z.object({
-  tab: z.enum(settingsTabValues).optional(),
+  tab: z
+    .enum([...settingsTabValues, ...legacySettingsTabValues])
+    .optional(),
 })
 
 export const Route = createFileRoute("/_layout/settings")({
@@ -12,7 +18,10 @@ export const Route = createFileRoute("/_layout/settings")({
   beforeLoad: ({ search }) => {
     throw redirect({
       to: "/v2/settings",
-      search: { tab: search.tab },
+      search:
+        search.tab !== undefined
+          ? { tab: normalizeSettingsTab(search.tab) }
+          : undefined,
     })
   },
   head: () => ({

--- a/src/routes/v2/settings.tsx
+++ b/src/routes/v2/settings.tsx
@@ -1,19 +1,33 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router"
 import { z } from "zod"
 
 import {
+  legacySettingsTabValues,
+  normalizeSettingsTab,
   type SettingsTab,
   settingsTabValues,
   UserSettingsPage,
 } from "@/components/UserSettings/UserSettingsPage"
 
 const searchSchema = z.object({
-  tab: z.enum(settingsTabValues).optional(),
+  tab: z
+    .enum([...settingsTabValues, ...legacySettingsTabValues])
+    .optional(),
 })
 
 export const Route = createFileRoute("/v2/settings")({
   component: TaskforceSettings,
   validateSearch: searchSchema,
+  beforeLoad: ({ search }) => {
+    const activeTab = normalizeSettingsTab(search.tab)
+    if (search.tab !== undefined && search.tab !== activeTab) {
+      throw redirect({
+        to: "/v2/settings",
+        search: { tab: activeTab },
+        replace: true,
+      })
+    }
+  },
   head: () => ({
     meta: [
       {
@@ -26,7 +40,7 @@ export const Route = createFileRoute("/v2/settings")({
 function TaskforceSettings() {
   const navigate = useNavigate()
   const { tab } = Route.useSearch()
-  const activeTab = tab ?? "my-profile"
+  const activeTab = normalizeSettingsTab(tab)
 
   return (
     <UserSettingsPage

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -6,11 +6,11 @@ import { randomEmail, randomPassword } from "./utils/random"
 import { logInUser, logOutUser } from "./utils/user"
 
 const tabs = [
-  "My profile",
+  "Account",
   "Organization",
   "Connect agent",
   "Billing",
-  "Password",
+  "Appearance",
   "Danger zone",
 ]
 
@@ -18,9 +18,9 @@ test.beforeEach(async ({ page }) => {
   await mockV2Documents(page)
 })
 
-test("My profile tab is active by default", async ({ page }) => {
+test("Account tab is active by default", async ({ page }) => {
   await page.goto("/v2/settings")
-  await expect(page.getByRole("tab", { name: "My profile" })).toHaveAttribute(
+  await expect(page.getByRole("tab", { name: "Account" })).toHaveAttribute(
     "aria-selected",
     "true",
   )
@@ -333,7 +333,7 @@ test.describe("Edit user profile", () => {
   test.beforeEach(async ({ page }) => {
     await logInUser(page, email, password)
     await page.goto("/v2/settings")
-    await page.getByRole("tab", { name: "My profile" }).click()
+    await page.getByRole("tab", { name: "Account" }).click()
   })
 
   test("Edit user name with a valid name", async ({ page }) => {
@@ -371,7 +371,7 @@ test.describe("Edit user email", () => {
     await createUser({ email, password })
     await logInUser(page, email, password)
     await page.goto("/v2/settings")
-    await page.getByRole("tab", { name: "My profile" }).click()
+    await page.getByRole("tab", { name: "Account" }).click()
 
     await page.getByRole("button", { name: "Edit" }).click()
     await page.getByLabel("Email").fill(updatedEmail)
@@ -394,7 +394,7 @@ test.describe("Cancel edit actions", () => {
 
     await logInUser(page, email, password)
     await page.goto("/v2/settings")
-    await page.getByRole("tab", { name: "My profile" }).click()
+    await page.getByRole("tab", { name: "Account" }).click()
     await page.getByRole("button", { name: "Edit" }).click()
     await page.getByLabel("Full name").fill("Test User")
     await page.getByRole("button", { name: "Cancel" }).first().click()
@@ -411,7 +411,7 @@ test.describe("Cancel edit actions", () => {
 
     await logInUser(page, email, password)
     await page.goto("/v2/settings")
-    await page.getByRole("tab", { name: "My profile" }).click()
+    await page.getByRole("tab", { name: "Account" }).click()
     await page.getByRole("button", { name: "Edit" }).click()
     await page.getByLabel("Email").fill(randomEmail())
     await page.getByRole("button", { name: "Cancel" }).first().click()
@@ -434,7 +434,7 @@ test.describe("Change password", () => {
     await logInUser(page, email, password)
 
     await page.goto("/v2/settings")
-    await page.getByRole("tab", { name: "Password" }).click()
+    await page.getByRole("tab", { name: "Account" }).click()
     await page.getByTestId("current-password-input").fill(password)
     await page.getByTestId("new-password-input").fill(newPassword)
     await page.getByTestId("confirm-password-input").fill(newPassword)
@@ -461,7 +461,7 @@ test.describe("Change password validation", () => {
   test.beforeEach(async ({ page }) => {
     await logInUser(page, email, password)
     await page.goto("/v2/settings")
-    await page.getByRole("tab", { name: "Password" }).click()
+    await page.getByRole("tab", { name: "Account" }).click()
   })
 
   test("Update password with weak passwords", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Rename **My profile** → **Account** (`?tab=account`); legacy `my-profile` and `password` URLs redirect to Account.
- Reorder tabs: Account, Organization, Connect agent, Billing, Appearance, Danger zone.
- Move password change form onto the Account page (Profile + Password sections).
- Update settings e2e tests for the new tab names and order.

## Test plan
- [ ] `/v2/settings` defaults to Account tab with profile + password sections
- [ ] `/v2/settings?tab=password` redirects to `?tab=account`
- [ ] Tab order matches spec on all breakpoints


Made with [Cursor](https://cursor.com)