### PR TITLE
Tab eyebrow copy and Fleet header divider polish

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -21,7 +21,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 20px 0 12px;
+  padding: 8px 0;
 }
 
 .overviewSummary {

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -743,11 +743,16 @@ export function FleetPage() {
       )}
     >
       <div className={cn(V2_PAGE_BODY, "gap-0 pb-6 md:pb-8")}>
-        <div className={V2_STICKY_HEADER_CLASS}>
+        <div
+          className={cn(
+            V2_STICKY_HEADER_CLASS,
+            "flex flex-col gap-6 border-b-0 pb-0",
+          )}
+        >
           <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div>
               <p className={V2_TAB_EYEBROW_CLASS}>
-                Fleet · {activeSessionCount} active session
+                {activeSessionCount} active session
                 {activeSessionCount === 1 ? "" : "s"} · {activeAgentCount}{" "}
                 active agent{activeAgentCount === 1 ? "" : "s"}
               </p>
@@ -766,10 +771,7 @@ export function FleetPage() {
               New fleet
             </Button>
           </header>
-        </div>
-
-        <div className={styles.pageBody}>
-          <div className={styles.overview}>
+          <div className={cn(styles.overview, "border-y border-border")}>
             <div className={styles.overviewSummary}>
               <strong>{activeSessionCount}</strong>{" "}
               {activeSessionCount === 1 ? "session" : "sessions"} ·{" "}
@@ -779,7 +781,9 @@ export function FleetPage() {
             </div>
             <div className={styles.liveLabel}>Live activity</div>
           </div>
+        </div>
 
+        <div className={styles.pageBody}>
           {Boolean(mutationError) && (
             <div className="border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
               {errorMessage(mutationError)}

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -399,10 +399,9 @@ export function LedgerPage({
               <header className={styles.head}>
                 <div>
                   <div className={styles.crumb}>
-                    Ledger
                     {typeof ledgerQuery.data?.total === "number"
-                      ? ` · ${ledgerQuery.data.total} sessions archived`
-                      : ""}
+                      ? `${ledgerQuery.data.total} sessions archived`
+                      : null}
                   </div>
                   <h1 className={styles.h1}>Ledger</h1>
                 </div>

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -680,7 +680,7 @@ function ExperimentalMetricsPage({
           <header className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
             <div>
               <div className={V2_TAB_EYEBROW_CLASS}>
-                Metrics · {windowCopy.label} · personal
+                {windowCopy.label} · personal
               </div>
               <h1 className="mt-2 text-3xl font-semibold leading-none tracking-tight md:text-4xl">
                 You saved{" "}
@@ -856,7 +856,7 @@ function ExperimentalSessionMetrics({
           <header className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
             <div>
               <div className={V2_TAB_EYEBROW_CLASS}>
-                Metrics · session · {sessionShortId}
+                session · {sessionShortId}
               </div>
               <h1 className="mt-2 text-3xl font-semibold leading-none tracking-tight md:text-4xl">
                 This session saved{" "}

--- a/src/components/V2/v2PageShell.ts
+++ b/src/components/V2/v2PageShell.ts
@@ -29,7 +29,7 @@ export const V2_PAGE_CONTENT_FIXED = cn(
   V2_PAGE_PADDING,
 )
 
-/** Tab page meta line (e.g. "Metrics · 7d · personal"). */
+/** Tab page meta line (e.g. "7d · personal") — page title lives in the h1 below. */
 export const V2_TAB_EYEBROW_CLASS =
   "font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground"
 

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -152,7 +152,7 @@ function AgentsIndex() {
           <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div>
               <div className={AGENT_EYEBROW_CLASS}>
-                Profiles · {activeCount} active across team
+                {activeCount} active across team
               </div>
               <h1 className={cn("mt-1", AGENT_PAGE_TITLE_CLASS)}>Profiles</h1>
             </div>

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -718,8 +718,8 @@ function TaskforceLibrary() {
             <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
               <div>
                 <div className={V2_TAB_EYEBROW_CLASS}>
-                  Library · {totalDocumentCount} documents ·{" "}
-                  {teamSharedDocumentCount} shared with team
+                  {totalDocumentCount} documents · {teamSharedDocumentCount}{" "}
+                  shared with team
                 </div>
                 <h1 className="mt-1 text-2xl font-semibold">Library</h1>
               </div>


### PR DESCRIPTION
## Summary
- Remove redundant page name prefix from tab eyebrows on Fleet, Profiles, Library, Metrics, and Ledger (title stays in the h1)
- Align Fleet sticky chrome with Profiles: drop full-bleed header border, move overview strip into sticky block with `border-y border-border` matching ScopeFilterBar

## Test plan
- [x] Fleet eyebrow shows counts only (`1 active session · 5 active agents`)
- [x] Profiles, Library, Metrics, Ledger eyebrows omit page name prefix
- [x] Fleet horizontal divider aligns with content margins like Profiles filter bar
- [x] Fleet overview strip stays sticky with title while scrolling


Made with [Cursor](https://cursor.com)