### PR TITLE
[codex] Restyle live Fleet with clean session layout

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -1,0 +1,341 @@
+.pageBody {
+  --fleet-grid: 176px minmax(0, 1.05fr) minmax(0, 1.1fr) 48px;
+  --fleet-hairline: color-mix(
+    in srgb,
+    var(--foreground) 10%,
+    var(--background)
+  );
+  --fleet-faint: color-mix(
+    in srgb,
+    var(--muted-foreground) 66%,
+    var(--background)
+  );
+
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.overview {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 0 12px;
+}
+
+.overviewSummary {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+
+.overviewSummary strong {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+.liveLabel {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.liveLabel::before {
+  width: 6px;
+  height: 6px;
+  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten live indicators. */
+  border-radius: 999px !important;
+  background: var(--primary);
+  content: "";
+  animation: fleet-ping 2s ease-out infinite;
+}
+
+.sessionList {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-bottom: 24px;
+}
+
+.session {
+  border: 1px solid var(--border);
+  background: var(--background);
+  padding: 20px 22px;
+}
+
+.unassignedSession {
+  border-style: dashed;
+}
+
+.sessionHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.sessionOpen {
+  min-width: 0;
+  flex: 1;
+  text-align: left;
+}
+
+.sessionOpen:focus-visible,
+.instanceOpen:focus-visible,
+.workingOn:focus-visible,
+.document:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.sessionTitle {
+  overflow: hidden;
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.4;
+  font-weight: 600;
+  letter-spacing: -0.014em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sessionMenu,
+.instanceMenu {
+  color: var(--fleet-faint);
+}
+
+.renameForm {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  gap: 8px;
+}
+
+.sessionSummary {
+  margin: 5px 0 0;
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+
+.instances {
+  margin-top: 16px;
+}
+
+.columns,
+.instance {
+  display: grid;
+  grid-template-columns: var(--fleet-grid);
+  gap: 18px;
+}
+
+.columns {
+  padding-bottom: 9px;
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.alignRight {
+  text-align: right;
+}
+
+.instance {
+  align-items: baseline;
+  padding: 13px 0;
+  border-top: 1px solid var(--fleet-hairline);
+}
+
+.identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 3px;
+}
+
+.instanceOpen {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: baseline;
+  gap: 9px;
+  text-align: left;
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+  transform: translateY(-1px);
+  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten status indicators. */
+  border-radius: 999px !important;
+  background: var(--fleet-faint);
+}
+
+.runningDot {
+  background: var(--primary);
+  animation: fleet-ping 2s ease-out infinite;
+}
+
+.modelBlock,
+.workingOn,
+.documents {
+  min-width: 0;
+}
+
+.model {
+  overflow: hidden;
+  margin: 0;
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status {
+  margin-top: 4px;
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.idleStatus {
+  color: var(--foreground);
+  font-weight: 500;
+}
+
+.workingOn {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: 12.5px;
+  line-height: 1.45;
+  text-align: left;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.muted {
+  color: var(--fleet-faint);
+}
+
+.documents {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.document {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 8px;
+  color: inherit;
+  text-align: left;
+}
+
+.documentTitle {
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.documentMode {
+  flex-shrink: 0;
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.noDocuments,
+.emptySession {
+  color: var(--fleet-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.elapsed {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.emptySession {
+  padding: 22px 0 8px;
+  border-top: 1px solid var(--fleet-hairline);
+}
+
+@keyframes fleet-ping {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (max-width: 960px) {
+  .pageBody {
+    --fleet-grid: 155px minmax(0, 1fr) minmax(0, 0.9fr) 40px;
+  }
+}
+
+@media (max-width: 760px) {
+  .liveLabel,
+  .columns {
+    display: none;
+  }
+
+  .session {
+    padding: 18px;
+  }
+
+  .instance {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px 16px;
+    padding: 16px 0;
+  }
+
+  .identity {
+    grid-column: 1;
+  }
+
+  .elapsed {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .workingOn,
+  .documents {
+    grid-column: 1 / -1;
+    padding-left: 15px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .liveLabel::before,
+  .runningDot {
+    animation: none;
+  }
+}

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -61,6 +61,7 @@ import {
   V2_TAB_EYEBROW_CLASS,
 } from "@/components/V2/v2PageShell"
 import { cn } from "@/lib/utils"
+import styles from "./FleetPage.module.css"
 
 const FLEET_QUERY_KEY = ["v2-taskforce-fleet"] as const
 
@@ -106,6 +107,28 @@ function agentDisplayName(agent: TaskforceFleetAgent) {
   return agent.title || modelLabel(agent.model_id) || repoLabel(agent)
 }
 
+function agentModelName(agent: TaskforceFleetAgent) {
+  return modelLabel(agent.model_id) || "Connected agent"
+}
+
+function compactPresence(agent: TaskforceFleetAgent) {
+  if (agent.minutes_ago < 1) return "now"
+  return `${agent.minutes_ago}m`
+}
+
+function fleetSummary(agents: TaskforceFleetAgent[]) {
+  const running = agents.filter((agent) => agent.minutes_ago < 5).length
+  const idle = agents.length - running
+  const details = [
+    running > 0 ? `${running} running` : "",
+    idle > 0 ? `${idle} idle` : "",
+  ].filter(Boolean)
+
+  return `${agents.length} ${agents.length === 1 ? "instance" : "instances"}${
+    details.length ? ` · ${details.join(" · ")}` : ""
+  }`
+}
+
 function AgentCard({
   agent,
   fleetSessions,
@@ -124,49 +147,22 @@ function AgentCard({
   const isLive = agent.minutes_ago < 5
 
   return (
-    <article className="border border-border bg-background p-3 shadow-xs">
-      <div className="flex items-start gap-3">
+    <article className={styles.instance}>
+      <div className={styles.identity}>
         <button
           type="button"
-          className="min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className={styles.instanceOpen}
           onClick={() => onOpen(agent)}
         >
-          <div className="flex items-center gap-2">
-            <span
-              className={cn(
-                "size-2 shrink-0 rounded-full",
-                isLive
-                  ? "animate-pulse bg-emerald-500"
-                  : "bg-muted-foreground/50",
-              )}
-              title={presenceLabel(agent)}
-            />
-            <h3 className="truncate text-sm font-semibold">
-              {agentDisplayName(agent)}
-            </h3>
-          </div>
-          <div className="mt-1 flex flex-wrap items-center gap-1.5 font-mono text-[10px] text-muted-foreground">
-            <span>{repoLabel(agent)}</span>
-            {agent.branch && (
-              <>
-                <span aria-hidden>·</span>
-                <span className="max-w-[190px] truncate">{agent.branch}</span>
-              </>
-            )}
-          </div>
-          <p className="mt-2 line-clamp-3 text-xs leading-5 text-muted-foreground">
-            {agent.summary_markdown ||
-              "This session has just started capturing work."}
-          </p>
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            {agent.specialist_slug && (
-              <Badge variant="outline" className="font-mono text-[9px]">
-                {agent.specialist_slug}
-              </Badge>
-            )}
-            <span className="text-[10px] text-muted-foreground">
-              {presenceLabel(agent)}
-            </span>
+          <span
+            className={cn(styles.statusDot, isLive && styles.runningDot)}
+            title={presenceLabel(agent)}
+          />
+          <div className={styles.modelBlock}>
+            <h3 className={styles.model}>{agentModelName(agent)}</h3>
+            <div className={cn(styles.status, !isLive && styles.idleStatus)}>
+              {isLive ? "Running" : "Idle"}
+            </div>
           </div>
         </button>
 
@@ -178,6 +174,7 @@ function AgentCard({
               size="icon-sm"
               disabled={isMoving}
               aria-label={`Move ${agent.title || agent.session_id}`}
+              className={styles.instanceMenu}
             >
               <ChevronDown />
             </Button>
@@ -209,6 +206,51 @@ function AgentCard({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+
+      <button
+        type="button"
+        className={cn(styles.workingOn, !isLive && styles.muted)}
+        onClick={() => onOpen(agent)}
+      >
+        {agent.summary_markdown ||
+          `Connected in ${repoLabel(agent)}${
+            agent.branch ? ` on ${agent.branch}` : ""
+          }`}
+      </button>
+
+      <div className={styles.documents}>
+        {agent.active_document_id ? (
+          <Link
+            to="/v2/library/$documentId"
+            params={{ documentId: agent.active_document_id }}
+            className={styles.document}
+          >
+            <span className={styles.documentTitle}>
+              {agent.title || "Active Taskforce document"}
+            </span>
+            <span className={styles.documentMode}>writing</span>
+          </Link>
+        ) : (
+          <span className={styles.noDocuments}>No active document</span>
+        )}
+        {agent.referenced_document_ids.length > 0 && (
+          <button
+            type="button"
+            className={styles.document}
+            onClick={() => onOpen(agent)}
+          >
+            <span className={styles.documentTitle}>
+              {agent.referenced_document_ids.length} referenced{" "}
+              {agent.referenced_document_ids.length === 1
+                ? "document"
+                : "documents"}
+            </span>
+            <span className={styles.documentMode}>reading</span>
+          </button>
+        )}
+      </div>
+
+      <div className={styles.elapsed}>{compactPresence(agent)}</div>
     </article>
   )
 }
@@ -250,10 +292,10 @@ function FleetBox({
   }
 
   return (
-    <section className="flex min-h-[220px] flex-col border border-border bg-card">
-      <div className="flex min-h-14 items-center gap-2 border-b border-border px-4 py-3">
+    <section className={styles.session}>
+      <div className={styles.sessionHeader}>
         {renaming ? (
-          <form onSubmit={submitRename} className="flex min-w-0 flex-1 gap-2">
+          <form onSubmit={submitRename} className={styles.renameForm}>
             <Input
               value={name}
               onChange={(event) => setName(event.target.value)}
@@ -268,16 +310,10 @@ function FleetBox({
         ) : (
           <button
             type="button"
-            className="min-w-0 flex-1 text-left"
+            className={styles.sessionOpen}
             onClick={() => onOpenFleet(fleet)}
           >
-            <div className="flex items-center gap-2">
-              <FolderKanban className="size-4 text-muted-foreground" />
-              <h2 className="truncate text-sm font-semibold">{fleet.name}</h2>
-              <Badge variant="secondary" className="text-[10px]">
-                {fleet.agents.length}
-              </Badge>
-            </div>
+            <h2 className={styles.sessionTitle}>{fleet.name}</h2>
           </button>
         )}
 
@@ -288,6 +324,7 @@ function FleetBox({
                 variant="ghost"
                 size="icon-sm"
                 aria-label="Fleet session actions"
+                className={styles.sessionMenu}
               >
                 <MoreHorizontal />
               </Button>
@@ -313,10 +350,17 @@ function FleetBox({
           </DropdownMenu>
         )}
       </div>
+      <p className={styles.sessionSummary}>{fleetSummary(fleet.agents)}</p>
 
-      <div className="flex flex-1 flex-col gap-2 p-3">
+      <div className={styles.instances}>
+        <div className={styles.columns} aria-hidden="true">
+          <div>Instance</div>
+          <div>Working on</div>
+          <div>Documents</div>
+          <div className={styles.alignRight}>Time</div>
+        </div>
         {fleet.agents.length === 0 ? (
-          <div className="grid min-h-28 flex-1 place-items-center border border-dashed border-border px-4 text-center text-xs text-muted-foreground">
+          <div className={styles.emptySession}>
             Move an active agent here to group its work.
           </div>
         ) : (
@@ -667,6 +711,13 @@ export function FleetPage() {
   const activeAgentCount =
     unassigned.length +
     fleetSessions.reduce((total, fleet) => total + fleet.agents.length, 0)
+  const runningAgentCount =
+    unassigned.filter((agent) => agent.minutes_ago < 5).length +
+    fleetSessions.reduce(
+      (total, fleet) =>
+        total + fleet.agents.filter((agent) => agent.minutes_ago < 5).length,
+      0,
+    )
 
   const moveAgent = (
     agent: TaskforceFleetAgent,
@@ -709,7 +760,18 @@ export function FleetPage() {
           </header>
         </div>
 
-        <div className="flex flex-col gap-6">
+        <div className={styles.pageBody}>
+          <div className={styles.overview}>
+            <div className={styles.overviewSummary}>
+              <strong>{activeSessionCount}</strong>{" "}
+              {activeSessionCount === 1 ? "session" : "sessions"} ·{" "}
+              <strong>{activeAgentCount}</strong>{" "}
+              {activeAgentCount === 1 ? "instance" : "instances"} ·{" "}
+              <strong>{runningAgentCount}</strong> running
+            </div>
+            <div className={styles.liveLabel}>Live activity</div>
+          </div>
+
           {Boolean(mutationError) && (
             <div className="border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
               {errorMessage(mutationError)}
@@ -717,11 +779,11 @@ export function FleetPage() {
           )}
 
           {fleetQuery.isLoading ? (
-            <div className="grid gap-4 lg:grid-cols-2">
+            <div className={styles.sessionList}>
               {[0, 1, 2].map((item) => (
                 <div
                   key={item}
-                  className="h-64 animate-pulse border bg-muted/30"
+                  className="h-48 animate-pulse border bg-muted/30"
                 />
               ))}
             </div>
@@ -760,16 +822,21 @@ export function FleetPage() {
               </Button>
             </div>
           ) : (
-            <div className="grid items-start gap-4 lg:grid-cols-2">
-              <section className="flex min-h-[220px] flex-col border border-dashed border-border bg-muted/20">
-                <div className="flex min-h-14 items-center gap-2 border-b border-border px-4 py-3">
-                  <Bot className="size-4 text-muted-foreground" />
-                  <h2 className="text-sm font-semibold">Unassigned</h2>
-                  <Badge variant="secondary" className="text-[10px]">
-                    {unassigned.length}
-                  </Badge>
+            <div className={styles.sessionList}>
+              <section className={cn(styles.session, styles.unassignedSession)}>
+                <div className={styles.sessionHeader}>
+                  <h2 className={styles.sessionTitle}>Unassigned</h2>
                 </div>
-                <div className="flex flex-1 flex-col gap-2 p-3">
+                <p className={styles.sessionSummary}>
+                  {fleetSummary(unassigned)}
+                </p>
+                <div className={styles.instances}>
+                  <div className={styles.columns} aria-hidden="true">
+                    <div>Instance</div>
+                    <div>Working on</div>
+                    <div>Documents</div>
+                    <div className={styles.alignRight}>Time</div>
+                  </div>
                   {unassigned.length ? (
                     unassigned.map((agent) => (
                       <AgentCard
@@ -790,7 +857,7 @@ export function FleetPage() {
                       />
                     ))
                   ) : (
-                    <div className="grid min-h-28 flex-1 place-items-center px-4 text-center text-xs text-muted-foreground">
+                    <div className={styles.emptySession}>
                       All active agents are assigned.
                     </div>
                   )}

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -1,0 +1,98 @@
+import { expect, type Page, test } from "@playwright/test"
+
+const currentUser = {
+  id: "user-1",
+  email: "alex@example.com",
+  is_active: true,
+  is_superuser: true,
+  full_name: "Alex Lee",
+  created_at: "2026-03-24T00:00:00Z",
+  v2: true,
+  subscription_tier: "free",
+}
+
+test.use({
+  storageState: {
+    cookies: [],
+    origins: [],
+  },
+})
+
+async function mockFleet(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "test-token")
+  })
+
+  await page.route("**/api/v1/users/**", async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname === "/api/v1/users/me") {
+      await route.fulfill({ json: currentUser })
+      return
+    }
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+
+  await page.route("**/api/v1/v2/taskforce/fleet", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue()
+      return
+    }
+
+    await route.fulfill({
+      json: {
+        fleet_sessions: [
+          {
+            id: "fleet-1",
+            name: "Stripe tax rollout",
+            created_at: "2026-06-12T10:00:00Z",
+            updated_at: "2026-06-12T10:20:00Z",
+            agents: [
+              {
+                session_id: "session-1",
+                fleet_session_id: "fleet-1",
+                cwd: "/workspace/billing",
+                branch: "feature/automatic-tax",
+                repo: "billing",
+                active_document_id: "doc-1",
+                referenced_document_ids: ["doc-2"],
+                title: "Stripe checkout wiring",
+                summary_markdown:
+                  "Wiring automatic tax onto the subscription create path",
+                last_seen_at: "2026-06-12T10:20:00Z",
+                minutes_ago: 1,
+                specialist_slug: "billing",
+                model_id: "claude-opus-4-8",
+              },
+            ],
+          },
+        ],
+        unassigned: [],
+      },
+    })
+  })
+}
+
+test("Fleet renders live API data in the clean session layout", async ({
+  page,
+}) => {
+  await mockFleet(page)
+  await page.goto("/v2/fleet")
+
+  await expect(page.getByRole("heading", { name: "Fleet" })).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Stripe tax rollout" }),
+  ).toBeVisible()
+  await expect(page.getByText("Opus 4.8")).toBeVisible()
+  await expect(
+    page.getByText("Wiring automatic tax onto the subscription create path"),
+  ).toBeVisible()
+  await expect(page.getByText("Stripe checkout wiring")).toBeVisible()
+  await expect(
+    page.getByText("1 session · 1 instance · 1 running"),
+  ).toBeVisible()
+
+  await page.getByRole("button", { name: "New fleet" }).click()
+  await expect(
+    page.getByRole("heading", { name: "New Fleet session" }),
+  ).toBeVisible()
+})


### PR DESCRIPTION
## Summary

- restyle the existing API-backed Fleet page to match `fleet-clean.html`
- render each Fleet group as a compact session card with instance, work, document, and activity columns
- add responsive mobile rows and live status indicators
- preserve Fleet polling, create, move, unassign, rename, delete, document links, and detail drawers
- add focused Playwright coverage using the real Fleet response shape

## Scope

Frontend only. No backend or API contract changes.

## Validation

- `npm run build`
- Biome check on changed files
- targeted Fleet Playwright test against mocked live API data
- `git diff --check`