### PR TITLE
Fleet page polish: sticky header, nav order, copy

### DIFF
--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -178,7 +178,7 @@ function AgentCard({
             ))}
             <DropdownMenuItem onSelect={() => onCreateSession(agent)}>
               <Plus />
-              New Fleet session
+              New fleet
             </DropdownMenuItem>
             {agent.fleet_session_id && (
               <>
@@ -645,7 +645,8 @@ export function FleetPage() {
 
   const fleetSessions = fleetQuery.data?.fleet_sessions ?? []
   const unassigned = fleetQuery.data?.unassigned ?? []
-  const totalAgents =
+  const activeSessionCount = fleetSessions.length
+  const activeAgentCount =
     unassigned.length +
     fleetSessions.reduce((total, fleet) => total + fleet.agents.length, 0)
 
@@ -668,7 +669,11 @@ export function FleetPage() {
         <div className={V2_STICKY_HEADER_CLASS}>
           <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div>
-              <p className={V2_TAB_EYEBROW_CLASS}>Active agent control panel</p>
+              <p className={V2_TAB_EYEBROW_CLASS}>
+                Fleet · {activeSessionCount} active session
+                {activeSessionCount === 1 ? "" : "s"} · {activeAgentCount}{" "}
+                active agent{activeAgentCount === 1 ? "" : "s"}
+              </p>
               <h1 className="mt-1 text-2xl font-semibold tracking-tight">
                 Fleet
               </h1>
@@ -681,7 +686,7 @@ export function FleetPage() {
               }}
             >
               <Plus />
-              New Fleet session
+              New fleet
             </Button>
           </header>
         </div>
@@ -718,7 +723,7 @@ export function FleetPage() {
               Try again
             </Button>
           </div>
-        ) : totalAgents === 0 ? (
+        ) : activeAgentCount === 0 ? (
           <div className="flex flex-col items-start gap-4 border bg-card p-6">
             <div>
               <h2 className="font-medium text-foreground">

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -658,10 +658,15 @@ export function FleetPage() {
   }
 
   return (
-    <div className={V2_PAGE_FRAME}>
-      <div className={V2_PAGE_BODY}>
-        <header className={V2_STICKY_HEADER_CLASS}>
-          <div className="flex flex-wrap items-start justify-between gap-4">
+    <section
+      className={cn(
+        V2_PAGE_FRAME,
+        "-mb-6 bg-background font-sans text-foreground md:-mb-8",
+      )}
+    >
+      <div className={cn(V2_PAGE_BODY, "gap-0 pb-6 md:pb-8")}>
+        <div className={V2_STICKY_HEADER_CLASS}>
+          <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div>
               <p className={V2_TAB_EYEBROW_CLASS}>Active agent control panel</p>
               <h1 className="mt-1 text-2xl font-semibold tracking-tight">
@@ -669,6 +674,7 @@ export function FleetPage() {
               </h1>
             </div>
             <Button
+              className="w-fit"
               onClick={() => {
                 setMutationError(null)
                 setCreateRequest({})
@@ -677,9 +683,10 @@ export function FleetPage() {
               <Plus />
               New Fleet session
             </Button>
-          </div>
-        </header>
+          </header>
+        </div>
 
+        <div className="flex flex-col gap-6">
         {Boolean(mutationError) && (
           <div className="border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
             {errorMessage(mutationError)}
@@ -799,6 +806,7 @@ export function FleetPage() {
             ))}
           </div>
         )}
+        </div>
       </div>
 
       <CreateFleetDialog
@@ -824,6 +832,6 @@ export function FleetPage() {
         {detail?.kind === "agent" && <AgentDetail agent={detail.agent} />}
         {detail?.kind === "fleet" && <FleetDetail fleet={detail.fleet} />}
       </Sheet>
-    </div>
+    </section>
   )
 }

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -667,10 +667,6 @@ export function FleetPage() {
               <h1 className="mt-1 text-2xl font-semibold tracking-tight">
                 Fleet
               </h1>
-              <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-                Group active Claude Code sessions and inspect the Taskforce
-                documents each one contributed.
-              </p>
             </div>
             <Button
               onClick={() => {

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -64,13 +64,10 @@ type TaskforceNavItem = {
   path: string
 }
 
-// Ordered by the pipeline's distillation altitude (TF-206): most-distilled
-// first (Profiles ← Library ← Ledger), then Metrics as the rollup. Upgrade
-// stays at the bottom.
 const taskforceItems: TaskforceNavItem[] = [
+  { icon: LayoutGrid, title: "Fleet", path: "/v2/fleet" },
   { icon: Bot, title: "Profiles", path: "/v2/agents" },
   { icon: BookOpen, title: "Library", path: "/v2/library" },
-  { icon: LayoutGrid, title: "Fleet", path: "/v2/fleet" },
   { icon: ReceiptText, title: "Ledger", path: "/v2/ledger" },
   { icon: LineChart, title: "Metrics", path: "/v2/metrics" },
   { icon: Rocket, title: "Upgrade", path: "/v2/pricing" },


### PR DESCRIPTION
## Summary
- Align Fleet page shell with Library/Metrics sticky header pattern (divider, margins, scroll-end padding)
- Remove subtitle under the Fleet title; show live active session and agent counts in the eyebrow
- Rename create CTA to **New fleet** (header button and agent dropdown)
- Move **Fleet** to the top of the sidebar nav

## Test plan
- [x] Fleet header sticks while scrolling with horizontal divider aligned to page margins
- [x] Eyebrow shows correct session/agent counts with pluralization
- [x] **New fleet** opens create dialog from header and agent move menu
- [x] Fleet appears first in sidebar above Profiles


Made with [Cursor](https://cursor.com)