### PR TITLE
Ledger harness filters, Other tab, and sticky column headers

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -42,6 +42,7 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  --ledger-row-padding-inline: 1rem;
   background: var(--tf-bg);
   color: var(--tf-fg);
   font-family: var(--font-sans);
@@ -63,7 +64,7 @@
 
 /* Extra inset for table text inside the shared v2 page padding. */
 .listShell {
-  --ledger-row-padding-inline: 1rem;
+  min-width: 0;
 }
 
 .head {
@@ -156,7 +157,6 @@
   grid-template-columns: var(--grid);
   gap: 16px;
   padding: 11px var(--ledger-row-padding-inline, 1rem);
-  border-top: 1px solid var(--tf-border);
   border-bottom: 1px solid var(--tf-border);
   font-family: var(--font-mono);
   font-size: 12px;

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -419,38 +419,39 @@ export function LedgerPage({
                 </div>
               </header>
 
-              <ScopeFilterBar
-                items={HARNESS_OPTIONS.map((option) => ({
-                  key: option.value,
-                  label: option.label,
-                }))}
-                active={client ?? "all"}
-                onChange={(value) =>
-                  setLedgerSearch({
-                    client: value === "all" ? undefined : value,
-                    session_id: undefined,
-                  })
-                }
-                sortLabel={`recent ${sort === "newest" ? "↓" : "↑"}`}
-                onSortToggle={() =>
-                  setLedgerSearch({
-                    session_id: undefined,
-                    sort: sort === "newest" ? "oldest" : undefined,
-                  })
-                }
-              />
+              <div>
+                <ScopeFilterBar
+                  items={HARNESS_OPTIONS.map((option) => ({
+                    key: option.value,
+                    label: option.label,
+                  }))}
+                  active={client ?? "all"}
+                  onChange={(value) =>
+                    setLedgerSearch({
+                      client: value === "all" ? undefined : value,
+                      session_id: undefined,
+                    })
+                  }
+                  sortLabel={`recent ${sort === "newest" ? "↓" : "↑"}`}
+                  onSortToggle={() =>
+                    setLedgerSearch({
+                      session_id: undefined,
+                      sort: sort === "newest" ? "oldest" : undefined,
+                    })
+                  }
+                />
+                <div className={styles.cols}>
+                  <div>Time</div>
+                  <div>Session</div>
+                  <div>Harness · agent</div>
+                  <div>Activity</div>
+                  <div>Referenced by</div>
+                  <div />
+                </div>
+              </div>
             </div>
 
             <div className={styles.listShell}>
-              <div className={styles.cols}>
-                <div>Time</div>
-                <div>Session</div>
-                <div>Harness · agent</div>
-                <div>Activity</div>
-                <div>Referenced by</div>
-                <div />
-              </div>
-
               <LedgerList
                 groups={groups}
                 isError={ledgerQuery.isError}

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -40,10 +40,11 @@ const CLIENT_LABELS: Record<string, string> = {
 }
 
 const HARNESS_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: "all", label: "All harnesses" },
+  { value: "all", label: "All" },
   { value: "claude-code", label: "Claude Code" },
   { value: "codex", label: "Codex" },
   { value: "cursor", label: "Cursor" },
+  { value: "other", label: "Other" },
 ]
 
 type LedgerSort = "newest" | "oldest"
@@ -66,7 +67,7 @@ type DayGroup = {
 
 function clientLabel(value: string | null | undefined): string {
   if (!value) return "Unknown"
-  return CLIENT_LABELS[value] ?? value
+  return CLIENT_LABELS[value] ?? "Other"
 }
 
 function cleanLedgerSearch(filters: LedgerSearchFilters): LedgerSearchFilters {


### PR DESCRIPTION
## Summary
- Rename harness filter tabs to All, Claude Code, Codex, Cursor, Other.
- Show unknown harnesses as Other in row labels.
- Pin Time / Session / Harness · agent / Activity / Referenced by in the sticky header below the filter bar.

## Test plan
- [ ] `/v2/ledger` — filter labels match spec; column headers stay pinned on scroll
- [ ] Other tab filters non-standard harnesses (requires backend `client=other` support)


Made with [Cursor](https://cursor.com)