### PR TITLE
TF-231/TF-236: Finish search surface polish

### DIFF
--- a/src/components/V2/TaskforceLandingPage.tsx
+++ b/src/components/V2/TaskforceLandingPage.tsx
@@ -1,10 +1,9 @@
 import { Link as RouterLink } from "@tanstack/react-router"
-import { ArrowRight, BarChart3, BookOpenText, Bot, Search } from "lucide-react"
+import { ArrowRight, BarChart3, BookOpenText, Bot } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 
 const navItems = [
-  { icon: Search, label: "Search" },
   { icon: BookOpenText, label: "Library" },
   { icon: Bot, label: "Profiles" },
   { icon: BarChart3, label: "Metrics" },

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -387,12 +387,13 @@ function DocumentSearch() {
   const documentsQuery = useQuery({
     queryKey: ["v2-documents", { demo: isDemoMode }],
     queryFn: () => readV2Documents({ demo: isDemoMode }),
-    enabled: isDemoMode,
+    enabled: isOpen && trimmedQuery.length > 0,
+    retry: false,
   })
   const documents = documentsQuery.data?.data ?? []
 
   const results = useMemo<DocumentSearchMatch[]>(() => {
-    if (!isDemoMode || !trimmedQuery) return []
+    if (!trimmedQuery) return []
     const needle = trimmedQuery.toLowerCase()
     const matches: DocumentSearchMatch[] = []
     for (const document of documents) {
@@ -403,7 +404,7 @@ function DocumentSearch() {
       }
     }
     return matches
-  }, [isDemoMode, trimmedQuery, documents])
+  }, [trimmedQuery, documents])
 
   useEffect(() => {
     if (lastQueryRef.current === trimmedQuery) return
@@ -426,9 +427,13 @@ function DocumentSearch() {
     }
   }, [])
 
-  const showHint = isOpen && trimmedQuery.length > 0 && !isDemoMode
-  const showResults = isOpen && isDemoMode && trimmedQuery.length > 0
-  const dropdownOpen = showHint || showResults
+  const dropdownOpen = isOpen && trimmedQuery.length > 0
+  const showLoading = dropdownOpen && documentsQuery.isPending
+  const showError = dropdownOpen && documentsQuery.isError
+  const showEmpty =
+    dropdownOpen && !showLoading && !showError && results.length === 0
+  const showResults =
+    dropdownOpen && !showLoading && !showError && results.length > 0
   const activeResult = showResults ? results[activeIndex] : undefined
 
   const openDocument = (documentId: string) => {
@@ -513,15 +518,33 @@ function DocumentSearch() {
           data-testid="v2-document-lookup-results"
           className="absolute top-full right-0 left-0 z-50 mt-2 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg"
         >
-          {showHint && (
+          {showLoading && (
             <p
-              data-testid="v2-document-lookup-hint"
+              data-testid="v2-document-lookup-loading"
               className="px-4 py-3 text-sm text-muted-foreground"
             >
-              Turn on demo mode to search documents.
+              Searching documents...
             </p>
           )}
-          {showResults && results.length === 0 && (
+          {showError && (
+            <div className="flex items-center justify-between gap-3 px-4 py-3">
+              <p
+                data-testid="v2-document-lookup-error"
+                className="text-sm text-destructive"
+              >
+                Could not search documents.
+              </p>
+              <button
+                type="button"
+                className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => documentsQuery.refetch()}
+              >
+                Try again
+              </button>
+            </div>
+          )}
+          {showEmpty && (
             <p
               data-testid="v2-document-lookup-empty"
               className="px-4 py-3 text-sm text-muted-foreground"

--- a/src/data/membershipPlans.ts
+++ b/src/data/membershipPlans.ts
@@ -50,7 +50,6 @@ export const membershipPlans: MembershipPlan[] = [
       "Up to 1,000 agent profiles",
       "1 TB of library storage",
       "Organizations up to 1,000 members",
-      "Access to Enterprise Search in Taskforce",
     ],
     cta: "Select this tier",
   },

--- a/tests/home-docs.spec.ts
+++ b/tests/home-docs.spec.ts
@@ -50,6 +50,7 @@ test("Landing page presents Taskforce V2 as the public product", async ({
   await page.goto("/")
 
   await expect(page.getByTestId("taskforce-landing")).toBeVisible()
+  await expect(page.getByText("Search", { exact: true })).toHaveCount(0)
   await expect(
     page.getByRole("heading", { name: "Taskforce", exact: true }),
   ).toBeVisible()

--- a/tests/taskforce-shell.spec.ts
+++ b/tests/taskforce-shell.spec.ts
@@ -227,6 +227,7 @@ test("Upgrade link opens membership tiers with current and selected indicators",
   )
   await expect(page.getByTestId("membership-plan-pro")).toContainText("$4.99")
   await expect(page.getByTestId("membership-plan-max")).toContainText("$49.99")
+  await expect(page.getByText("Enterprise Search")).toHaveCount(0)
 
   let checkoutBody: unknown
   await page.route("**/api/v1/billing/checkout-session", async (route) => {
@@ -253,37 +254,85 @@ test("Taskforce v2 wordmark links to Taskforce Library", async ({ page }) => {
   await expect(page).toHaveURL(/\/v2\/library$/)
 })
 
-test("Taskforce v2 document search filters demo documents and opens results", async ({
+test("Taskforce v2 document search isolates live and demo results and opens documents", async ({
   page,
 }) => {
   await mockTaskforceAuth(page)
   await mockV2Documents(page)
+
+  let releaseLiveDocuments: (() => void) | undefined
+  const liveDocumentsReady = new Promise<void>((resolve) => {
+    releaseLiveDocuments = resolve
+  })
+  await page.route("**/api/v1/v2/documents/**", async (route) => {
+    const url = new URL(route.request().url())
+    if (
+      url.pathname !== "/api/v1/v2/documents/" ||
+      url.searchParams.get("demo") === "true"
+    ) {
+      await route.fallback()
+      return
+    }
+
+    await liveDocumentsReady
+    await route.fulfill({
+      json: {
+        data: [
+          {
+            id: "live-document-1",
+            owner_id: "user-1",
+            organization_id: null,
+            folder_id: null,
+            folder_name: null,
+            visibility: "private",
+            user_access: "owner",
+            is_favorite: false,
+            title: "Live Architecture Decision",
+            description: "Production library context for the current user.",
+            human_summary: "Live-only searchable content.",
+            ai_generated_summary: "",
+            collaborators: ["Alex Lee"],
+            shared_with: [],
+            main_body: [{ segments: [{ text: "Live architecture details." }] }],
+            details_file_name: "live-architecture-decision.details.md",
+            details_markdown_sections: [],
+            is_demo: false,
+            created_at: "2026-06-01T00:00:00Z",
+            updated_at: "2026-06-01T00:00:00Z",
+          },
+        ],
+        count: 1,
+      },
+    })
+  })
 
   await page.goto("/v2/library")
 
   const search = page.getByTestId("v2-document-lookup-input")
   await expect(search).toBeVisible()
 
-  // Without demo mode, typing prompts the user to enable it.
-  await search.fill("bridge")
-  await expect(page.getByTestId("v2-document-lookup-hint")).toBeVisible()
-  await expect(page.getByTestId("v2-document-lookup-results")).toContainText(
-    "demo mode",
+  await search.fill("live architecture")
+  await expect(page.getByTestId("v2-document-lookup-loading")).toBeVisible()
+  releaseLiveDocuments?.()
+  await expect(
+    page.getByTestId("v2-document-lookup-result-live-document-1"),
+  ).toBeVisible()
+  await expect(page.getByText("Latest Stale Network Bridge Issue")).toHaveCount(
+    0,
   )
 
-  // Enabling demo mode replaces the hint with matching documents.
+  // Demo mode uses its separate query cache and only returns demo documents.
   await search.fill("")
   await page.getByTestId("demo-mode-toggle").click()
   await search.fill("bridge")
-  const lookupResults = page.getByTestId("v2-document-lookup-results")
   await expect(
-    lookupResults
+    page.getByTestId("v2-document-lookup-result-live-document-1"),
+  ).toHaveCount(0)
+  await expect(
+    page
       .getByText("Latest Stale Network Bridge Issue", { exact: true })
       .first(),
   ).toBeVisible()
-  await expect(
-    lookupResults.getByText("Hosted MCP Credential Setup Refresh"),
-  ).toHaveCount(0)
 
   // Unrelated query produces an empty-state message.
   await search.fill("zzzzznomatch")
@@ -300,6 +349,7 @@ test("Taskforce v2 document search filters demo documents and opens results", as
   await expect(page).toHaveURL(
     /\/v2\/library\/5b7462e9-6b0e-4d48-81a2-07f052534a12$/,
   )
+
   await expect(
     page.getByRole("heading", { name: "V2 Document Evidence Contract" }),
   ).toBeVisible()
@@ -323,6 +373,37 @@ test("Taskforce v2 document search filters demo documents and opens results", as
   await expect(page.getByTestId("v2-document-lookup-results")).toBeVisible()
   await search.press("Escape")
   await expect(page.getByTestId("v2-document-lookup-results")).toHaveCount(0)
+})
+
+test("Taskforce v2 document search retries live API failures", async ({
+  page,
+}) => {
+  await mockTaskforceAuth(page)
+
+  let requestCount = 0
+  await page.route("**/api/v1/v2/documents/**", async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname !== "/api/v1/v2/documents/") {
+      await route.fulfill({ status: 404, json: { detail: "Not found" } })
+      return
+    }
+
+    requestCount += 1
+    if (requestCount === 1) {
+      await route.fulfill({ status: 503, json: { detail: "Unavailable" } })
+      return
+    }
+    await route.fulfill({ json: { data: [], count: 0 } })
+  })
+
+  await page.goto("/v2/pricing")
+  const search = page.getByTestId("v2-document-lookup-input")
+  await search.fill("retry me")
+
+  await expect(page.getByTestId("v2-document-lookup-error")).toBeVisible()
+  await page.getByRole("button", { name: "Try again" }).click()
+  await expect(page.getByTestId("v2-document-lookup-empty")).toBeVisible()
+  expect(requestCount).toBe(2)
 })
 
 test("Taskforce v2 library shows document demo data only in demo mode", async ({


### PR DESCRIPTION
## Summary
- enable top-bar document lookup for live libraries while preserving separate demo/live query caches
- add loading, API error/retry, empty, keyboard, and navigation behavior for document lookup
- remove unreachable Enterprise Search claims from Max pricing and the public product preview
- retain the explicit `/v2/search` redirect to Library while RAG Search remains disabled

## Product decision
RAG/Enterprise Search remains disabled and absent from navigation. The source implementation is not imported by the redirecting route, so it is not included in the reachable route bundle; pricing and marketing no longer advertise it.

## Validation
- `bun run build`
- `playwright test tests/home-docs.spec.ts tests/taskforce-shell.spec.ts tests/taskforce-routing.spec.ts:65 --project=chromium --no-deps --workers=1` (12 passed)
- broader selected run: 18 passed, with one unrelated existing routing expectation (`/skills` expects Library while the current app redirects to Profiles)

## Jira
- [TF-231](https://alexlee4190.atlassian.net/browse/TF-231)
- [TF-236](https://alexlee4190.atlassian.net/browse/TF-236)