### PR TITLE
TF-239/TF-240: Polish placeholder UI

### DIFF
--- a/src/components/V2/TaskforceLandingPage.tsx
+++ b/src/components/V2/TaskforceLandingPage.tsx
@@ -75,6 +75,13 @@ export function TaskforceLandingPage() {
         </div>
 
         <div className="overflow-hidden rounded-lg border bg-card shadow-sm">
+          <div
+            data-testid="taskforce-landing-demo-disclosure"
+            className="border-b bg-muted/60 px-5 py-3 text-sm text-muted-foreground"
+          >
+            Illustrative product preview. Documents and activity below are
+            example data.
+          </div>
           <div className="grid border-b bg-muted/35 md:grid-cols-[220px_1fr]">
             <div className="border-b p-5 md:border-b-0 md:border-r">
               <div className="text-lg font-semibold">Taskforce</div>
@@ -99,7 +106,7 @@ export function TaskforceLandingPage() {
                   <h2 className="text-2xl font-semibold">Recent work</h2>
                 </div>
                 <div className="text-sm text-muted-foreground">
-                  73% rediscovery avoided this week
+                  Example workspace data
                 </div>
               </div>
 

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -52,6 +52,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar"
+import { normalizeTaskforceDiscordUrl } from "@/lib/taskforceExternalLinks"
 import { cn } from "@/lib/utils"
 
 type TaskforceShellProps = {
@@ -75,7 +76,9 @@ const taskforceItems: TaskforceNavItem[] = [
 
 const SIDEBAR_TAB_LABEL_CLASS = "text-[calc(18px*0.85)]"
 
-const TASKFORCE_DISCORD_URL = ""
+const TASKFORCE_DISCORD_URL = normalizeTaskforceDiscordUrl(
+  import.meta.env.VITE_TASKFORCE_DISCORD_URL,
+)
 const EXTRAS_DRAWER_COLLAPSED_STORAGE_KEY = "taskforce.sidebar.extras.collapsed"
 
 function readStoredExtrasDrawerCollapsed() {
@@ -168,6 +171,8 @@ function TaskforceNav({ currentUser }: TaskforceShellProps) {
 }
 
 function DiscordButton() {
+  if (!TASKFORCE_DISCORD_URL) return null
+
   const content = (
     <>
       <MessageCircle className="size-[18px] text-muted-foreground transition-colors" />
@@ -175,33 +180,17 @@ function DiscordButton() {
     </>
   )
 
-  if (TASKFORCE_DISCORD_URL) {
-    return (
-      <SidebarMenuItem>
-        <SidebarMenuButton tooltip="Join Discord" asChild>
-          <a
-            href={TASKFORCE_DISCORD_URL}
-            target="_blank"
-            rel="noreferrer"
-            data-testid="taskforce-discord-link"
-          >
-            {content}
-          </a>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
-    )
-  }
-
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton
-        type="button"
-        tooltip="Discord link coming soon"
-        data-testid="taskforce-discord-placeholder"
-        aria-disabled="true"
-        className="text-sidebar-foreground/70 hover:text-sidebar-foreground"
-      >
-        {content}
+      <SidebarMenuButton tooltip="Join Discord" asChild>
+        <a
+          href={TASKFORCE_DISCORD_URL}
+          target="_blank"
+          rel="noreferrer"
+          data-testid="taskforce-discord-link"
+        >
+          {content}
+        </a>
       </SidebarMenuButton>
     </SidebarMenuItem>
   )

--- a/src/lib/taskforceExternalLinks.ts
+++ b/src/lib/taskforceExternalLinks.ts
@@ -1,0 +1,18 @@
+const DISCORD_HOSTS = new Set(["discord.com", "www.discord.com", "discord.gg"])
+
+export function normalizeTaskforceDiscordUrl(
+  value: string | undefined,
+): string | null {
+  const candidate = value?.trim()
+  if (!candidate) return null
+
+  try {
+    const url = new URL(candidate)
+    if (url.protocol !== "https:" || !DISCORD_HOSTS.has(url.hostname)) {
+      return null
+    }
+    return url.toString()
+  } catch {
+    return null
+  }
+}

--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -1,11 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { useCallback, useEffect, useRef, useState } from "react"
 
-import {
-  LandingTerminal,
-  type LandingTerminalEvent,
-} from "@/components/V2/LandingTerminal"
-import { cn } from "@/lib/utils"
+import { LandingTerminal } from "@/components/V2/LandingTerminal"
 
 export const Route = createFileRoute("/landing")({
   component: LandingExpressive,
@@ -18,104 +13,7 @@ export const Route = createFileRoute("/landing")({
   }),
 })
 
-const BASE_TOKENS = 82_400_000
-const BASE_DOLLARS = 1_237
-const BASE_SESSIONS = 127
-const TOKENS_PER_DOLLAR = BASE_TOKENS / BASE_DOLLARS
-
-function formatTokens(n: number): string {
-  return `${(n / 1_000_000).toFixed(1)}M tokens`
-}
-
-function formatDollars(n: number): string {
-  return `$${Math.round(n).toLocaleString("en-US")}`
-}
-
-function formatSessions(n: number): string {
-  return `${Math.round(n).toLocaleString("en-US")} work sessions`
-}
-
-function CountUp({
-  value,
-  format,
-  duration = 750,
-}: {
-  value: number
-  format: (n: number) => string
-  duration?: number
-}) {
-  const [displayed, setDisplayed] = useState(value)
-  const fromRef = useRef(value)
-  useEffect(() => {
-    const from = fromRef.current
-    if (from === value) {
-      setDisplayed(value)
-      return
-    }
-    const start = performance.now()
-    let raf = 0
-    const tick = (now: number) => {
-      const t = Math.min(1, (now - start) / duration)
-      const eased = 1 - (1 - t) ** 3
-      setDisplayed(from + (value - from) * eased)
-      if (t < 1) {
-        raf = requestAnimationFrame(tick)
-      } else {
-        fromRef.current = value
-      }
-    }
-    raf = requestAnimationFrame(tick)
-    return () => cancelAnimationFrame(raf)
-  }, [value, duration])
-  return <span className="tabular-nums">{format(displayed)}</span>
-}
-
 function LandingExpressive() {
-  const [stats, setStats] = useState({
-    tokens: BASE_TOKENS,
-    dollars: BASE_DOLLARS,
-    sessions: BASE_SESSIONS,
-  })
-  const [tokensPulsing, setTokensPulsing] = useState(false)
-  const pulseTimerRef = useRef<number | null>(null)
-
-  useEffect(() => {
-    return () => {
-      if (pulseTimerRef.current !== null) {
-        window.clearTimeout(pulseTimerRef.current)
-      }
-    }
-  }, [])
-
-  const handleTerminalEvent = useCallback((event: LandingTerminalEvent) => {
-    if (event.type === "cycle-reset") {
-      setStats({
-        tokens: BASE_TOKENS,
-        dollars: BASE_DOLLARS,
-        sessions: BASE_SESSIONS,
-      })
-      setTokensPulsing(false)
-      if (pulseTimerRef.current !== null) {
-        window.clearTimeout(pulseTimerRef.current)
-        pulseTimerRef.current = null
-      }
-    } else if (event.type === "reveal") {
-      setStats((prev) => ({
-        tokens: prev.tokens + event.savedUsd * TOKENS_PER_DOLLAR,
-        dollars: prev.dollars + event.savedUsd,
-        sessions: prev.sessions + 1,
-      }))
-      setTokensPulsing(true)
-      if (pulseTimerRef.current !== null) {
-        window.clearTimeout(pulseTimerRef.current)
-      }
-      pulseTimerRef.current = window.setTimeout(() => {
-        setTokensPulsing(false)
-        pulseTimerRef.current = null
-      }, 5000)
-    }
-  }, [])
-
   return (
     <main
       data-testid="landing-expressive"
@@ -198,32 +96,30 @@ function LandingExpressive() {
             </div>
           </div>
 
-          <dl className="mt-10 grid border-t border-zinc-200 pt-4 font-mono text-[0.85rem] text-zinc-500 dark:border-white/10 dark:text-zinc-400 sm:grid-cols-3 md:mt-auto">
+          <div
+            data-testid="landing-demo-disclosure"
+            className="mt-10 border-t border-zinc-200 pt-4 font-mono text-xs leading-5 text-zinc-500 dark:border-white/10 dark:text-zinc-400 md:mt-auto"
+          >
+            Illustrative product walkthrough. Names, events, and savings shown
+            are example data.
+          </div>
+          <dl className="mt-3 grid font-mono text-[0.85rem] text-zinc-500 dark:text-zinc-400 sm:grid-cols-3">
             <div className="border-b border-zinc-200 py-3 last:border-b-0 sm:border-r sm:border-b-0 sm:px-4 sm:first:pl-0 sm:last:border-r-0 dark:border-white/10">
-              <dt className="uppercase tracking-[0.16em]">Tokens saved</dt>
-              <dd
-                className={cn(
-                  "mt-1 font-sans text-[1.09375rem] font-semibold leading-snug transition-colors duration-700",
-                  tokensPulsing
-                    ? "text-[#8447ff]"
-                    : "text-zinc-950 dark:text-white",
-                )}
-              >
-                <CountUp value={stats.tokens} format={formatTokens} />
-                {" / "}
-                <CountUp value={stats.dollars} format={formatDollars} />
+              <dt className="uppercase tracking-[0.16em]">Example outcome</dt>
+              <dd className="mt-1 font-sans text-[1.09375rem] font-semibold leading-snug text-zinc-950 dark:text-white">
+                Prior work reused
               </dd>
             </div>
             <div className="border-b border-zinc-200 py-3 last:border-b-0 sm:border-r sm:border-b-0 sm:px-4 sm:first:pl-0 sm:last:border-r-0 dark:border-white/10">
-              <dt className="uppercase tracking-[0.16em]">Context saved</dt>
+              <dt className="uppercase tracking-[0.16em]">Example context</dt>
               <dd className="mt-1 font-sans text-[1.09375rem] font-semibold leading-snug text-zinc-950 dark:text-white">
-                <CountUp value={stats.sessions} format={formatSessions} />
+                Profile + docs restored
               </dd>
             </div>
             <div className="border-b border-zinc-200 py-3 last:border-b-0 sm:border-r sm:border-b-0 sm:px-4 sm:first:pl-0 sm:last:border-r-0 dark:border-white/10">
-              <dt className="uppercase tracking-[0.16em]">Setup time</dt>
+              <dt className="uppercase tracking-[0.16em]">Metrics</dt>
               <dd className="mt-1 font-sans text-[1.09375rem] font-semibold leading-snug text-zinc-950 dark:text-white">
-                3 minutes
+                Illustrative only
               </dd>
             </div>
           </dl>
@@ -231,7 +127,7 @@ function LandingExpressive() {
 
         <div className="flex min-h-[36rem] flex-col justify-end bg-zinc-50 px-5 py-6 dark:bg-zinc-900/40 md:min-h-0 md:items-end md:px-8 md:py-8">
           <div className="w-full max-w-[42rem]">
-            <LandingTerminal onEvent={handleTerminalEvent} />
+            <LandingTerminal />
           </div>
         </div>
       </section>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string
+  readonly VITE_TASKFORCE_DISCORD_URL?: string
   readonly VITE_HOSTED_MCP_URL?: string
   readonly VITE_FIREBASE_API_KEY: string
   readonly VITE_FIREBASE_AUTH_DOMAIN: string

--- a/tests/home-docs.spec.ts
+++ b/tests/home-docs.spec.ts
@@ -54,9 +54,13 @@ test("Landing page presents Taskforce V2 as the public product", async ({
     page.getByRole("heading", { name: "Taskforce", exact: true }),
   ).toBeVisible()
   await expect(page.getByText("AI work memory for builders")).toBeVisible()
+  await expect(
+    page.getByTestId("taskforce-landing-demo-disclosure"),
+  ).toContainText("Documents and activity below are example data.")
   await expect(page.getByText("Library").first()).toBeVisible()
-  await expect(page.getByText("Agents").first()).toBeVisible()
+  await expect(page.getByText("Profiles").first()).toBeVisible()
   await expect(page.getByText("Metrics").first()).toBeVisible()
+  await expect(page.getByText(/rediscovery avoided/i)).toHaveCount(0)
   await expect(
     page.getByRole("link", { name: "Log in", exact: true }),
   ).toBeVisible()

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -14,6 +14,10 @@ test("/landing renders the expressive Taskforce demo page", async ({
   await page.goto("/landing")
 
   await expect(page.getByTestId("landing-expressive")).toBeVisible()
+  await expect(page.getByTestId("landing-demo-disclosure")).toContainText(
+    "Names, events, and savings shown are example data.",
+  )
+  await expect(page.getByText("82.4M tokens")).toHaveCount(0)
   await expect(
     page.getByRole("heading", {
       name: /stop re-explaining your codebase/i,

--- a/tests/taskforce-external-links.spec.ts
+++ b/tests/taskforce-external-links.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test"
+
+import { normalizeTaskforceDiscordUrl } from "../src/lib/taskforceExternalLinks"
+
+test("Discord navigation accepts configured Discord destinations", () => {
+  expect(normalizeTaskforceDiscordUrl("https://discord.gg/taskforce")).toBe(
+    "https://discord.gg/taskforce",
+  )
+  expect(
+    normalizeTaskforceDiscordUrl("https://discord.com/invite/taskforce"),
+  ).toBe("https://discord.com/invite/taskforce")
+})
+
+test("Discord navigation stays hidden without a valid destination", () => {
+  expect(normalizeTaskforceDiscordUrl(undefined)).toBeNull()
+  expect(normalizeTaskforceDiscordUrl("")).toBeNull()
+  expect(normalizeTaskforceDiscordUrl("javascript:alert(1)")).toBeNull()
+  expect(
+    normalizeTaskforceDiscordUrl("https://example.com/community"),
+  ).toBeNull()
+})

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -111,6 +111,8 @@ test("Taskforce v2 sidebar includes drag collapse and Extras controls", async ({
   await expect(sidebarRail).toBeVisible()
   await expect(extrasHandle).toHaveAttribute("aria-label", "Sidebar utilities")
   await expect(extrasDrawer).toContainText("Demo mode")
+  await expect(page.getByTestId("taskforce-discord-link")).toHaveCount(0)
+  await expect(page.getByText("Discord", { exact: true })).toHaveCount(0)
   await expect(documentLookup).toBeVisible()
   await expect(documentLookup).toHaveAttribute(
     "placeholder",


### PR DESCRIPTION
## Summary

- hide the Discord sidebar item unless a validated HTTPS Discord URL is configured through `VITE_TASKFORCE_DISCORD_URL`
- label both public product previews as illustrative and remove synthetic live-looking counters and unsupported quantitative claims
- add focused coverage for Discord URL validation, hidden navigation, and landing-page disclosure copy
- align the touched root landing test with the current Profiles label

## Decisions

The Discord control is omitted by default instead of presenting a disabled navigation item. Configured destinations are restricted to HTTPS URLs on Discord-owned hosts.

The landing demonstrations remain visually useful, but their documents, events, and savings are now explicitly marked as example data. The synthetic aggregate counter animation was removed.

## Validation

- `bun run build`
- focused Playwright run: 5 passed
- Biome check on all changed files
- `git diff --check`

## Jira

- [TF-239](https://alexlee4190.atlassian.net/browse/TF-239)
- [TF-240](https://alexlee4190.atlassian.net/browse/TF-240)