### PR TITLE
Connect Agent: one-step, self-contained metrics-hook install

### DIFF
--- a/src/assets/taskforce-record-usage.sh
+++ b/src/assets/taskforce-record-usage.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Taskforce metrics hook for Claude Code (Stop event).
+# Records each turn's token usage to your Taskforce Metrics page.
+# Fails silently and never blocks your session.
+set -uo pipefail
+trap 'exit 0' EXIT
+
+# Token from the Connect Agent flow (legacy path kept as a fallback).
+token_file="$HOME/.taskforce_mcp_token"
+[ -r "$token_file" ] || token_file="$HOME/.enderai_mcp_token"
+[ -r "$token_file" ] || exit 0
+token="$(tr -d '\r\n' < "$token_file")"
+[ -n "$token" ] || exit 0
+
+backend="${TASKFORCE_BACKEND_URL:-https://enderai-backend.onrender.com}"
+
+# The Stop payload (stdin) points at the session transcript; take the last
+# assistant turn carrying usage — scanning from the end keeps it cheap.
+transcript="$(jq -r '.transcript_path // empty')"
+[ -r "$transcript" ] || exit 0
+turn="$(tac "$transcript" | awk '/"type":"assistant"/ && /"usage":/ {print; exit}')"
+[ -n "$turn" ] || exit 0
+
+usage="$(jq -c '{
+  model_id: (.message.model // "unknown"),
+  input_tokens: (.message.usage.input_tokens // 0),
+  output_tokens: (.message.usage.output_tokens // 0),
+  cache_read_input_tokens: (.message.usage.cache_read_input_tokens // 0),
+  cache_creation_input_tokens: (.message.usage.cache_creation_input_tokens // 0)
+}' <<<"$turn")"
+[ -n "$usage" ] || exit 0
+
+# Skip empty finalization turns where nothing was generated.
+[ "$(jq -r '[.[] | numbers] | add' <<<"$usage")" = 0 ] && exit 0
+
+curl -sS --max-time 8 -X POST \
+  -H "Authorization: Bearer $token" -H "Content-Type: application/json" \
+  --data "$usage" "$backend/api/v1/v2/metrics/usage?source=hook" >/dev/null 2>&1 || true

--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -18,6 +18,7 @@ import {
   revokeAgentCredential,
   rotateAgentCredential,
 } from "@/api/agentCredentials"
+import recordUsageScript from "@/assets/taskforce-record-usage.sh?raw"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -50,35 +51,35 @@ function formatTimestamp(value: string | null): string {
   }).format(new Date(value))
 }
 
-// One-liner that drops the Claude Code Stop hook on disk + chmods it.
-// Pulls the canonical script straight from the Taskforce repository so users
-// always get the latest version (the script logs to ~/.claude/taskforce-record-usage.log
-// and fails silent — see the script's header comments for full env vars).
-const STOP_HOOK_INSTALL_COMMAND = [
-  "mkdir -p ~/.claude/hooks",
-  "curl -fsSL -o ~/.claude/hooks/taskforce-record-usage.sh \\",
-  "  https://raw.githubusercontent.com/al-exe/EnderAI/main/scripts/claude-code-record-usage.sh",
-  "chmod +x ~/.claude/hooks/taskforce-record-usage.sh",
-].join("\n")
+// Single self-contained install for the Claude Code metrics hook: saves the
+// token, writes the hook script inline (nothing is downloaded), and registers
+// it as a Stop hook via an idempotent jq merge. The script body is the real
+// asset file imported above, so what runs is exactly what the user can read.
+function buildMetricsHookInstallSnippet(mcpToken: string): string {
+  const stopHookMerge =
+    ".hooks.Stop = ((.hooks.Stop // []) | " +
+    'if any(.[]?.hooks[]?; .command | test("taskforce-record-usage")) then . ' +
+    'else . + [{matcher:"*",hooks:[{type:"command",' +
+    'command:"$HOME/.claude/hooks/taskforce-record-usage.sh",timeout:10}]}] end)'
 
-// JSON snippet the user merges into ~/.claude/settings.json so Claude
-// Code actually fires the hook after every assistant turn.
-const STOP_HOOK_SETTINGS_JSON = `{
-  "hooks": {
-    "Stop": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$HOME/.claude/hooks/taskforce-record-usage.sh",
-            "timeout": 10
-          }
-        ]
-      }
-    ]
-  }
-}`
+  return [
+    "# 1 · Save your Taskforce token (stays on this machine)",
+    `printf '%s\\n' '${mcpToken}' > ~/.taskforce_mcp_token && chmod 600 ~/.taskforce_mcp_token`,
+    "",
+    "# 2 · Write the metrics hook locally — nothing is downloaded",
+    "mkdir -p ~/.claude/hooks",
+    "cat > ~/.claude/hooks/taskforce-record-usage.sh <<'TF_RECORD_USAGE_EOF'",
+    recordUsageScript.trimEnd(),
+    "TF_RECORD_USAGE_EOF",
+    "chmod +x ~/.claude/hooks/taskforce-record-usage.sh",
+    "",
+    "# 3 · Register it as a Stop hook (idempotent; requires jq)",
+    "[ -f ~/.claude/settings.json ] || echo '{}' > ~/.claude/settings.json",
+    `tmp="$(mktemp)" && jq '${stopHookMerge}' ~/.claude/settings.json > "$tmp" && mv "$tmp" ~/.claude/settings.json`,
+    "",
+    'echo "✓ Taskforce metrics hook installed — restart Claude Code to activate."',
+  ].join("\n")
+}
 
 function buildPersistentShellSnippet(mcpToken: string): string {
   const lines = [
@@ -682,32 +683,32 @@ const ConnectAgent = () => {
         </CardHeader>
         <CardContent className={styles.cardContent}>
           <p className={styles.mutedText}>
-            Optional — Claude Code only. Drop this Stop hook in to auto-record
-            every assistant turn's token usage to the Taskforce Metrics page, so
-            cost charts populate without the agent having to introspect itself.
-            Requires the MCP token above (already created when you generate a
-            credential).
+            Optional — Claude Code only. Records each turn's token usage to your
+            Taskforce Metrics page, so cost charts populate on their own. One
+            command: it saves your token, writes the hook locally (nothing is
+            downloaded), and registers it. Requires <code>jq</code>.
           </p>
-          <SnippetBlock
-            title="Install the hook"
-            description="Run once in a terminal. Pulls the canonical script from the Taskforce repository."
-            snippet={STOP_HOOK_INSTALL_COMMAND}
-            copiedText={copiedText}
-            onCopy={(value) => {
-              void copy(value)
-            }}
-            testId="connect-agent-stop-hook-install"
-          />
-          <SnippetBlock
-            title="~/.claude/settings.json"
-            description="Merge this `hooks` block into your existing settings.json. Restart Claude Code after editing so it picks up the hook."
-            snippet={STOP_HOOK_SETTINGS_JSON}
-            copiedText={copiedText}
-            onCopy={(value) => {
-              void copy(value)
-            }}
-            testId="connect-agent-stop-hook-settings"
-          />
+          {hasFreshToken && mcpToken ? (
+            <SnippetBlock
+              title="Install the metrics hook"
+              description="Paste into a terminal, then restart Claude Code to activate."
+              snippet={buildMetricsHookInstallSnippet(mcpToken)}
+              copiedText={copiedText}
+              onCopy={(value) => {
+                void copy(value)
+              }}
+              testId="connect-agent-stop-hook-install"
+            />
+          ) : (
+            <Alert>
+              <KeyRound className={styles.icon} />
+              <AlertTitle>Token needed</AlertTitle>
+              <AlertDescription>
+                Create or rotate a credential above to reveal your one-command
+                metrics-hook install.
+              </AlertDescription>
+            </Alert>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## What
Replaces the Claude Code **cost-tracking hook** setup (two steps: `curl` the script from GitHub + manually merge a `hooks` block into `settings.json`) with **one self-contained copy-paste block**.

The block:
1. saves the token to `~/.taskforce_mcp_token` (stays in the shell — never pasted into an agent),
2. writes the hook script **inline** via a heredoc (nothing is downloaded), and
3. registers the Stop hook with an **idempotent `jq` merge** (no manual JSON editing).

## Why
The old flow `curl … raw.githubusercontent.com/al-exe/EnderAI/… | …` is a remote-code-fetch from a personal GitHub at install time — a supply-chain/trust smell and an availability dependency for an external user. Inlining removes the remote dependency; the user can read exactly what runs.

## How it stays maintainable
The script body is a **real vendored asset** (`src/assets/taskforce-record-usage.sh`) imported with Vite `?raw`, so the snippet and the actual file can't drift, and the script stays lintable on its own. Script code + comments trimmed to ~40 lines.

## Notes
- Gated on a fresh token; shows a "token needed" prompt until a credential is created/rotated.
- Same supply-chain pattern still exists in the **cross-session** installer (`taskforce-hooks/install.sh | bash`, TF-221) — left as a follow-up; that script is more complex to inline.
- `tsc` clean; biome-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)