### PR TITLE
Ledger, Metrics, and UI polish batch

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -634,13 +634,6 @@
   border-top: 1px solid var(--tf-hairline);
   text-decoration: none;
 }
-.docMk {
-  width: 3px;
-  height: 36px;
-  background: var(--tf-primary);
-  flex-shrink: 0;
-  margin-top: 1px;
-}
 .docDt {
   min-width: 0;
 }

--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -60,25 +60,9 @@
 }
 
 /* ============ INDEX ============ */
-.scroll {
-  flex: 1;
-  min-height: 0;
-  overflow: auto;
-}
-
-/* Pin the eyebrow, title, and filter bar to the top while the list scrolls.
-   flow-root keeps the filter bar's bottom margin inside the opaque background. */
-.stickyHead {
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  display: flow-root;
-  background: var(--tf-bg);
-}
 
 .head {
-  /* 24px bottom matches the Profiles gap-6 between the title block and the bar. */
-  padding: 0 0 24px;
+  padding: 0;
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 14px;
@@ -162,9 +146,6 @@
 
 /* Column header */
 .cols {
-  position: sticky;
-  top: 0;
-  z-index: 2;
   background: var(--tf-bg);
   display: grid;
   grid-template-columns: var(--grid);

--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -61,6 +61,11 @@
 
 /* ============ INDEX ============ */
 
+/* Full-bleed list bands with padded cell text — matches sticky header -mx-6 px-6. */
+.listShell {
+  margin-inline: -1.5rem;
+}
+
 .head {
   padding: 0;
   display: grid;
@@ -150,7 +155,7 @@
   display: grid;
   grid-template-columns: var(--grid);
   gap: 16px;
-  padding: 11px 0;
+  padding: 11px 1.5rem;
   border-top: 1px solid var(--tf-border);
   border-bottom: 1px solid var(--tf-border);
   font-family: var(--font-mono);
@@ -164,7 +169,7 @@
   display: flex;
   align-items: baseline;
   gap: 12px;
-  padding: 10px 0;
+  padding: 10px 1.5rem;
   background: var(--tf-card);
   border-bottom: 1px solid var(--tf-hairline);
 }
@@ -191,7 +196,7 @@
   grid-template-columns: var(--grid);
   gap: 16px;
   align-items: center;
-  padding: 14px 0;
+  padding: 14px 1.5rem;
   border: 0;
   border-bottom: 1px solid var(--tf-hairline);
   width: 100%;
@@ -329,13 +334,13 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 24px 0;
+  padding: 24px 1.5rem;
   font-family: var(--font-mono);
   font-size: 14px;
   color: var(--tf-muted-fg);
 }
 .empty {
-  margin: 24px 0;
+  margin: 24px 1.5rem;
   border: 1px dashed var(--tf-border);
   padding: 44px;
   text-align: center;

--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -407,7 +407,7 @@
 }
 .transcript {
   overflow: auto;
-  padding: 24px 0 64px;
+  padding: 24px 1.5rem 0;
   min-width: 0;
 }
 .tHead {
@@ -593,7 +593,7 @@
   border-left: 1px solid var(--tf-border);
   background: var(--tf-card);
   overflow: auto;
-  padding: 22px 20px 44px;
+  padding: 22px 20px 0;
 }
 .grp {
   font-family: var(--font-mono);

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -364,7 +364,7 @@ export function LedgerPage({
         "-mb-6 bg-background font-sans text-foreground md:-mb-8",
       )}
     >
-      <div className={V2_PAGE_BODY}>
+      <div className={cn(V2_PAGE_BODY, selectedSessionId && "pb-0")}>
         {selectedSessionId ? (
           <div className={styles.app}>
             <LedgerDetail

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -431,23 +431,25 @@ export function LedgerPage({
               />
             </div>
 
-            <div className={styles.cols}>
-              <div>Time</div>
-              <div>Session</div>
-              <div>Harness · agent</div>
-              <div>Activity</div>
-              <div>Referenced by</div>
-              <div />
-            </div>
+            <div className={styles.listShell}>
+              <div className={styles.cols}>
+                <div>Time</div>
+                <div>Session</div>
+                <div>Harness · agent</div>
+                <div>Activity</div>
+                <div>Referenced by</div>
+                <div />
+              </div>
 
-            <LedgerList
-              groups={groups}
-              isError={ledgerQuery.isError}
-              isLoading={ledgerQuery.isLoading}
-              onOpenSession={(sessionId) =>
-                setLedgerSearch({ session_id: sessionId })
-              }
-            />
+              <LedgerList
+                groups={groups}
+                isError={ledgerQuery.isError}
+                isLoading={ledgerQuery.isLoading}
+                onOpenSession={(sessionId) =>
+                  setLedgerSearch({ session_id: sessionId })
+                }
+              />
+            </div>
           </div>
         )}
       </div>

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -843,7 +843,6 @@ function RailDoc({ doc }: { doc: LedgerDocRef }) {
       params={{ documentId: doc.document_id }}
       to="/v2/library/$documentId"
     >
-      <span className={styles.docMk} />
       <span className={styles.docDt}>
         <span className={styles.docLink}>{doc.title}</span>
         {doc.state === "stale" ? (

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -22,7 +22,11 @@ import {
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { formatCompactNumber } from "@/components/V2/Agents/formatters"
 import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
-import { V2_PAGE_CONTENT_FIXED, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
+import {
+  V2_PAGE_BODY,
+  V2_PAGE_FRAME,
+  V2_STICKY_HEADER_CLASS,
+} from "@/components/V2/v2PageShell"
 import { cn } from "@/lib/utils"
 
 import styles from "./LedgerPage.module.css"
@@ -360,87 +364,92 @@ export function LedgerPage({
         "-mb-6 bg-background font-sans text-foreground md:-mb-8",
       )}
     >
-      <div className={V2_PAGE_CONTENT_FIXED}>
-        <div className={styles.app}>
-      {selectedSessionId ? (
-        <LedgerDetail
-          detail={detailQuery.data}
-          isError={detailQuery.isError}
-          isLoading={detailQuery.isLoading}
-          onBack={() => setLedgerSearch({ session_id: undefined })}
-        />
-      ) : (
-        <div
-          className={styles.scroll}
-          style={{ "--grid": GRID } as CSSProperties}
-        >
-          <div className={styles.stickyHead}>
-            <header className={styles.head}>
-              <div>
-                <div className={styles.crumb}>
-                  Ledger
-                  {typeof ledgerQuery.data?.total === "number"
-                    ? ` · ${ledgerQuery.data.total} sessions archived`
-                    : ""}
+      <div className={V2_PAGE_BODY}>
+        {selectedSessionId ? (
+          <div className={styles.app}>
+            <LedgerDetail
+              detail={detailQuery.data}
+              isError={detailQuery.isError}
+              isLoading={detailQuery.isLoading}
+              onBack={() => setLedgerSearch({ session_id: undefined })}
+            />
+          </div>
+        ) : (
+          <div
+            className={styles.app}
+            style={{ "--grid": GRID } as CSSProperties}
+          >
+            <div
+              className={cn(
+                V2_STICKY_HEADER_CLASS,
+                "border-b-0 pb-0",
+                "flex flex-col gap-6",
+              )}
+            >
+              <header className={styles.head}>
+                <div>
+                  <div className={styles.crumb}>
+                    Ledger
+                    {typeof ledgerQuery.data?.total === "number"
+                      ? ` · ${ledgerQuery.data.total} sessions archived`
+                      : ""}
+                  </div>
+                  <h1 className={styles.h1}>Ledger</h1>
                 </div>
-                <h1 className={styles.h1}>Ledger</h1>
-              </div>
-              <div className={styles.tools}>
-                <form className={styles.search} onSubmit={onSearchSubmit}>
-                  <input
-                    className={styles.searchInput}
-                    placeholder="/ Search transcripts, commands, files…"
-                    value={search}
-                    onChange={(event) => setSearch(event.target.value)}
-                    aria-label="Search the ledger"
-                  />
-                </form>
-              </div>
-            </header>
+                <div className={styles.tools}>
+                  <form className={styles.search} onSubmit={onSearchSubmit}>
+                    <input
+                      className={styles.searchInput}
+                      placeholder="/ Search transcripts, commands, files…"
+                      value={search}
+                      onChange={(event) => setSearch(event.target.value)}
+                      aria-label="Search the ledger"
+                    />
+                  </form>
+                </div>
+              </header>
 
-            <ScopeFilterBar
-              className="mb-6"
-              items={HARNESS_OPTIONS.map((option) => ({
-                key: option.value,
-                label: option.label,
-              }))}
-              active={client ?? "all"}
-              onChange={(value) =>
-                setLedgerSearch({
-                  client: value === "all" ? undefined : value,
-                  session_id: undefined,
-                })
-              }
-              sortLabel={`recent ${sort === "newest" ? "↓" : "↑"}`}
-              onSortToggle={() =>
-                setLedgerSearch({
-                  session_id: undefined,
-                  sort: sort === "newest" ? "oldest" : undefined,
-                })
+              <ScopeFilterBar
+                items={HARNESS_OPTIONS.map((option) => ({
+                  key: option.value,
+                  label: option.label,
+                }))}
+                active={client ?? "all"}
+                onChange={(value) =>
+                  setLedgerSearch({
+                    client: value === "all" ? undefined : value,
+                    session_id: undefined,
+                  })
+                }
+                sortLabel={`recent ${sort === "newest" ? "↓" : "↑"}`}
+                onSortToggle={() =>
+                  setLedgerSearch({
+                    session_id: undefined,
+                    sort: sort === "newest" ? "oldest" : undefined,
+                  })
+                }
+              />
+            </div>
+
+            <div className={styles.cols}>
+              <div>Time</div>
+              <div>Session</div>
+              <div>Harness · agent</div>
+              <div>Activity</div>
+              <div>Referenced by</div>
+              <div />
+            </div>
+
+            <LedgerList
+              groups={groups}
+              isError={ledgerQuery.isError}
+              isLoading={ledgerQuery.isLoading}
+              onOpenSession={(sessionId) =>
+                setLedgerSearch({ session_id: sessionId })
               }
             />
           </div>
-
-          <div className={styles.cols}>
-            <div>Time</div>
-            <div>Session</div>
-            <div>Harness · agent</div>
-            <div>Activity</div>
-            <div>Referenced by</div>
-            <div />
-          </div>
-
-          <LedgerList
-            groups={groups}
-            isError={ledgerQuery.isError}
-            isLoading={ledgerQuery.isLoading}
-            onOpenSession={(sessionId) =>
-              setLedgerSearch({ session_id: sessionId })
-            }
-          />
-        </div>
-      )}
-        </div>
+        )}
       </div>
     </section>
   )

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -211,6 +211,15 @@ function whoLabel(row: LedgerSessionRow): string {
   return row.actor_handle ?? row.actor_name ?? "Unknown"
 }
 
+function userDisplayLabel(row: LedgerSessionRow): string {
+  const handle = row.actor_handle?.trim()
+  const name = row.actor_name?.trim()
+  if (handle && name && handle !== name) {
+    return `${handle} · ${name}`
+  }
+  return whoLabel(row)
+}
+
 function eventWho(event: LedgerTranscriptEvent, row: LedgerSessionRow): string {
   return event.who ?? whoLabel(row)
 }
@@ -762,7 +771,7 @@ function SessionRail({ detail }: { detail: LedgerSessionDetail }) {
     <aside className={styles.rail}>
       <div className={cn(styles.grp, styles.grpFirst)}>Session</div>
       <Kv k="ID" mono value={detail.session_id} />
-      <Kv k="User" value={`${whoLabel(detail)} · ${detail.actor_name}`} />
+      <Kv k="User" value={userDisplayLabel(detail)} />
       <Kv k="Agent" mono value={agentLabel(detail)} />
       <Kv k="Harness" value={harnessWithVersion(detail)} />
       {detail.repo ? <Kv k="Repo" mono value={detail.repo} /> : null}

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -29,8 +29,9 @@ import {
 } from "@/components/ui/table"
 import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
 import {
-  V2_PAGE_CONTENT,
+  V2_PAGE_BODY,
   V2_PAGE_FRAME,
+  V2_STICKY_HEADER_CLASS,
   V2_TAB_EYEBROW_CLASS,
 } from "@/components/V2/v2PageShell"
 import { usePersistentState } from "@/hooks/usePersistentState"
@@ -448,17 +449,31 @@ export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
   }
 
   return (
-    <section className={V2_PAGE_FRAME}>
-      <div className={V2_PAGE_CONTENT}>
-        <div>
-          <h1 className="text-2xl font-semibold">Metrics</h1>
+    <section
+      className={cn(
+        V2_PAGE_FRAME,
+        "-mb-6 bg-background font-sans text-foreground md:-mb-8",
+      )}
+    >
+      <div className={cn(V2_PAGE_BODY, "gap-0 pb-6 md:pb-8")}>
+        <div
+          className={cn(
+            V2_STICKY_HEADER_CLASS,
+            "border-b-0 pb-0",
+            "flex flex-col gap-6",
+          )}
+        >
+          <header>
+            <h1 className="text-2xl font-semibold">Metrics</h1>
+          </header>
+          <ScopeFilterBar
+            items={METRICS_WINDOWS}
+            active={window}
+            onChange={setWindow}
+          />
         </div>
-        <ScopeFilterBar
-          items={METRICS_WINDOWS}
-          active={window}
-          onChange={setWindow}
-        />
 
+        <div className="flex flex-col gap-6">
         {scopedSessionId && (
           <div
             data-testid="metrics-session-filter-banner"
@@ -578,6 +593,7 @@ export function MetricsPage({ currentUser: _currentUser, sessionId }: Props) {
             rows={tokensConsumed?.top_models ?? []}
           />
         </section>
+        </div>
       </div>
     </section>
   )
@@ -650,26 +666,35 @@ function ExperimentalMetricsPage({
   const windowCopy = WINDOW_COPY[window]
 
   return (
-    <div
-      data-testid="metrics-experimental-page"
-      className={`${V2_PAGE_CONTENT} bg-background font-sans text-foreground`}
+    <section
+      className={cn(
+        V2_PAGE_FRAME,
+        "-mb-6 bg-background font-sans text-foreground md:-mb-8",
+      )}
     >
-      <header className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
-        <div>
-          <div className={V2_TAB_EYEBROW_CLASS}>
-            Metrics · {windowCopy.label} · personal
-          </div>
-          <h1 className="mt-2 text-3xl font-semibold leading-none tracking-tight md:text-4xl">
-            You saved{" "}
-            <span className="text-primary">
-              {formatMetricValue(savedTokens, "compact-int")} tokens
-            </span>{" "}
-            {windowCopy.title}.
-          </h1>
+      <div
+        className={cn(V2_PAGE_BODY, "gap-0 pb-6 md:pb-8")}
+        data-testid="metrics-experimental-page"
+      >
+        <div className={cn(V2_STICKY_HEADER_CLASS, "border-b-0 pb-0")}>
+          <header className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+            <div>
+              <div className={V2_TAB_EYEBROW_CLASS}>
+                Metrics · {windowCopy.label} · personal
+              </div>
+              <h1 className="mt-2 text-3xl font-semibold leading-none tracking-tight md:text-4xl">
+                You saved{" "}
+                <span className="text-primary">
+                  {formatMetricValue(savedTokens, "compact-int")} tokens
+                </span>{" "}
+                {windowCopy.title}.
+              </h1>
+            </div>
+            <MetricsTimeRange value={window} onChange={onWindowChange} />
+          </header>
         </div>
-        <MetricsTimeRange value={window} onChange={onWindowChange} />
-      </header>
 
+        <div className="flex flex-col gap-6">
       {metricsQueryIsError && (
         <div className="border border-destructive bg-destructive/10 p-3 text-sm">
           Failed to load metrics. Try again in a moment.
@@ -787,7 +812,9 @@ function ExperimentalMetricsPage({
       />
 
       <MethodologyLink />
-    </div>
+        </div>
+      </div>
+    </section>
   )
 }
 
@@ -815,46 +842,55 @@ function ExperimentalSessionMetrics({
   const lastSeen = sessionSavings?.occurred_at_last
 
   return (
-    <div
-      data-testid="metrics-experimental-session-page"
-      className={`${V2_PAGE_CONTENT} bg-background font-sans text-foreground`}
+    <section
+      className={cn(
+        V2_PAGE_FRAME,
+        "-mb-6 bg-background font-sans text-foreground md:-mb-8",
+      )}
     >
-      <header className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
-        <div>
-          <div className={V2_TAB_EYEBROW_CLASS}>
-            Metrics · session · {sessionShortId}
-          </div>
-          <h1 className="mt-2 text-3xl font-semibold leading-none tracking-tight md:text-4xl">
-            This session saved{" "}
-            <span className="text-primary">
-              {formatMetricValue(tokensSaved?.total, "compact-int")} tokens
-            </span>
-            .
-          </h1>
-          {sessionSavings?.specialist_slug ? (
+      <div
+        className={cn(V2_PAGE_BODY, "gap-0 pb-6 md:pb-8")}
+        data-testid="metrics-experimental-session-page"
+      >
+        <div className={cn(V2_STICKY_HEADER_CLASS, "border-b-0 pb-0")}>
+          <header className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+            <div>
+              <div className={V2_TAB_EYEBROW_CLASS}>
+                Metrics · session · {sessionShortId}
+              </div>
+              <h1 className="mt-2 text-3xl font-semibold leading-none tracking-tight md:text-4xl">
+                This session saved{" "}
+                <span className="text-primary">
+                  {formatMetricValue(tokensSaved?.total, "compact-int")} tokens
+                </span>
+                .
+              </h1>
+              {sessionSavings?.specialist_slug ? (
+                <Link
+                  to="/v2/agents/$slug"
+                  params={{ slug: sessionSavings.specialist_slug }}
+                  className="mt-3 inline-flex items-center gap-1.5 border border-border px-2.5 py-1 font-mono text-xs uppercase tracking-[0.12em] text-foreground hover:bg-muted"
+                >
+                  Selected profile:{" "}
+                  <span className="font-semibold normal-case tracking-normal">
+                    {sessionSavings.specialist_name ??
+                      sessionSavings.specialist_slug}
+                  </span>
+                  <span aria-hidden>→</span>
+                </Link>
+              ) : null}
+            </div>
             <Link
-              to="/v2/agents/$slug"
-              params={{ slug: sessionSavings.specialist_slug }}
-              className="mt-3 inline-flex items-center gap-1.5 border border-border px-2.5 py-1 font-mono text-xs uppercase tracking-[0.12em] text-foreground hover:bg-muted"
+              to="/v2/metrics"
+              search={{}}
+              className="border border-border px-3 py-2 text-sm font-medium text-foreground underline-offset-4 hover:bg-muted"
             >
-              Selected profile:{" "}
-              <span className="font-semibold normal-case tracking-normal">
-                {sessionSavings.specialist_name ??
-                  sessionSavings.specialist_slug}
-              </span>
-              <span aria-hidden>→</span>
+              View all metrics →
             </Link>
-          ) : null}
+          </header>
         </div>
-        <Link
-          to="/v2/metrics"
-          search={{}}
-          className="border border-border px-3 py-2 text-sm font-medium text-foreground underline-offset-4 hover:bg-muted"
-        >
-          View all metrics →
-        </Link>
-      </header>
 
+        <div className="flex flex-col gap-6">
       <section className="grid border border-border bg-background text-foreground lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
         <div className="px-5 py-6 md:px-7">
           <div className="font-mono text-xs uppercase tracking-[0.18em] opacity-70">
@@ -933,7 +969,9 @@ function ExperimentalSessionMetrics({
       />
 
       <MethodologyLink />
-    </div>
+        </div>
+      </div>
+    </section>
   )
 }
 


### PR DESCRIPTION
## Summary
- **Ledger index:** Match Library scroll chrome (`V2_PAGE_BODY` + sticky header), remove gap below filter bar, add horizontal row padding, and align margins with other v2 pages.
- **Ledger session detail:** Remove excess bottom scroll padding; fix duplicate "Alex Lee · Alex Lee" user label; remove purple accent bars on referenced-by links.
- **Metrics:** Sticky hero header (standard + experimental views), flush content below header, scroll-end bottom padding, shell bottom bleed.

## Test plan
- [ ] `/v2/ledger` — filter bar sticks; no gap below tabs; rows have side padding; margins match Profiles
- [ ] `/v2/ledger?session_id=…` — no duplicate user name; no purple bars on referenced docs; no dead bottom scroll gap
- [ ] `/v2/metrics` (experimental mode) — hero sticks on scroll; content flush under header; comfortable bottom padding when scrolled to end


Made with [Cursor](https://cursor.com)