### PR TITLE
feat(fleet): link an agent to its Ledger session

### DIFF
--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -14,6 +14,7 @@ import {
   MoreHorizontal,
   Pencil,
   Plus,
+  ScrollText,
   Trash2,
 } from "lucide-react"
 import { type FormEvent, useEffect, useMemo, useState } from "react"
@@ -357,6 +358,13 @@ function AgentDetail({ agent }: { agent: TaskforceFleetAgent }) {
           {agent.repo && <Badge variant="secondary">{agent.repo}</Badge>}
           {agent.branch && <Badge variant="secondary">{agent.branch}</Badge>}
         </div>
+
+        <Button asChild className="w-full">
+          <Link to="/v2/ledger" search={{ session_id: agent.session_id }}>
+            <ScrollText />
+            View session in Ledger
+          </Link>
+        </Button>
 
         <section>
           <h3 className="text-sm font-semibold">Current work</h3>


### PR DESCRIPTION
## What
Adds a primary **"View session in Ledger"** button to the Fleet agent detail sheet. It deep-links to `/v2/ledger?session_id=<agent.session_id>`.

## Why
Fleet shows what each live agent is doing, but there was no way to jump from an agent to the full captured session. The agent's `session_id` is the exact key the Ledger groups on, and `LedgerPage` already opens that session's transcript detail directly when `session_id` is in the search params — so this is a one-line bridge between the two surfaces. Click an agent → land on its session.

## Scope
Frontend only; the `/v2/ledger` route and `session_id` filter already exist. `tsc` + `biome` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)