### PR TITLE
TF-219: use public Taskforce hook installer

### DIFF
--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -114,11 +114,16 @@ function buildMcpConfigSnippet(hostedMcpUrl: string): string {
   ].join("\n")
 }
 
-function buildClaudeCodeConnectSnippet(mcpToken: string): string {
+function buildClaudeCodeConnectSnippet(
+  mcpToken: string,
+  backendUrl: string,
+): string {
+  const installerUrl = `${backendUrl.replace(/\/$/, "")}/api/v1/v2/taskforce/install.sh`
+
   return [
     `printf '%s\\n' '${mcpToken}' > ~/.taskforce_mcp_token && \\`,
     "chmod 600 ~/.taskforce_mcp_token && \\",
-    "curl -fsSL https://raw.githubusercontent.com/al-exe/EnderAI/main/scripts/taskforce-hooks/install.sh | bash",
+    `curl -fsSL '${installerUrl}' | bash`,
   ].join("\n")
 }
 
@@ -440,7 +445,7 @@ const ConnectAgent = () => {
     ? buildPersistentShellSnippet(mcpToken)
     : null
   const claudeCodeConnectSnippet = hasFreshToken
-    ? buildClaudeCodeConnectSnippet(mcpToken)
+    ? buildClaudeCodeConnectSnippet(mcpToken, import.meta.env.VITE_API_URL)
     : null
   const reconnectClientSnippet =
     "# Start a fresh terminal, then restart or reconnect your AI client after saving the MCP config."

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -713,8 +713,10 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
     "chmod 600 ~/.taskforce_mcp_token",
   )
   await expect(claudeCodeSetup).toContainText(
-    "scripts/taskforce-hooks/install.sh | bash",
+    "https://enderai-backend.onrender.com/api/v1/v2/taskforce/install.sh",
   )
+  await expect(claudeCodeSetup).not.toContainText("github.com")
+  await expect(claudeCodeSetup).not.toContainText("raw.githubusercontent.com")
   await expect(page.getByText("3. Advanced MCP setup")).toBeVisible()
   await expect(
     page.getByRole("tab", { name: "AI-assisted MCP" }),


### PR DESCRIPTION
## Summary
- replace the private GitHub raw installer URL in Connect Agent with the public backend installer endpoint derived from `VITE_API_URL`
- keep the onboarding command compact: save token, set permissions, then pipe the backend installer to Bash
- assert the production backend URL and reject GitHub dependencies in the browser test

## Why
The previous command 404ed for external users because `al-exe/EnderAI` is private.

## Validation
- `bun run build`
- Biome checks pass
- focused Connect Agent Chromium test passes with `VITE_API_URL=https://enderai-backend.onrender.com`
- `git diff --check`

Depends on the backend installer PR in al-exe/EnderAI.
Epic: [TF-219](https://alexlee4190.atlassian.net/browse/TF-219)

A follow-up Jira story was requested under TF-219, but this environment has no authenticated Atlassian write tool; the PR is linked to the epic directly.
