### PR TITLE
Frontend polish: margins, sticky headers, card padding

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -3,8 +3,9 @@
  *
  * Type and spacing are normalized to the rest of the v2 surface (Profiles /
  * Library): the mono eyebrow matches V2_TAB_EYEBROW_CLASS (12px), the page
- * title matches text-2xl (24px), horizontal insets match the p-6 content
- * padding (24px), and body/label sizes round to the standard Tailwind scale
+ * title matches text-2xl (24px), horizontal insets come from V2_PAGE_CONTENT
+ * padding on the page shell, and body/label sizes round to the standard
+ * Tailwind scale
  * (12 / 14 / 16 / 24) so the page reads the same as every other tab.
  *
  * The standalone mock defined a `--tf-*` palette in a missing `_shared.css`;
@@ -77,7 +78,7 @@
 
 .head {
   /* 24px bottom matches the Profiles gap-6 between the title block and the bar. */
-  padding: 24px 24px 24px;
+  padding: 0 0 24px;
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 14px;
@@ -168,7 +169,7 @@
   display: grid;
   grid-template-columns: var(--grid);
   gap: 16px;
-  padding: 11px 24px;
+  padding: 11px 0;
   border-top: 1px solid var(--tf-border);
   border-bottom: 1px solid var(--tf-border);
   font-family: var(--font-mono);
@@ -182,7 +183,7 @@
   display: flex;
   align-items: baseline;
   gap: 12px;
-  padding: 10px 24px;
+  padding: 10px 0;
   background: var(--tf-card);
   border-bottom: 1px solid var(--tf-hairline);
 }
@@ -209,7 +210,7 @@
   grid-template-columns: var(--grid);
   gap: 16px;
   align-items: center;
-  padding: 14px 24px;
+  padding: 14px 0;
   border: 0;
   border-bottom: 1px solid var(--tf-hairline);
   width: 100%;
@@ -347,13 +348,13 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 24px;
+  padding: 24px 0;
   font-family: var(--font-mono);
   font-size: 14px;
   color: var(--tf-muted-fg);
 }
 .empty {
-  margin: 24px;
+  margin: 24px 0;
   border: 1px dashed var(--tf-border);
   padding: 44px;
   text-align: center;
@@ -373,7 +374,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px 24px;
+  padding: 12px 0;
   border-bottom: 1px solid var(--tf-border);
 }
 .back {
@@ -420,7 +421,7 @@
 }
 .transcript {
   overflow: auto;
-  padding: 24px 32px 64px;
+  padding: 24px 0 64px;
   min-width: 0;
 }
 .tHead {

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -22,6 +22,7 @@ import {
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { formatCompactNumber } from "@/components/V2/Agents/formatters"
 import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
+import { V2_PAGE_CONTENT_FIXED, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
 import { cn } from "@/lib/utils"
 
 import styles from "./LedgerPage.module.css"
@@ -353,7 +354,14 @@ export function LedgerPage({
   }
 
   return (
-    <div className={cn(styles.app, "-mb-6 md:-mb-8")}>
+    <section
+      className={cn(
+        V2_PAGE_FRAME,
+        "-mb-6 bg-background font-sans text-foreground md:-mb-8",
+      )}
+    >
+      <div className={V2_PAGE_CONTENT_FIXED}>
+        <div className={styles.app}>
       {selectedSessionId ? (
         <LedgerDetail
           detail={detailQuery.data}
@@ -391,7 +399,7 @@ export function LedgerPage({
             </header>
 
             <ScopeFilterBar
-              className="mx-6 mb-6"
+              className="mb-6"
               items={HARNESS_OPTIONS.map((option) => ({
                 key: option.value,
                 label: option.label,
@@ -432,7 +440,9 @@ export function LedgerPage({
           />
         </div>
       )}
-    </div>
+        </div>
+      </div>
+    </section>
   )
 }
 

--- a/src/components/V2/Library/LibraryRecentReel.tsx
+++ b/src/components/V2/Library/LibraryRecentReel.tsx
@@ -86,7 +86,7 @@ function RecentCard({
           {document.description}
         </p>
       )}
-      <div className="mt-[9px] font-mono text-[9.5px] text-muted-foreground/70">
+      <div className="mt-[9px] pb-2.5 font-mono text-[9.5px] text-muted-foreground/70">
         {sharedByOther ? "Shared" : "Updated"} ·{" "}
         <span className="font-medium text-foreground">
           {formatRelativeTime(document.updated_at ?? document.created_at)}

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -24,7 +24,11 @@ import {
 } from "@/components/V2/Agents/agentsTypography"
 import { CreateProfileDialog } from "@/components/V2/Agents/CreateProfileDialog"
 import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
-import { V2_PAGE_CONTENT, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
+import {
+  V2_PAGE_BODY,
+  V2_PAGE_FRAME,
+  V2_STICKY_HEADER_CLASS,
+} from "@/components/V2/v2PageShell"
 import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
 
@@ -137,47 +141,54 @@ function AgentsIndex() {
         "-mb-6 bg-background font-sans text-foreground md:-mb-8",
       )}
     >
-      <div className={V2_PAGE_CONTENT}>
-        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-          <div>
-            <div className={AGENT_EYEBROW_CLASS}>
-              Profiles · {activeCount} active across team
+      <div className={V2_PAGE_BODY}>
+        <div
+          className={cn(
+            V2_STICKY_HEADER_CLASS,
+            "border-b-0 pb-0",
+            "flex flex-col gap-6",
+          )}
+        >
+          <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <div className={AGENT_EYEBROW_CLASS}>
+                Profiles · {activeCount} active across team
+              </div>
+              <h1 className={cn("mt-1", AGENT_PAGE_TITLE_CLASS)}>Profiles</h1>
             </div>
-            <h1 className={cn("mt-1", AGENT_PAGE_TITLE_CLASS)}>Profiles</h1>
-          </div>
-          <Button
-            type="button"
-            size="sm"
-            className="w-fit"
-            onClick={() => setCreateProfileOpen(true)}
-          >
-            + Profile
-          </Button>
-        </header>
+            <Button
+              type="button"
+              size="sm"
+              className="w-fit"
+              onClick={() => setCreateProfileOpen(true)}
+            >
+              + Profile
+            </Button>
+          </header>
+          <ScopeFilterBar
+            items={AGENT_SCOPES.map((agentScope) => ({
+              key: agentScope.key,
+              label: agentScope.label,
+              count:
+                agentScope.key === "all"
+                  ? agents.length
+                  : agents.filter((agent) => agent.status === agentScope.key)
+                      .length,
+            }))}
+            active={scope}
+            onChange={setScope}
+            sortLabel={`tokens saved ${sortDir === "desc" ? "↓" : "↑"}`}
+            onSortToggle={() =>
+              setSortDir((dir) => (dir === "desc" ? "asc" : "desc"))
+            }
+          />
+        </div>
 
         <CreateProfileDialog
           open={createProfileOpen}
           onOpenChange={setCreateProfileOpen}
           isCreating={createProfileMutation.isPending}
           onSubmit={(values) => createProfileMutation.mutate(values)}
-        />
-
-        <ScopeFilterBar
-          items={AGENT_SCOPES.map((agentScope) => ({
-            key: agentScope.key,
-            label: agentScope.label,
-            count:
-              agentScope.key === "all"
-                ? agents.length
-                : agents.filter((agent) => agent.status === agentScope.key)
-                    .length,
-          }))}
-          active={scope}
-          onChange={setScope}
-          sortLabel={`tokens saved ${sortDir === "desc" ? "↓" : "↑"}`}
-          onSortToggle={() =>
-            setSortDir((dir) => (dir === "desc" ? "asc" : "desc"))
-          }
         />
 
         {agentsQuery.isLoading ? (

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -81,8 +81,9 @@ import {
 import { LibraryRecentReel } from "@/components/V2/Library/LibraryRecentReel"
 import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
 import {
-  V2_PAGE_CONTENT,
+  V2_PAGE_BODY,
   V2_PAGE_FRAME,
+  V2_STICKY_HEADER_CLASS,
   V2_TAB_EYEBROW_CLASS,
 } from "@/components/V2/v2PageShell"
 import useCustomToast from "@/hooks/useCustomToast"
@@ -706,67 +707,75 @@ function TaskforceLibrary() {
           "-mb-6 bg-background font-sans text-foreground md:-mb-8",
         )}
       >
-        <div className={V2_PAGE_CONTENT}>
-          <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-            <div>
-              <div className={V2_TAB_EYEBROW_CLASS}>
-                Library · {totalDocumentCount} documents ·{" "}
-                {teamSharedDocumentCount} shared with team
+        <div className={V2_PAGE_BODY}>
+          <div
+            className={cn(
+              V2_STICKY_HEADER_CLASS,
+              "border-b-0 pb-0",
+              "flex flex-col gap-6",
+            )}
+          >
+            <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div>
+                <div className={V2_TAB_EYEBROW_CLASS}>
+                  Library · {totalDocumentCount} documents ·{" "}
+                  {teamSharedDocumentCount} shared with team
+                </div>
+                <h1 className="mt-1 text-2xl font-semibold">Library</h1>
               </div>
-              <h1 className="mt-1 text-2xl font-semibold">Library</h1>
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
-              <div
-                role="tablist"
-                aria-label="Library view"
-                className="inline-flex h-9 w-fit shrink-0 items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground"
-              >
-                <LibraryViewToggle
-                  label="Files"
-                  active={libraryView === "files"}
-                  onClick={() => setLibraryView("files")}
-                />
-                <LibraryViewToggle
-                  label="Folders"
-                  active={libraryView === "folders"}
-                  onClick={() => setLibraryView("folders")}
-                />
+              <div className="flex flex-wrap items-center gap-2">
+                <div
+                  role="tablist"
+                  aria-label="Library view"
+                  className="inline-flex h-9 w-fit shrink-0 items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground"
+                >
+                  <LibraryViewToggle
+                    label="Files"
+                    active={libraryView === "files"}
+                    onClick={() => setLibraryView("files")}
+                  />
+                  <LibraryViewToggle
+                    label="Folders"
+                    active={libraryView === "folders"}
+                    onClick={() => setLibraryView("folders")}
+                  />
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="w-fit"
+                  onClick={() => setCreateFolderOpen(true)}
+                >
+                  + Folder
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  className="w-fit"
+                  onClick={() => setCreateDocumentOpen(true)}
+                >
+                  + Document
+                </Button>
               </div>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="w-fit"
-                onClick={() => setCreateFolderOpen(true)}
-              >
-                + Folder
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                className="w-fit"
-                onClick={() => setCreateDocumentOpen(true)}
-              >
-                + Document
-              </Button>
-            </div>
-          </header>
-          <ScopeFilterBar
-            items={LIBRARY_SCOPES.map((scope) => ({
-              key: scope.key,
-              label: scope.label,
-              count: scopeDocumentCounts[scope.key],
-            }))}
-            active={scopeFilter}
-            onChange={(key) => {
-              setScopeFilter(key)
-              setSelectedFolderId("all")
-            }}
-            sortLabel={`recent ${sortDir === "desc" ? "↓" : "↑"}`}
-            onSortToggle={() =>
-              setSortDir((dir) => (dir === "desc" ? "asc" : "desc"))
-            }
-          />
+            </header>
+            <ScopeFilterBar
+              items={LIBRARY_SCOPES.map((scope) => ({
+                key: scope.key,
+                label: scope.label,
+                count: scopeDocumentCounts[scope.key],
+              }))}
+              active={scopeFilter}
+              onChange={(key) => {
+                setScopeFilter(key)
+                setSelectedFolderId("all")
+              }}
+              sortLabel={`recent ${sortDir === "desc" ? "↓" : "↑"}`}
+              onSortToggle={() =>
+                setSortDir((dir) => (dir === "desc" ? "asc" : "desc"))
+              }
+            />
+          </div>
 
           <FolderCreateDialog
             open={createFolderOpen}


### PR DESCRIPTION
## Summary
- Balance padding above/below the divider on Library recent-access cards (`pb-2.5` under the Updated timestamp).
- Align Ledger horizontal margins with Profiles by using the shared `V2_PAGE_FRAME` / `V2_PAGE_CONTENT_FIXED` shell.
- Make Library and Profiles page chrome sticky (title row, actions, and scope/sort filter bar) while lists scroll underneath.

## Test plan
- [ ] Library `/v2/library` — scroll down; header + filter bar stay pinned; recent cards have even divider spacing
- [ ] Profiles `/v2/agents` — scroll down; header + filter bar stay pinned
- [ ] Ledger `/v2/ledger` — horizontal insets match Profiles


Made with [Cursor](https://cursor.com)