### PR TITLE
TF-232/TF-233: Finish Ledger access controls

### DIFF
--- a/src/api/v2Ledger.ts
+++ b/src/api/v2Ledger.ts
@@ -89,6 +89,11 @@ export interface LedgerSessionDetail extends LedgerSessionRow {
   source_metadata: Record<string, unknown>
 }
 
+export interface LedgerRawTranscript {
+  session_id: string
+  events: Record<string, unknown>[]
+}
+
 export interface LedgerResponse {
   scope: "organization"
   organization_id: string | null
@@ -141,6 +146,22 @@ export function readLedgerSessionDetail(
   return request(OpenAPI, {
     method: "GET",
     url: "/api/v1/v2/taskforce/ledger/{session_id}",
+    path: {
+      session_id: sessionId,
+    },
+    query: {
+      demo: args.demo || undefined,
+    },
+  })
+}
+
+export function readLedgerRawTranscript(
+  sessionId: string,
+  args: Pick<ReadLedgerArgs, "demo"> = {},
+): CancelablePromise<LedgerRawTranscript> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/taskforce/ledger/{session_id}/raw-transcript",
     path: {
       session_id: sessionId,
     },

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -58,6 +58,8 @@ export type UserPublic = {
     email: string;
     is_superuser?: boolean;
     full_name?: (string | null);
+    organization_id?: (string | null);
+    organization_role?: string;
     id: string;
     v2?: boolean;
     created_at?: (string | null);

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -17,6 +17,7 @@ import {
   type LedgerSessionRow,
   type LedgerTranscriptEvent,
   readLedger,
+  readLedgerRawTranscript,
   readLedgerSessionDetail,
 } from "@/api/v2Ledger"
 import { useDemoMode } from "@/components/demo-mode-provider"
@@ -379,6 +380,7 @@ export function LedgerPage({
           <div className={styles.app}>
             <LedgerDetail
               detail={detailQuery.data}
+              demo={isDemoMode}
               isError={detailQuery.isError}
               isLoading={detailQuery.isLoading}
               onBack={() => setLedgerSearch({ session_id: undefined })}
@@ -582,11 +584,13 @@ function LedgerRow({
 
 function LedgerDetail({
   detail,
+  demo,
   isError,
   isLoading,
   onBack,
 }: {
   detail?: LedgerSessionDetail
+  demo: boolean
   isError: boolean
   isLoading: boolean
   onBack: () => void
@@ -655,7 +659,7 @@ function LedgerDetail({
             </div>
           )}
         </div>
-        <SessionRail detail={detail} />
+        <SessionRail demo={demo} detail={detail} />
       </div>
     </div>
   )
@@ -762,10 +766,45 @@ function EventShell({
   )
 }
 
-function SessionRail({ detail }: { detail: LedgerSessionDetail }) {
+function SessionRail({
+  demo,
+  detail,
+}: {
+  demo: boolean
+  detail: LedgerSessionDetail
+}) {
+  const [downloadError, setDownloadError] = useState("")
+  const [isDownloading, setIsDownloading] = useState(false)
+
   const copyMarkdown = () => {
     void navigator.clipboard?.writeText(buildMarkdown(detail))
   }
+
+  const downloadRawTranscript = async () => {
+    setDownloadError("")
+    setIsDownloading(true)
+    try {
+      const transcript = await readLedgerRawTranscript(detail.session_id, {
+        demo,
+      })
+      const blob = new Blob([JSON.stringify(transcript.events, null, 2)], {
+        type: "application/json",
+      })
+      const href = URL.createObjectURL(blob)
+      const anchor = document.createElement("a")
+      anchor.href = href
+      anchor.download = `${detail.session_id.replace(/[^a-zA-Z0-9._-]/g, "_")}-transcript.json`
+      document.body.appendChild(anchor)
+      anchor.click()
+      anchor.remove()
+      URL.revokeObjectURL(href)
+    } catch {
+      setDownloadError("Could not download the raw transcript.")
+    } finally {
+      setIsDownloading(false)
+    }
+  }
+
   const messages = detail.message_count || detail.event_count
 
   return (
@@ -813,17 +852,25 @@ function SessionRail({ detail }: { detail: LedgerSessionDetail }) {
       )}
 
       <div className={styles.actRow}>
-        <button
-          className={cn(styles.btn, styles.btnSolid)}
-          disabled={!detail.raw_transcript_available}
-          type="button"
-        >
-          Open raw transcript
-        </button>
+        {detail.raw_transcript_available ? (
+          <button
+            className={cn(styles.btn, styles.btnSolid)}
+            disabled={isDownloading}
+            onClick={() => void downloadRawTranscript()}
+            type="button"
+          >
+            {isDownloading ? "Preparing download…" : "Download raw transcript"}
+          </button>
+        ) : null}
         <button className={styles.btn} onClick={copyMarkdown} type="button">
           Copy as Markdown
         </button>
       </div>
+      {downloadError ? (
+        <p className="mt-2 text-xs text-destructive" role="alert">
+          {downloadError}
+        </p>
+      ) : null}
     </aside>
   )
 }

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -134,7 +134,9 @@ function TaskforceNav({ currentUser }: TaskforceShellProps) {
   const router = useRouterState()
   const currentPath = router.location.pathname
   const items = [
-    ...taskforceItems,
+    ...taskforceItems.filter(
+      (item) => item.path !== "/v2/ledger" || currentUser.organization_id,
+    ),
     ...(currentUser.is_superuser
       ? [{ icon: Shield, title: "Admin", path: "/v2/admin" }]
       : []),

--- a/src/routes/v2/ledger.tsx
+++ b/src/routes/v2/ledger.tsx
@@ -1,7 +1,8 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Link } from "@tanstack/react-router"
 import { z } from "zod"
 
 import { LedgerPage } from "@/components/V2/Ledger/LedgerPage"
+import { V2_PAGE_BODY, V2_PAGE_FRAME } from "@/components/V2/v2PageShell"
 
 const searchSchema = z.object({
   actor_id: z.string().optional(),
@@ -34,5 +35,34 @@ export const Route = createFileRoute("/v2/ledger")({
 
 function TaskforceLedger() {
   const search = Route.useSearch()
+  const { currentUser } = Route.useRouteContext()
+
+  if (!currentUser.organization_id) {
+    return (
+      <section className={V2_PAGE_FRAME} data-testid="ledger-team-only">
+        <div className={V2_PAGE_BODY}>
+          <div className="max-w-2xl border-l border-border pl-5">
+            <p className="mb-3 font-mono text-xs uppercase tracking-[0.14em] text-muted-foreground">
+              Ledger for teams
+            </p>
+            <h1 className="text-2xl font-semibold">Create or join a team</h1>
+            <p className="mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
+              Ledger keeps an organization-wide record of sessions across people
+              and coding tools. It becomes available after your account joins an
+              organization.
+            </p>
+            <Link
+              className="mt-6 inline-flex border border-border bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90"
+              search={{ tab: "organization" }}
+              to="/v2/settings"
+            >
+              Manage organization
+            </Link>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
   return <LedgerPage searchFilters={search} />
 }

--- a/tests/ledger.spec.ts
+++ b/tests/ledger.spec.ts
@@ -1,0 +1,205 @@
+import { expect, type Page, test } from "@playwright/test"
+
+const baseUser = {
+  id: "user-1",
+  email: "alex@example.com",
+  is_active: true,
+  is_superuser: false,
+  full_name: "Alex Lee",
+  created_at: "2026-03-24T00:00:00Z",
+  v2: true,
+  subscription_tier: "max",
+}
+
+test.use({
+  storageState: {
+    cookies: [],
+    origins: [],
+  },
+})
+
+async function mockTaskforceAuth(page: Page, organizationId: string | null) {
+  const currentUser = {
+    ...baseUser,
+    organization_id: organizationId,
+    organization_role: "admin",
+  }
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "test-token")
+  })
+  await page.route("**/api/v1/users/**", async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname === "/api/v1/users/me") {
+      await route.fulfill({ json: currentUser })
+      return
+    }
+    if (url.pathname === "/api/v1/users/") {
+      await route.fulfill({ json: { data: [currentUser], count: 1 } })
+      return
+    }
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+  await page.route("**/api/v1/organizations/invitations", async (route) => {
+    await route.fulfill({ json: { data: [], count: 0 } })
+  })
+}
+
+function ledgerDetail(rawTranscriptAvailable: boolean) {
+  return {
+    session_id: "session-raw",
+    actor_id: "user-1",
+    actor_name: "Alex Lee",
+    client: "codex",
+    specialist_slug: null,
+    specialist_name: null,
+    specialist_href: null,
+    documents: [],
+    kinds: ["session.observed"],
+    net_saved_tokens: 0,
+    usd_amount: "0",
+    event_count: 1,
+    cross_boundary: false,
+    occurred_at_first: "2026-06-12T20:00:00Z",
+    occurred_at_last: "2026-06-12T20:01:00Z",
+    title: "Ledger transcript polish",
+    short_session_id: "session-",
+    actor_handle: "alex",
+    harness_label: "codex",
+    harness_version: "1.0",
+    model_id: "gpt-5",
+    repo: "EnderAI",
+    branch: "feature/ledger-polish",
+    cwd: "/workspace/EnderAI",
+    started_at: "2026-06-12T20:00:00Z",
+    ended_at: "2026-06-12T20:01:00Z",
+    duration_ms: 60000,
+    imported_at: "2026-06-12T20:01:00Z",
+    message_count: 1,
+    command_count: 0,
+    edit_count: 0,
+    input_tokens: 100,
+    output_tokens: 20,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    source: "observe",
+    transcript_available: true,
+    transcript_events: [
+      {
+        kind: "prompt",
+        occurred_at: "2026-06-12T20:00:00Z",
+        role: "user",
+        who: "Alex Lee",
+        text: "Polish the Ledger.",
+        cmd: null,
+        exit_code: null,
+        output: null,
+        file: null,
+        added: null,
+        removed: null,
+        note: null,
+        repo: null,
+      },
+    ],
+    raw_transcript_available: rawTranscriptAvailable,
+    source_metadata: {},
+  }
+}
+
+async function mockLedger(
+  page: Page,
+  { rawTranscriptAvailable }: { rawTranscriptAvailable: boolean },
+) {
+  await page.route("**/api/v1/v2/taskforce/ledger/**", async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname.endsWith("/raw-transcript")) {
+      await route.fulfill({
+        json: {
+          session_id: "session-raw",
+          events: [
+            { role: "user", content: "Polish the Ledger." },
+            { role: "assistant", content: "Ledger polished." },
+          ],
+        },
+      })
+      return
+    }
+    if (url.pathname.endsWith("/session-raw")) {
+      await route.fulfill({ json: ledgerDetail(rawTranscriptAvailable) })
+      return
+    }
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+  await page.route("**/api/v1/v2/taskforce/ledger?*", async (route) => {
+    await route.fulfill({
+      json: {
+        scope: "organization",
+        organization_id: "org-1",
+        total: 0,
+        limit: 50,
+        offset: 0,
+        rows: [],
+      },
+    })
+  })
+}
+
+test("solo users see the team Ledger state without calling Ledger APIs", async ({
+  page,
+}) => {
+  await mockTaskforceAuth(page, null)
+  let ledgerRequests = 0
+  page.on("request", (request) => {
+    if (request.url().includes("/api/v1/v2/taskforce/ledger")) {
+      ledgerRequests += 1
+    }
+  })
+
+  await page.goto("/v2/ledger")
+
+  await expect(page.getByTestId("ledger-team-only")).toBeVisible()
+  await expect(page.getByRole("link", { name: "Ledger" })).toHaveCount(0)
+  await expect(
+    page.getByRole("link", { name: "Manage organization" }),
+  ).toHaveAttribute("href", "/v2/settings?tab=organization")
+  expect(ledgerRequests).toBe(0)
+})
+
+test("organization users can download an available raw transcript", async ({
+  page,
+}) => {
+  await mockTaskforceAuth(page, "org-1")
+  await mockLedger(page, { rawTranscriptAvailable: true })
+
+  await page.goto("/v2/ledger?session_id=session-raw")
+
+  await expect(page.getByRole("link", { name: "Ledger" })).toBeVisible()
+  const downloadPromise = page.waitForEvent("download")
+  await page.getByRole("button", { name: "Download raw transcript" }).click()
+  const download = await downloadPromise
+
+  expect(download.suggestedFilename()).toBe("session-raw-transcript.json")
+  const stream = await download.createReadStream()
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk))
+  }
+  expect(JSON.parse(Buffer.concat(chunks).toString("utf8"))).toEqual([
+    { role: "user", content: "Polish the Ledger." },
+    { role: "assistant", content: "Ledger polished." },
+  ])
+})
+
+test("sessions without a raw archive show no transcript download control", async ({
+  page,
+}) => {
+  await mockTaskforceAuth(page, "org-1")
+  await mockLedger(page, { rawTranscriptAvailable: false })
+
+  await page.goto("/v2/ledger?session_id=session-raw")
+
+  await expect(page.getByText("Ledger transcript polish")).toBeVisible()
+  await expect(
+    page.getByRole("button", { name: /raw transcript/i }),
+  ).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary

- expose organization membership from the current-user contract used by the frontend
- hide Ledger navigation for solo users
- render a deliberate team-only direct-route state with an organization settings action, without issuing Ledger API requests
- replace the dead raw transcript button with an authenticated JSON download when an archive exists
- omit the transcript control when raw data is unavailable and show download failures explicitly

## Dependency

Requires backend [EnderAI PR #138](https://github.com/al-exe/EnderAI/pull/138).

## Validation

- `bun run build`
- focused Playwright Ledger suite: 3 passed
- Biome check on changed files
- `git diff --check`

## Jira

- [TF-232](https://alexlee4190.atlassian.net/browse/TF-232)
- [TF-233](https://alexlee4190.atlassian.net/browse/TF-233)