### PR TITLE
TF-234: Finish profile status lifecycle

### DIFF
--- a/src/api/v2Agents.ts
+++ b/src/api/v2Agents.ts
@@ -34,6 +34,7 @@ export interface AgentSpecialistUpdate {
   role?: string
   short_description?: string
   domain_tags?: string[]
+  status?: AgentSpecialistStatus
 }
 
 export interface AgentSpecialistLinkedDoc {
@@ -69,6 +70,7 @@ export interface AgentSpecialistDetail {
   slug: string
   name: string
   role: string
+  status: AgentSpecialistStatus
   short_description: string
   description: string
   created_from: string

--- a/src/components/V2/Agents/AgentProfileCard.tsx
+++ b/src/components/V2/Agents/AgentProfileCard.tsx
@@ -3,6 +3,7 @@ import { Hash } from "lucide-react"
 
 import type { AgentSpecialistSummary } from "@/api/v2Agents"
 import { cn } from "@/lib/utils"
+import { AgentStatusBadge } from "./AgentStatusBadge"
 import { formatCompactNumber, formatRelativeTime } from "./formatters"
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
@@ -81,8 +82,11 @@ export function AgentProfileCard({ agent }: { agent: AgentSpecialistSummary }) {
           {initialsOf(agent.name)}
         </div>
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-semibold tracking-[-0.01em]">
-            {agent.name}
+          <div className="flex items-center justify-between gap-2">
+            <div className="truncate text-sm font-semibold tracking-[-0.01em]">
+              {agent.name}
+            </div>
+            <AgentStatusBadge status={agent.status} className="h-6 shrink-0" />
           </div>
           <div className="mt-[3px] font-mono text-[10px] uppercase tracking-[0.12em] text-foreground/70">
             {agent.role}

--- a/src/components/V2/Agents/AgentStatusBadge.tsx
+++ b/src/components/V2/Agents/AgentStatusBadge.tsx
@@ -1,0 +1,37 @@
+import type { AgentSpecialistStatus } from "@/api/v2Agents"
+import { cn } from "@/lib/utils"
+
+const STATUS_STYLES: Record<AgentSpecialistStatus, string> = {
+  active: "border-emerald-500/30 text-emerald-700 dark:text-emerald-400",
+  draft: "border-amber-500/30 text-amber-700 dark:text-amber-400",
+  archived: "border-border text-muted-foreground",
+}
+
+export function AgentStatusBadge({
+  status,
+  className,
+}: {
+  status: AgentSpecialistStatus
+  className?: string
+}) {
+  return (
+    <span
+      data-testid={`agent-status-${status}`}
+      className={cn(
+        "inline-flex h-7 items-center gap-2 rounded-md border px-2.5 text-xs font-medium capitalize",
+        STATUS_STYLES[status],
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          "size-1.5 rounded-full",
+          status === "active" && "bg-emerald-500",
+          status === "draft" && "bg-amber-500",
+          status === "archived" && "bg-muted-foreground/60",
+        )}
+      />
+      {status}
+    </span>
+  )
+}

--- a/src/components/V2/Agents/EditProfileDialog.tsx
+++ b/src/components/V2/Agents/EditProfileDialog.tsx
@@ -3,6 +3,7 @@ import { type FormEvent, useEffect, useState } from "react"
 
 import type {
   AgentSpecialistDetail,
+  AgentSpecialistStatus,
   AgentSpecialistUpdate,
 } from "@/api/v2Agents"
 import { Button } from "@/components/ui/button"
@@ -16,6 +17,13 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 
 function parseTags(raw: string): string[] {
@@ -50,6 +58,7 @@ export function EditProfileDialog({
   const [role, setRole] = useState(agent.role)
   const [description, setDescription] = useState(agent.short_description)
   const [tags, setTags] = useState(agent.domain_tags.join(", "))
+  const [status, setStatus] = useState<AgentSpecialistStatus>(agent.status)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
 
   // Re-seed the form from the current profile each time the dialog opens.
@@ -59,6 +68,7 @@ export function EditProfileDialog({
       setRole(agent.role)
       setDescription(agent.short_description)
       setTags(agent.domain_tags.join(", "))
+      setStatus(agent.status)
       setConfirmingDelete(false)
     }
   }, [open, agent])
@@ -74,6 +84,7 @@ export function EditProfileDialog({
       role: role.trim(),
       short_description: description.trim(),
       domain_tags: parseTags(tags),
+      status,
     })
   }
 
@@ -115,6 +126,28 @@ export function EditProfileDialog({
               placeholder="One line on what this profile owns."
               rows={3}
             />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-profile-status">Status</Label>
+            <Select
+              value={status}
+              onValueChange={(value) =>
+                setStatus(value as AgentSpecialistStatus)
+              }
+              disabled={busy}
+            >
+              <SelectTrigger id="edit-profile-status" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="active">Active</SelectItem>
+                <SelectItem value="draft">Draft</SelectItem>
+                <SelectItem value="archived">Archived</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Only active profiles can be selected for Taskforce routing.
+            </p>
           </div>
           <div className="space-y-2">
             <Label htmlFor="edit-profile-tags">Domain tags</Label>

--- a/src/components/V2/Agents/agentDetailPlaceholder.ts
+++ b/src/components/V2/Agents/agentDetailPlaceholder.ts
@@ -12,6 +12,7 @@ export function agentSummaryToDetailPlaceholder(
     slug: summary.slug,
     name: summary.name,
     role: summary.role,
+    status: summary.status,
     short_description: summary.short_description,
     description: summary.short_description,
     created_from: summary.created_from,

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -14,6 +14,7 @@ import {
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Button } from "@/components/ui/button"
 import { AgentDetailSkeleton } from "@/components/V2/Agents/AgentDetailSkeleton"
+import { AgentStatusBadge } from "@/components/V2/Agents/AgentStatusBadge"
 import {
   agentSummaryToDetailPlaceholder,
   findAgentSummaryInList,
@@ -463,7 +464,7 @@ function AgentDetailPage() {
           <div>
             <div className={AGENT_BREADCRUMB_CLASS}>
               <Link to="/v2/agents" className="hover:text-foreground">
-                Agents
+                Profiles
               </Link>
               <span className="px-2 text-muted-foreground/50">/</span>
               <span className="text-foreground">{agent.slug}</span>
@@ -484,10 +485,7 @@ function AgentDetailPage() {
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <span className="inline-flex h-8 items-center gap-2 rounded-md border border-black/10 px-3 text-xs font-medium text-emerald-600 dark:border-white/12 dark:text-emerald-400">
-              <span className="size-1.5 rounded-full bg-emerald-500" />
-              Active
-            </span>
+            <AgentStatusBadge status={agent.status} className="h-8 px-3" />
             <button
               type="button"
               onClick={() => setEditOpen(true)}

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -37,7 +37,7 @@ const agents = [
     short_description:
       "Indexer drift, pgvector retrieval, and citation anchors.",
     domain_tags: ["Search", "Retrieval", "Citations"],
-    status: "active",
+    status: "archived",
     created_from: "seeded",
     linked_docs_count: 2,
     invocations_count: 4,
@@ -51,6 +51,9 @@ const jensenDetail = {
   slug: "jensen",
   name: "Jensen",
   role: "Billing Reliability Specialist",
+  status: "active",
+  short_description:
+    "Stripe webhooks, subscriptions, and double-charge prevention.",
   created_from: "earned",
   description:
     "Helps debug Stripe billing, subscription upgrades, webhook retries, idempotency, duplicate invoices, and customer double-charge incidents.",
@@ -100,6 +103,9 @@ test.use({
 })
 
 async function mockAgentsShell(page: Page, options: { empty?: boolean } = {}) {
+  let agentItems = agents.map((agent) => ({ ...agent }))
+  let detail = { ...jensenDetail }
+
   await page.addInitScript(() => {
     window.localStorage.setItem("access_token", "test-token")
   })
@@ -125,12 +131,19 @@ async function mockAgentsShell(page: Page, options: { empty?: boolean } = {}) {
     const url = new URL(route.request().url())
     if (url.pathname === "/api/v1/v2/agents") {
       await route.fulfill({
-        json: { items: options.empty ? [] : agents },
+        json: { items: options.empty ? [] : agentItems },
       })
       return
     }
     if (url.pathname === "/api/v1/v2/agents/jensen") {
-      await route.fulfill({ json: jensenDetail })
+      if (route.request().method() === "PATCH") {
+        const body = route.request().postDataJSON()
+        detail = { ...detail, ...body }
+        agentItems = agentItems.map((agent) =>
+          agent.slug === "jensen" ? { ...agent, ...body } : agent,
+        )
+      }
+      await route.fulfill({ json: detail })
       return
     }
     await route.fulfill({ status: 404, json: { detail: "Not found" } })
@@ -155,10 +168,9 @@ test("direct specialist URL renders detail instead of the agents grid", async ({
     page.getByRole("heading", { name: "Jensen", level: 1 }),
   ).toBeVisible()
   await expect(page.getByText("Operating instructions")).toBeVisible()
-  await expect(page.getByText("Earned from")).toBeVisible()
-  await expect(page.getByText("Earned profile")).toBeVisible()
+  await expect(page.getByTestId("agent-status-active")).toBeVisible()
   await expect(
-    page.getByRole("heading", { name: "Agents", level: 1 }),
+    page.getByRole("heading", { name: "Profiles", level: 1 }),
   ).toHaveCount(0)
 })
 
@@ -173,7 +185,7 @@ test("agent detail navigation does not flash no-access or not-found", async ({
   })
 
   await page.goto("/v2/agents")
-  await page.getByRole("link", { name: /open specialist jensen/i }).click()
+  await page.getByRole("link", { name: /open profile jensen/i }).click()
 
   await expect(page).toHaveURL(/\/v2\/agents\/jensen$/)
   await expect(
@@ -238,34 +250,31 @@ test("v2 route invalid session redirects to login instead of membership no-acces
     .toBeNull()
 })
 
-test("agents grid links to specialist detail and session metrics", async ({
-  page,
-}) => {
+test("profiles grid links to detail and session metrics", async ({ page }) => {
   await mockAgentsShell(page)
 
   await page.goto("/v2/agents")
 
   await expect(
-    page.getByRole("heading", { name: "Agents", level: 1 }),
+    page.getByRole("heading", { name: "Profiles", level: 1 }),
   ).toBeVisible()
-  await expect(page.getByTestId("agents-grid")).toBeVisible()
-  await expect(
-    page.getByRole("heading", { name: "Jensen", level: 3 }),
-  ).toBeVisible()
-  await expect(
-    page.getByRole("heading", { name: "Mira", level: 3 }),
-  ).toBeVisible()
+  await expect(page.getByTestId("agents-card-grid")).toBeVisible()
+  await expect(page.getByText("Jensen", { exact: true })).toBeVisible()
+  await expect(page.getByText("Mira", { exact: true })).toBeVisible()
+  await expect(page.getByTestId("agent-status-active")).toBeVisible()
+  await expect(page.getByTestId("agent-status-archived")).toBeVisible()
 
-  await page.getByRole("link", { name: /open specialist jensen/i }).click()
+  await page.getByRole("link", { name: /open profile jensen/i }).click()
   await expect(page).toHaveURL(/\/v2\/agents\/jensen$/)
   await expect(
     page.getByRole("heading", { name: "Jensen", level: 1 }),
   ).toBeVisible()
   await expect(page.getByText("Operating instructions")).toBeVisible()
-  await expect(page.getByRole("link", { name: /^Sessions$/ })).toHaveAttribute(
-    "href",
-    "/v2/ledger?specialist=jensen",
-  )
+  await expect(
+    page.getByRole("link", {
+      name: /open session "stripe is double-charging some users/i,
+    }),
+  ).toHaveAttribute("href", "/v2/ledger?session_id=session-1")
 
   const linkedKnowledge = page.getByRole("link", {
     name: /Stripe webhook idempotency strategy/,
@@ -277,13 +286,48 @@ test("agents grid links to specialist detail and session metrics", async ({
 
   await page
     .getByRole("link", {
-      name: /Stripe is double-charging some users on plan upgrades/,
+      name: /open metrics for "stripe is double-charging some users/i,
     })
     .click()
   await expect(page).toHaveURL(/\/v2\/metrics\?session_id=session-1$/)
 })
 
-test("agents grid shows empty state before specialists are seeded", async ({
+test("profile lifecycle updates detail and list filters", async ({ page }) => {
+  await mockAgentsShell(page)
+
+  await page.goto("/v2/agents/jensen")
+  await expect(page.getByTestId("agent-status-active")).toBeVisible()
+
+  await page.getByRole("button", { name: "Edit" }).click()
+  await page.getByLabel("Status").click()
+  await page.getByRole("option", { name: "Archived" }).click()
+
+  const updateResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/v2/agents/jensen") &&
+      response.request().method() === "PATCH",
+  )
+  await page.getByRole("button", { name: "Save" }).click()
+  expect(
+    await updateResponse.then((response) => response.request().postDataJSON()),
+  ).toMatchObject({ status: "archived" })
+  await expect(page.getByTestId("agent-status-archived")).toBeVisible()
+
+  await page
+    .getByTestId("agent-detail-sticky-header")
+    .getByRole("link", { name: "Profiles" })
+    .click()
+  await page.getByRole("button", { name: /^Archived/ }).click()
+  await expect(
+    page.getByRole("link", { name: /open profile jensen/i }),
+  ).toBeVisible()
+  await page.getByRole("button", { name: /^Active/ }).click()
+  await expect(
+    page.getByRole("link", { name: /open profile jensen/i }),
+  ).toHaveCount(0)
+})
+
+test("profiles grid shows empty state before profiles are seeded", async ({
   page,
 }) => {
   await mockAgentsShell(page, { empty: true })
@@ -291,11 +335,11 @@ test("agents grid shows empty state before specialists are seeded", async ({
   await page.goto("/v2/agents")
 
   await expect(
-    page.getByRole("heading", { name: "No specialists yet" }),
+    page.getByRole("heading", { name: "No profiles yet" }),
   ).toBeVisible()
   await expect(
     page.getByText(
-      "Agents will appear here after Taskforce packages reusable specialist knowledge",
+      "Agents will appear here after Taskforce packages reusable profile knowledge",
     ),
   ).toBeVisible()
 })


### PR DESCRIPTION
## Summary
- add accurate Active/Draft/Archived badges to Profile cards and detail
- expose lifecycle changes in Edit Profile and explain active-only routing
- hydrate status correctly from list summaries while opening detail
- update Profiles Playwright coverage for lifecycle changes and current UI contracts

## Dependency
Merge after the backend TF-234 API PR.

## Validation
- `bun run build`
- `playwright test tests/agents-routing.spec.ts --project=chromium --no-deps --workers=1` (7 passed)

## Jira
- [TF-234](https://alexlee4190.atlassian.net/browse/TF-234)