### PR TITLE
[codex] Add Fleet tab frontend

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -1,0 +1,364 @@
+.page {
+  --fleet-grid: 176px minmax(0, 1.05fr) minmax(0, 1.1fr) 48px;
+  --fleet-hairline: color-mix(
+    in srgb,
+    var(--foreground) 10%,
+    var(--background)
+  );
+  --fleet-faint: color-mix(
+    in srgb,
+    var(--muted-foreground) 66%,
+    var(--background)
+  );
+
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.wrap {
+  width: 100%;
+  max-width: 1056px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.pageHeader {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.pageHeader h1 {
+  margin: 4px 0 0;
+  font-size: 24px;
+  line-height: 2rem;
+  font-weight: 600;
+  letter-spacing: -0.018em;
+}
+
+.overview {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 24px;
+  padding-bottom: 12px;
+}
+
+.summary {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+
+.summary strong {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+.liveLabel {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.liveLabel svg {
+  width: 13px;
+  height: 13px;
+  color: var(--primary);
+}
+
+.sessionList {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-bottom: 24px;
+}
+
+.session {
+  border: 1px solid var(--border);
+  background: var(--background);
+  padding: 20px 22px;
+}
+
+.sessionHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.sessionTitle {
+  min-width: 0;
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.4;
+  font-weight: 600;
+  letter-spacing: -0.014em;
+}
+
+.sessionElapsed {
+  margin-left: auto;
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.sessionSummary {
+  margin: 5px 0 0;
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+
+.instances {
+  margin-top: 16px;
+}
+
+.columns,
+.instance {
+  display: grid;
+  grid-template-columns: var(--fleet-grid);
+  gap: 18px;
+}
+
+.columns {
+  padding-bottom: 9px;
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.alignRight {
+  text-align: right;
+}
+
+.instance {
+  align-items: baseline;
+  padding: 13px 0;
+  border-top: 1px solid var(--fleet-hairline);
+}
+
+.identity {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 9px;
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+  transform: translateY(-1px);
+  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten status indicators. */
+  border-radius: 999px !important;
+  background: var(--fleet-faint);
+}
+
+.runningDot {
+  background: var(--primary);
+  animation: fleet-ping 2s ease-out infinite;
+}
+
+.queuedDot {
+  border: 1.5px solid var(--fleet-faint);
+  background: transparent;
+}
+
+.modelBlock,
+.workingOn,
+.documents {
+  min-width: 0;
+}
+
+.model {
+  overflow: hidden;
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status {
+  margin-top: 4px;
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.attentionStatus {
+  color: var(--foreground);
+  font-weight: 500;
+}
+
+.workingOn {
+  color: var(--foreground);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.workingOn code {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+}
+
+.muted {
+  color: var(--fleet-faint);
+}
+
+.documents {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.document {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.documentTitle {
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.documentMode {
+  flex-shrink: 0;
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.noDocuments {
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.elapsed {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+@keyframes fleet-ping {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (max-width: 960px) {
+  .page {
+    --fleet-grid: 155px minmax(0, 1fr) minmax(0, 0.9fr) 40px;
+  }
+}
+
+@media (max-width: 760px) {
+  .wrap {
+    padding: 20px 16px;
+  }
+
+  .overview {
+    align-items: flex-start;
+  }
+
+  .liveLabel {
+    display: none;
+  }
+
+  .session {
+    padding: 18px;
+  }
+
+  .columns {
+    display: none;
+  }
+
+  .instance {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px 16px;
+    padding: 16px 0;
+  }
+
+  .identity {
+    grid-column: 1;
+  }
+
+  .elapsed {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .workingOn,
+  .documents {
+    grid-column: 1 / -1;
+    padding-left: 15px;
+  }
+}
+
+@media (max-width: 520px) {
+  .pageHeader {
+    align-items: flex-start;
+  }
+
+  .eyebrow {
+    letter-spacing: 0.12em;
+  }
+
+  .overview {
+    margin-top: 20px;
+  }
+
+  .sessionHeader {
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .runningDot {
+    animation: none;
+  }
+}

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -1,0 +1,305 @@
+import { Link } from "@tanstack/react-router"
+import { RadioTower } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import styles from "./FleetPage.module.css"
+
+type FleetInstanceStatus = "running" | "needs-review" | "idle" | "queued"
+type FleetDocumentMode = "reading" | "writing"
+
+type FleetDocument = {
+  title: string
+  mode: FleetDocumentMode
+}
+
+type FleetInstance = {
+  id: string
+  model: string
+  status: FleetInstanceStatus
+  workingOn: React.ReactNode
+  documents: FleetDocument[]
+  elapsed: string
+}
+
+type FleetSession = {
+  id: string
+  title: string
+  elapsed: string
+  instances: FleetInstance[]
+}
+
+const STATUS_LABELS: Record<FleetInstanceStatus, string> = {
+  running: "Running",
+  "needs-review": "Needs review",
+  idle: "Idle",
+  queued: "Queued",
+}
+
+const FLEET_SESSIONS: FleetSession[] = [
+  {
+    id: "stripe-tax",
+    title: "Stripe tax rollout — annual plans",
+    elapsed: "22m",
+    instances: [
+      {
+        id: "stripe-tax-opus",
+        model: "claude-opus-4.1",
+        status: "running",
+        workingOn: (
+          <>
+            Wiring <code>automatic_tax</code> onto the subscription create path
+          </>
+        ),
+        documents: [
+          { title: "Stripe checkout wiring", mode: "writing" },
+          { title: "Billing edge cases", mode: "reading" },
+        ],
+        elapsed: "12m",
+      },
+      {
+        id: "stripe-tax-sonnet-tests",
+        model: "claude-sonnet-4",
+        status: "running",
+        workingOn: (
+          <>
+            Running the <code>billing/dedupe</code> integration suite
+          </>
+        ),
+        documents: [{ title: "Webhook idempotency notes", mode: "reading" }],
+        elapsed: "6m",
+      },
+      {
+        id: "stripe-tax-sonnet-review",
+        model: "claude-sonnet-4",
+        status: "needs-review",
+        workingOn: "Drafted the tax-engine decision note",
+        documents: [{ title: "Tax engine decision", mode: "writing" }],
+        elapsed: "18m",
+      },
+    ],
+  },
+  {
+    id: "clerk-migration",
+    title: "Auth0 → Clerk migration window",
+    elapsed: "1h 04m",
+    instances: [
+      {
+        id: "clerk-migration-opus",
+        model: "claude-opus-4.1",
+        status: "running",
+        workingOn: (
+          <>
+            Re-shaping <code>org_id</code> + <code>role</code> for Clerk session
+            tokens
+          </>
+        ),
+        documents: [{ title: "Auth0 → Clerk plan", mode: "reading" }],
+        elapsed: "41m",
+      },
+      {
+        id: "clerk-migration-sonnet",
+        model: "claude-sonnet-4",
+        status: "idle",
+        workingOn: (
+          <>
+            Backfilling <code>tenant_id</code> RLS policies — needs staging
+            creds
+          </>
+        ),
+        documents: [{ title: "Postgres RLS audit", mode: "writing" }],
+        elapsed: "23m",
+      },
+    ],
+  },
+  {
+    id: "mcp-oauth",
+    title: "Hosted MCP OAuth rotation fix",
+    elapsed: "8m",
+    instances: [
+      {
+        id: "mcp-oauth-opus",
+        model: "claude-opus-4.1",
+        status: "running",
+        workingOn: (
+          <>
+            Clearing the cached credential on <code>invalid_grant</code>,
+            forcing re-issue
+          </>
+        ),
+        documents: [{ title: "Hosted MCP OAuth rotation", mode: "writing" }],
+        elapsed: "8m",
+      },
+    ],
+  },
+  {
+    id: "tailwind-tokens",
+    title: "Tailwind v4 token sweep",
+    elapsed: "queued",
+    instances: [
+      {
+        id: "tailwind-tokens-sonnet",
+        model: "claude-sonnet-4",
+        status: "queued",
+        workingOn: "Renaming theme tokens to the v4 map",
+        documents: [{ title: "Tailwind v4 token map", mode: "reading" }],
+        elapsed: "—",
+      },
+    ],
+  },
+]
+
+function sessionSummary(instances: FleetInstance[]): string {
+  const counts = instances.reduce<Record<FleetInstanceStatus, number>>(
+    (result, instance) => {
+      result[instance.status] += 1
+      return result
+    },
+    { running: 0, "needs-review": 0, idle: 0, queued: 0 },
+  )
+  const details = (
+    [
+      ["running", counts.running],
+      ["needs review", counts["needs-review"]],
+      ["idle", counts.idle],
+      ["queued", counts.queued],
+    ] as const
+  )
+    .filter(([, count]) => count > 0)
+    .map(([label, count]) => `${count} ${label}`)
+
+  return `${instances.length} ${instances.length === 1 ? "instance" : "instances"} · ${details.join(" · ")}`
+}
+
+function FleetInstanceRow({ instance }: { instance: FleetInstance }) {
+  const isMuted = instance.status === "idle" || instance.status === "queued"
+
+  return (
+    <div className={styles.instance}>
+      <div className={styles.identity}>
+        <span
+          className={cn(
+            styles.statusDot,
+            instance.status === "running" && styles.runningDot,
+            instance.status === "queued" && styles.queuedDot,
+          )}
+          aria-hidden="true"
+        />
+        <div className={styles.modelBlock}>
+          <div className={styles.model}>{instance.model}</div>
+          <div
+            className={cn(
+              styles.status,
+              (instance.status === "needs-review" ||
+                instance.status === "idle") &&
+                styles.attentionStatus,
+            )}
+          >
+            {STATUS_LABELS[instance.status]}
+          </div>
+        </div>
+      </div>
+
+      <div className={cn(styles.workingOn, isMuted && styles.muted)}>
+        {instance.workingOn}
+      </div>
+
+      <div className={styles.documents}>
+        {instance.documents.length > 0 ? (
+          instance.documents.map((document) => (
+            <div
+              className={styles.document}
+              key={`${instance.id}-${document.title}`}
+            >
+              <span className={styles.documentTitle}>{document.title}</span>
+              <span className={styles.documentMode}>{document.mode}</span>
+            </div>
+          ))
+        ) : (
+          <span className={styles.noDocuments}>No documents</span>
+        )}
+      </div>
+
+      <div className={styles.elapsed}>{instance.elapsed}</div>
+    </div>
+  )
+}
+
+function FleetSessionCard({ session }: { session: FleetSession }) {
+  return (
+    <section className={styles.session} aria-labelledby={`${session.id}-title`}>
+      <header className={styles.sessionHeader}>
+        <h2 id={`${session.id}-title`} className={styles.sessionTitle}>
+          {session.title}
+        </h2>
+        <span className={styles.sessionElapsed}>{session.elapsed}</span>
+      </header>
+      <p className={styles.sessionSummary}>
+        {sessionSummary(session.instances)}
+      </p>
+
+      <div className={styles.instances}>
+        <div className={styles.columns} aria-hidden="true">
+          <div>Instance</div>
+          <div>Working on</div>
+          <div>Documents</div>
+          <div className={styles.alignRight}>Time</div>
+        </div>
+        {session.instances.map((instance) => (
+          <FleetInstanceRow key={instance.id} instance={instance} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export function FleetPage() {
+  const instanceCount = FLEET_SESSIONS.reduce(
+    (total, session) => total + session.instances.length,
+    0,
+  )
+  const runningCount = FLEET_SESSIONS.reduce(
+    (total, session) =>
+      total +
+      session.instances.filter((instance) => instance.status === "running")
+        .length,
+    0,
+  )
+
+  return (
+    <section className={styles.page}>
+      <div className={styles.wrap}>
+        <header className={styles.pageHeader}>
+          <div>
+            <p className={styles.eyebrow}>
+              Fleet · {FLEET_SESSIONS.length} active sessions
+            </p>
+            <h1>Fleet</h1>
+          </div>
+          <Button asChild size="sm">
+            <Link to="/v2/settings" search={{ tab: "connect-agent" }}>
+              + New session
+            </Link>
+          </Button>
+        </header>
+
+        <div className={styles.overview}>
+          <div className={styles.summary}>
+            <strong>{FLEET_SESSIONS.length}</strong> sessions ·{" "}
+            <strong>{instanceCount}</strong> instances ·{" "}
+            <strong>{runningCount}</strong> running
+          </div>
+          <div className={styles.liveLabel}>
+            <RadioTower aria-hidden="true" />
+            Live activity
+          </div>
+        </div>
+
+        <div className={styles.sessionList}>
+          {FLEET_SESSIONS.map((session) => (
+            <FleetSessionCard key={session.id} session={session} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -13,6 +13,7 @@ import {
   GripHorizontal,
   LineChart,
   MessageCircle,
+  RadioTower,
   ReceiptText,
   Rocket,
   Search,
@@ -69,6 +70,7 @@ type TaskforceNavItem = {
 // on top as the entry point; Upgrade stays at the bottom.
 const taskforceItems: TaskforceNavItem[] = [
   { icon: Search, title: "Search", path: "/v2/search" },
+  { icon: RadioTower, title: "Fleet", path: "/v2/fleet" },
   { icon: Bot, title: "Profiles", path: "/v2/agents" },
   { icon: BookOpen, title: "Library", path: "/v2/library" },
   { icon: ReceiptText, title: "Ledger", path: "/v2/ledger" },

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as V2MetricsRouteImport } from './routes/v2/metrics'
 import { Route as V2LibraryRouteImport } from './routes/v2/library'
 import { Route as V2LedgerRouteImport } from './routes/v2/ledger'
 import { Route as V2HomeRouteImport } from './routes/v2/home'
+import { Route as V2FleetRouteImport } from './routes/v2/fleet'
 import { Route as V2AgentsRouteImport } from './routes/v2/agents'
 import { Route as V2AdminRouteImport } from './routes/v2/admin'
 import { Route as LayoutTopicsRouteImport } from './routes/_layout/topics'
@@ -122,6 +123,11 @@ const V2HomeRoute = V2HomeRouteImport.update({
   path: '/home',
   getParentRoute: () => V2Route,
 } as any)
+const V2FleetRoute = V2FleetRouteImport.update({
+  id: '/fleet',
+  path: '/fleet',
+  getParentRoute: () => V2Route,
+} as any)
 const V2AgentsRoute = V2AgentsRouteImport.update({
   id: '/agents',
   path: '/agents',
@@ -195,6 +201,7 @@ export interface FileRoutesByFullPath {
   '/topics': typeof LayoutTopicsRoute
   '/v2/admin': typeof V2AdminRoute
   '/v2/agents': typeof V2AgentsRouteWithChildren
+  '/v2/fleet': typeof V2FleetRoute
   '/v2/home': typeof V2HomeRoute
   '/v2/ledger': typeof V2LedgerRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
@@ -223,6 +230,7 @@ export interface FileRoutesByTo {
   '/topics': typeof LayoutTopicsRoute
   '/v2/admin': typeof V2AdminRoute
   '/v2/agents': typeof V2AgentsRouteWithChildren
+  '/v2/fleet': typeof V2FleetRoute
   '/v2/home': typeof V2HomeRoute
   '/v2/ledger': typeof V2LedgerRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
@@ -254,6 +262,7 @@ export interface FileRoutesById {
   '/_layout/topics': typeof LayoutTopicsRoute
   '/v2/admin': typeof V2AdminRoute
   '/v2/agents': typeof V2AgentsRouteWithChildren
+  '/v2/fleet': typeof V2FleetRoute
   '/v2/home': typeof V2HomeRoute
   '/v2/ledger': typeof V2LedgerRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
@@ -285,6 +294,7 @@ export interface FileRouteTypes {
     | '/topics'
     | '/v2/admin'
     | '/v2/agents'
+    | '/v2/fleet'
     | '/v2/home'
     | '/v2/ledger'
     | '/v2/library'
@@ -313,6 +323,7 @@ export interface FileRouteTypes {
     | '/topics'
     | '/v2/admin'
     | '/v2/agents'
+    | '/v2/fleet'
     | '/v2/home'
     | '/v2/ledger'
     | '/v2/library'
@@ -343,6 +354,7 @@ export interface FileRouteTypes {
     | '/_layout/topics'
     | '/v2/admin'
     | '/v2/agents'
+    | '/v2/fleet'
     | '/v2/home'
     | '/v2/ledger'
     | '/v2/library'
@@ -489,6 +501,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof V2HomeRouteImport
       parentRoute: typeof V2Route
     }
+    '/v2/fleet': {
+      id: '/v2/fleet'
+      path: '/fleet'
+      fullPath: '/v2/fleet'
+      preLoaderRoute: typeof V2FleetRouteImport
+      parentRoute: typeof V2Route
+    }
     '/v2/agents': {
       id: '/v2/agents'
       path: '/agents'
@@ -629,6 +648,7 @@ const V2MetricsRouteWithChildren = V2MetricsRoute._addFileChildren(
 interface V2RouteChildren {
   V2AdminRoute: typeof V2AdminRoute
   V2AgentsRoute: typeof V2AgentsRouteWithChildren
+  V2FleetRoute: typeof V2FleetRoute
   V2HomeRoute: typeof V2HomeRoute
   V2LedgerRoute: typeof V2LedgerRoute
   V2LibraryRoute: typeof V2LibraryRouteWithChildren
@@ -642,6 +662,7 @@ interface V2RouteChildren {
 const V2RouteChildren: V2RouteChildren = {
   V2AdminRoute: V2AdminRoute,
   V2AgentsRoute: V2AgentsRouteWithChildren,
+  V2FleetRoute: V2FleetRoute,
   V2HomeRoute: V2HomeRoute,
   V2LedgerRoute: V2LedgerRoute,
   V2LibraryRoute: V2LibraryRouteWithChildren,

--- a/src/routes/v2/fleet.tsx
+++ b/src/routes/v2/fleet.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { FleetPage } from "@/components/V2/Fleet/FleetPage"
+
+export const Route = createFileRoute("/v2/fleet")({
+  component: FleetPage,
+  head: () => ({
+    meta: [
+      {
+        title: "Taskforce | Fleet",
+      },
+    ],
+  }),
+})

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -1,0 +1,63 @@
+import { expect, type Page, test } from "@playwright/test"
+
+const currentUser = {
+  id: "user-1",
+  email: "alex@example.com",
+  is_active: true,
+  is_superuser: true,
+  full_name: "Alex Lee",
+  created_at: "2026-03-24T00:00:00Z",
+  v2: true,
+  subscription_tier: "free",
+}
+
+test.use({
+  storageState: {
+    cookies: [],
+    origins: [],
+  },
+})
+
+async function mockTaskforceAuth(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "test-token")
+  })
+
+  await page.route("**/api/v1/users/**", async (route) => {
+    const url = new URL(route.request().url())
+
+    if (url.pathname === "/api/v1/users/me") {
+      await route.fulfill({ json: currentUser })
+      return
+    }
+
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+}
+
+test("Fleet tab shows live sessions and links to agent setup", async ({
+  page,
+}) => {
+  await mockTaskforceAuth(page)
+
+  await page.goto("/v2/fleet")
+
+  await expect(page.getByRole("heading", { name: "Fleet" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "Fleet" })).toHaveAttribute(
+    "data-active",
+    "true",
+  )
+  await expect(
+    page.getByText("4 sessions · 7 instances · 4 running"),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("heading", {
+      name: "Stripe tax rollout — annual plans",
+    }),
+  ).toBeVisible()
+  await expect(page.getByText("Needs review", { exact: true })).toBeVisible()
+  await expect(page.getByText("Queued", { exact: true })).toBeVisible()
+
+  await page.getByRole("link", { name: "+ New session" }).click()
+  await expect(page).toHaveURL(/\/v2\/settings\?tab=connect-agent$/)
+})


### PR DESCRIPTION
## Summary

- add a new `/v2/fleet` route and Fleet sidebar entry
- port the `fleet-clean.html` design into a responsive React/CSS Modules surface
- show typed preview session, instance, status, document, and elapsed-time data
- route **New session** to the existing Connect Agent setup flow
- add focused Playwright coverage for the Fleet route and navigation

## Why

The Fleet design existed only as a standalone HTML mockup. This makes it available inside the production Taskforce shell while keeping the preview data isolated for a future live Fleet API.

## Validation

- `npm run build`
- Biome check on changed files
- `npx playwright test tests/fleet.spec.ts --config=playwright.fleet.config.ts --project=chromium` using a temporary local test config because the repository Playwright config requires unavailable `bun`
- desktop and mobile visual inspection