### PR TITLE
TF-237/TF-238: Add V2 reliability states and CI gate

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,49 @@
+name: Frontend CI
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    env:
+      VITE_API_URL: http://127.0.0.1:8000
+      VITE_FIREBASE_API_KEY: test-api-key
+      VITE_FIREBASE_AUTH_DOMAIN: test.firebaseapp.com
+      VITE_FIREBASE_PROJECT_ID: test-project
+      VITE_FIREBASE_MESSAGING_SENDER_ID: "123456789"
+      VITE_FIREBASE_APP_ID: 1:123456789:web:test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Run mocked V2 browser suite
+        run: npm run test:mocked
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "generate-client": "openapi-ts",
     "test": "bunx playwright test",
+    "test:mocked": "playwright test --config=playwright.mocked.config.ts",
     "test:ui": "bunx playwright test --ui"
   },
   "dependencies": {

--- a/playwright.mocked.config.ts
+++ b/playwright.mocked.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from "@playwright/test"
+
+const mockedSpecs = [
+  "agents-routing",
+  "fleet",
+  "home-docs",
+  "landing",
+  "ledger",
+  "taskforce-external-links",
+  "taskforce-routing",
+  "taskforce-shell",
+  "v2-document-hash",
+  "v2-metrics-session",
+  "v2-query-errors",
+].join("|")
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: new RegExp(`(${mockedSpecs})\\.spec\\.ts$`),
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    storageState: {
+      cookies: [],
+      origins: [],
+    },
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "mocked-chromium",
+      use: devices["Desktop Chrome"],
+    },
+  ],
+  webServer: {
+    command: process.env.CI
+      ? "npm run dev -- --host 127.0.0.1"
+      : "bun ./node_modules/vite/bin/vite.js --host 127.0.0.1",
+    url: "http://127.0.0.1:5173",
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/src/components/V2/QueryErrorState.tsx
+++ b/src/components/V2/QueryErrorState.tsx
@@ -1,0 +1,71 @@
+import { AlertCircle, Loader2, RotateCw } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export function QueryErrorState({
+  title,
+  description,
+  onRetry,
+  isRetrying = false,
+  compact = false,
+  testId,
+}: {
+  title: string
+  description: string
+  onRetry: () => void
+  isRetrying?: boolean
+  compact?: boolean
+  testId?: string
+}) {
+  return (
+    <div
+      role="alert"
+      data-testid={testId}
+      className={cn(
+        "border border-destructive/30 bg-destructive/5 text-foreground",
+        compact
+          ? "flex flex-wrap items-center justify-between gap-3 px-3 py-2"
+          : "flex min-h-52 flex-col items-start justify-center p-8",
+      )}
+    >
+      <div className={cn("flex gap-3", !compact && "max-w-xl")}>
+        <AlertCircle
+          className={cn(
+            "shrink-0 text-destructive",
+            compact ? "mt-0.5 size-4" : "mt-1 size-5",
+          )}
+          aria-hidden
+        />
+        <div>
+          <h2 className={cn("font-semibold", compact ? "text-sm" : "text-lg")}>
+            {title}
+          </h2>
+          <p
+            className={cn(
+              "text-muted-foreground",
+              compact ? "mt-0.5 text-xs" : "mt-2 text-sm leading-6",
+            )}
+          >
+            {description}
+          </p>
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size={compact ? "sm" : "default"}
+        className={cn(!compact && "mt-5")}
+        onClick={onRetry}
+        disabled={isRetrying}
+      >
+        {isRetrying ? (
+          <Loader2 className="size-4 animate-spin" aria-hidden />
+        ) : (
+          <RotateCw className="size-4" aria-hidden />
+        )}
+        {isRetrying ? "Trying again…" : "Try again"}
+      </Button>
+    </div>
+  )
+}

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -11,6 +11,7 @@ import {
   getAgent,
   updateAgent,
 } from "@/api/v2Agents"
+import { ApiError } from "@/client"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Button } from "@/components/ui/button"
 import { AgentDetailSkeleton } from "@/components/V2/Agents/AgentDetailSkeleton"
@@ -36,6 +37,7 @@ import {
   formatCompactNumber,
   formatRelativeTime,
 } from "@/components/V2/Agents/formatters"
+import { QueryErrorState } from "@/components/V2/QueryErrorState"
 import {
   V2_PAGE_BODY,
   V2_PAGE_CONTENT,
@@ -404,6 +406,7 @@ function AgentDetailPage() {
       const summary = findAgentSummaryInList(list, slug)
       return summary ? agentSummaryToDetailPlaceholder(summary) : undefined
     },
+    retry: false,
   })
   const agent = agentQuery.data
   const isAgentError = agentQuery.isError
@@ -412,10 +415,17 @@ function AgentDetailPage() {
   const isAgentPending = agentQuery.isPending
   const isAgentPlaceholderData = agentQuery.isPlaceholderData
   const hasMatchingAgent = agent?.slug === slug
+  const isAgentNotFound =
+    agentQuery.error instanceof ApiError && agentQuery.error.status === 404
   const showNotFound =
-    isAgentError || (isAgentFetched && !isAgentFetching && !hasMatchingAgent)
+    isAgentNotFound ||
+    (!isAgentError && isAgentFetched && !isAgentFetching && !hasMatchingAgent)
+  const showLoadError = isAgentError && !isAgentNotFound && !hasMatchingAgent
   const showFullSkeleton =
-    !showNotFound && !agent && (isAgentPending || isAgentFetching)
+    !showNotFound &&
+    !showLoadError &&
+    !agent &&
+    (isAgentPending || isAgentFetching)
   const isHydratingDetail =
     hasMatchingAgent && isAgentFetching && isAgentPlaceholderData
 
@@ -425,6 +435,24 @@ function AgentDetailPage() {
         className={`${V2_PAGE_FRAME} bg-background font-sans text-foreground`}
       >
         <AgentDetailSkeleton shellClassName={AGENTS_DETAIL_SHELL} />
+      </section>
+    )
+  }
+
+  if (showLoadError) {
+    return (
+      <section
+        className={`${V2_PAGE_FRAME} bg-background font-sans text-foreground`}
+      >
+        <div className={V2_PAGE_CONTENT}>
+          <QueryErrorState
+            title="Could not load this profile"
+            description="The profile service returned an unexpected error. Try again without reloading the page."
+            onRetry={() => void agentQuery.refetch()}
+            isRetrying={agentQuery.isFetching}
+            testId="profile-detail-load-error"
+          />
+        </div>
       </section>
     )
   }
@@ -454,6 +482,16 @@ function AgentDetailPage() {
       className={`${V2_PAGE_FRAME} bg-background font-sans text-foreground`}
     >
       <div className={AGENTS_DETAIL_SHELL}>
+        {isAgentError && (
+          <QueryErrorState
+            title="Profile details may be out of date"
+            description="The latest profile details could not be loaded. The last available version is still shown."
+            onRetry={() => void agentQuery.refetch()}
+            isRetrying={agentQuery.isFetching}
+            compact
+            testId="profile-detail-refresh-error"
+          />
+        )}
         <header
           data-testid="agent-detail-sticky-header"
           className={cn(

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -23,6 +23,7 @@ import {
   AGENT_PAGE_TITLE_CLASS,
 } from "@/components/V2/Agents/agentsTypography"
 import { CreateProfileDialog } from "@/components/V2/Agents/CreateProfileDialog"
+import { QueryErrorState } from "@/components/V2/QueryErrorState"
 import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
 import {
   V2_PAGE_BODY,
@@ -107,8 +108,10 @@ function AgentsIndex() {
   const agentsQuery = useQuery({
     queryKey: ["v2-agents", isDemoMode],
     queryFn: () => listAgents({ demo: isDemoMode }),
+    retry: false,
   })
   const agents = agentsQuery.data?.items ?? []
+  const hasAgentsData = agentsQuery.data !== undefined
   const activeCount = agents.filter((agent) => agent.status === "active").length
 
   const createProfileMutation = useMutation({
@@ -191,23 +194,45 @@ function AgentsIndex() {
           onSubmit={(values) => createProfileMutation.mutate(values)}
         />
 
-        {agentsQuery.isLoading ? (
+        {agentsQuery.isError && !hasAgentsData ? (
+          <QueryErrorState
+            title="Could not load profiles"
+            description="Taskforce could not reach the profiles service. Try again without leaving this page."
+            onRetry={() => void agentsQuery.refetch()}
+            isRetrying={agentsQuery.isFetching}
+            testId="profiles-load-error"
+          />
+        ) : agentsQuery.isLoading ? (
           <AgentsLoading />
-        ) : agents.length === 0 ? (
-          <EmptyAgents isDemoMode={isDemoMode} />
-        ) : visible.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            No profiles match this filter.
-          </p>
         ) : (
-          <div
-            data-testid="agents-card-grid"
-            className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
-          >
-            {visible.map((agent) => (
-              <AgentProfileCard key={agent.id} agent={agent} />
-            ))}
-          </div>
+          <>
+            {agentsQuery.isError && (
+              <QueryErrorState
+                title="Profiles may be out of date"
+                description="The latest profiles could not be loaded. The last available results are still shown."
+                onRetry={() => void agentsQuery.refetch()}
+                isRetrying={agentsQuery.isFetching}
+                compact
+                testId="profiles-refresh-error"
+              />
+            )}
+            {agents.length === 0 ? (
+              <EmptyAgents isDemoMode={isDemoMode} />
+            ) : visible.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No profiles match this filter.
+              </p>
+            ) : (
+              <div
+                data-testid="agents-card-grid"
+                className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+              >
+                {visible.map((agent) => (
+                  <AgentProfileCard key={agent.id} agent={agent} />
+                ))}
+              </div>
+            )}
+          </>
         )}
 
         {agentsQuery.isFetching && !agentsQuery.isLoading && (

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -12,9 +12,9 @@ import {
   Heading3,
   Italic,
   Link as LinkIcon,
-  ReceiptText,
   Pencil,
   Pilcrow,
+  ReceiptText,
   Search,
   Share2,
   Star,
@@ -54,6 +54,7 @@ import {
   type LedgerSessionRow,
   readDocumentLedgerSessions,
 } from "@/api/v2Ledger"
+import { ApiError } from "@/client"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -72,6 +73,7 @@ import {
   FolderCreateDialog,
   FolderPickerDropdown,
 } from "@/components/V2/Library/FolderControls"
+import { QueryErrorState } from "@/components/V2/QueryErrorState"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
@@ -546,6 +548,7 @@ function TaskforceDocumentDetail() {
   const documentQuery = useQuery({
     queryKey: ["v2-document", documentId, { demo: isDemoMode }],
     queryFn: () => readV2Document(documentId, { demo: isDemoMode }),
+    retry: false,
   })
 
   const document = documentQuery.data
@@ -577,12 +580,14 @@ function TaskforceDocumentDetail() {
     queryKey: ["organization-me"],
     queryFn: readMyOrganization,
     enabled: canManageDocument,
+    retry: false,
   })
 
   const sharesQuery = useQuery({
     queryKey: ["v2-document-shares", documentId],
     queryFn: () => readV2DocumentShares(documentId),
     enabled: canManageDocument,
+    retry: false,
   })
 
   const updateMutation = useMutation({
@@ -830,6 +835,26 @@ function TaskforceDocumentDetail() {
     )
   }
 
+  const isDocumentNotFound =
+    documentQuery.error instanceof ApiError &&
+    documentQuery.error.status === 404
+
+  if (documentQuery.isError && !isDocumentNotFound && !document) {
+    return (
+      <section className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto">
+        <div className="w-full max-w-3xl">
+          <QueryErrorState
+            title="Could not load this document"
+            description="The document service returned an unexpected error. Try again without reloading the page."
+            onRetry={() => void documentQuery.refetch()}
+            isRetrying={documentQuery.isFetching}
+            testId="document-detail-load-error"
+          />
+        </div>
+      </section>
+    )
+  }
+
   if (!document) {
     return (
       <section className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto">
@@ -897,6 +922,16 @@ function TaskforceDocumentDetail() {
           isSplit && "md:min-h-0 md:flex-1 md:overflow-hidden",
         )}
       >
+        {documentQuery.isError && (
+          <QueryErrorState
+            title="Document details may be out of date"
+            description="The latest document could not be loaded. The last available version is still shown."
+            onRetry={() => void documentQuery.refetch()}
+            isRetrying={documentQuery.isFetching}
+            compact
+            testId="document-detail-refresh-error"
+          />
+        )}
         <div
           data-testid="v2-document-sticky-header"
           className={cn(
@@ -1019,6 +1054,14 @@ function TaskforceDocumentDetail() {
             isSavingAccess={shareMutation.isPending}
             isLoadingAccess={
               sharesQuery.isLoading || organizationQuery.isLoading
+            }
+            hasAccessError={sharesQuery.isError || organizationQuery.isError}
+            onRetryAccess={() => {
+              if (sharesQuery.isError) void sharesQuery.refetch()
+              if (organizationQuery.isError) void organizationQuery.refetch()
+            }}
+            isRetryingAccess={
+              sharesQuery.isFetching || organizationQuery.isFetching
             }
             onMoveFolder={moveDocumentToFolder}
             isMovingFolder={updateMutation.isPending}
@@ -1209,6 +1252,9 @@ function DocumentMetadata({
   onSaveAccess,
   isSavingAccess,
   isLoadingAccess,
+  hasAccessError,
+  onRetryAccess,
+  isRetryingAccess,
   onMoveFolder,
   isMovingFolder,
   onCreateFolder,
@@ -1233,6 +1279,9 @@ function DocumentMetadata({
   onSaveAccess: () => void
   isSavingAccess: boolean
   isLoadingAccess: boolean
+  hasAccessError: boolean
+  onRetryAccess: () => void
+  isRetryingAccess: boolean
   onMoveFolder: (folderId: string | null) => void
   isMovingFolder: boolean
   onCreateFolder: () => void
@@ -1290,6 +1339,9 @@ function DocumentMetadata({
           onSave={onSaveAccess}
           isSaving={isSavingAccess}
           isLoading={isLoadingAccess}
+          hasError={hasAccessError}
+          onRetry={onRetryAccess}
+          isRetrying={isRetryingAccess}
         />
       ) : (
         <span className="inline-flex items-center gap-1.5 text-muted-foreground">
@@ -1397,6 +1449,9 @@ function DocumentAccessDropdown({
   onSave,
   isSaving,
   isLoading,
+  hasError,
+  onRetry,
+  isRetrying,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -1408,6 +1463,9 @@ function DocumentAccessDropdown({
   onSave: () => void
   isSaving: boolean
   isLoading: boolean
+  hasError: boolean
+  onRetry: () => void
+  isRetrying: boolean
 }) {
   const [query, setQuery] = useState("")
   const shareableMembers = members.filter((member) => member.id !== ownerId)
@@ -1457,17 +1515,28 @@ function DocumentAccessDropdown({
           />
         </div>
         <div className="max-h-72 space-y-1 overflow-y-auto">
+          {hasError && (
+            <QueryErrorState
+              title="Could not load sharing access"
+              description="Existing document access is unchanged. Try loading organization members again."
+              onRetry={onRetry}
+              isRetrying={isRetrying}
+              compact
+              testId="document-access-load-error"
+            />
+          )}
           {isLoading && (
             <div className="px-2 py-3 text-sm text-muted-foreground">
               Loading access…
             </div>
           )}
-          {!isLoading && shareableMembers.length === 0 && (
+          {!isLoading && !hasError && shareableMembers.length === 0 && (
             <div className="px-2 py-3 text-sm text-muted-foreground">
               No organization members available.
             </div>
           )}
           {!isLoading &&
+            !hasError &&
             filteredMembers.length === 0 &&
             shareableMembers.length > 0 && (
               <div className="px-2 py-3 text-sm text-muted-foreground">
@@ -1475,6 +1544,7 @@ function DocumentAccessDropdown({
               </div>
             )}
           {!isLoading &&
+            !hasError &&
             filteredMembers.map((member) => {
               const permission = shareDraft[member.id]
               const checked = Boolean(permission)
@@ -1536,7 +1606,12 @@ function DocumentAccessDropdown({
           <span className="text-xs text-muted-foreground">
             {assignedCount} selected
           </span>
-          <Button type="button" size="sm" onClick={onSave} disabled={isSaving}>
+          <Button
+            type="button"
+            size="sm"
+            onClick={onSave}
+            disabled={isSaving || hasError}
+          >
             {isSaving ? "Saving" : "Save access"}
           </Button>
         </div>

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -79,6 +79,7 @@ import {
   FolderPickerDropdown,
 } from "@/components/V2/Library/FolderControls"
 import { LibraryRecentReel } from "@/components/V2/Library/LibraryRecentReel"
+import { QueryErrorState } from "@/components/V2/QueryErrorState"
 import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
 import {
   V2_PAGE_BODY,
@@ -253,11 +254,13 @@ function TaskforceLibrary() {
   const documentsQuery = useQuery({
     queryKey: documentsQueryKey,
     queryFn: () => readV2Documents({ demo: isDemoMode }),
+    retry: false,
   })
 
   const foldersQuery = useQuery({
     queryKey: foldersQueryKey,
     queryFn: () => readV2DocumentFolders({ demo: isDemoMode }),
+    retry: false,
   })
 
   const moveDocumentMutation = useMutation({
@@ -563,8 +566,14 @@ function TaskforceLibrary() {
     return grouped
   }, [documents, folders])
   const isLoading = documentsQuery.isLoading || foldersQuery.isLoading
+  const hasInitialLoadError =
+    (documentsQuery.isError && documentsQuery.data === undefined) ||
+    (foldersQuery.isError && foldersQuery.data === undefined)
+  const hasRefreshError =
+    !hasInitialLoadError && (documentsQuery.isError || foldersQuery.isError)
   const isEmpty =
     !isLoading &&
+    !hasInitialLoadError &&
     documents.length === 0 &&
     (libraryView === "files" || folders.length === 0)
   const isFolderEmpty =
@@ -577,6 +586,10 @@ function TaskforceLibrary() {
     !moveDocumentMutation.isPending &&
     !moveFolderMutation.isPending &&
     !favoriteMutation.isPending
+  const retryLibrary = () => {
+    if (documentsQuery.isError) void documentsQuery.refetch()
+    if (foldersQuery.isError) void foldersQuery.refetch()
+  }
 
   // Only hand off to a child route when the URL actually has a document
   // segment after /v2/library/. A bare /v2/library/ (trailing slash, no id)
@@ -807,112 +820,139 @@ function TaskforceLibrary() {
             onConfirm={(document) => deleteDocumentMutation.mutate(document.id)}
           />
 
-          {isLoading && <LibraryLoadingSkeleton view={libraryView} />}
-
-          {isEmpty &&
-            (isDemoMode ? (
-              <div className="border bg-card p-6 text-sm text-muted-foreground">
-                No documents yet.
-              </div>
-            ) : (
-              <div className="flex flex-col items-start gap-4 border bg-card p-6">
-                <div>
-                  <h2 className="font-medium text-foreground">
-                    Connect a terminal to start capturing work
-                  </h2>
-                  <p className="mt-1 max-w-xl text-sm leading-6 text-muted-foreground">
-                    Taskforce creates documents automatically as your connected
-                    coding agents work, so context carries across terminals and
-                    VMs.
-                  </p>
-                </div>
-                <Button asChild>
-                  <Link to="/v2/settings" search={{ tab: "connect-agent" }}>
-                    Connect agent
-                  </Link>
-                </Button>
-              </div>
-            ))}
-
-          {!isLoading && documents.length > 0 && (
-            <LibraryRecentReel
-              documents={documents}
-              currentUser={currentUser}
+          {hasInitialLoadError ? (
+            <QueryErrorState
+              title="Could not load the library"
+              description="Taskforce could not load your documents and folders. Try again without leaving this page."
+              onRetry={retryLibrary}
+              isRetrying={documentsQuery.isFetching || foldersQuery.isFetching}
+              testId="library-load-error"
             />
-          )}
+          ) : (
+            <>
+              {hasRefreshError && (
+                <QueryErrorState
+                  title="Library results may be out of date"
+                  description="The latest documents or folders could not be loaded. The last available results are still shown."
+                  onRetry={retryLibrary}
+                  isRetrying={
+                    documentsQuery.isFetching || foldersQuery.isFetching
+                  }
+                  compact
+                  testId="library-refresh-error"
+                />
+              )}
 
-          {!isLoading && documents.length > 0 && libraryView === "files" && (
-            <div className="grid gap-6 xl:grid-cols-[240px_minmax(0,1fr)]">
-              <FolderNav
-                folderTree={folderTree}
-                selectedFolderId={selectedFolderId}
-                setSelectedFolderId={setSelectedFolderId}
-                allCount={documents.length}
-                favoritesCount={favoriteDocuments.length}
-                unfiledCount={folderCounts.unfiled}
-                folderCounts={folderCounts.counts}
-                loading={foldersQuery.isLoading}
-                currentUserId={currentUser.id}
-                demo={isDemoMode}
-                onFolderDeleted={handleFolderDeleted}
-              />
-              <div className="min-w-0 pr-1">
-                {isFolderEmpty && (
+              {isLoading && <LibraryLoadingSkeleton view={libraryView} />}
+
+              {isEmpty &&
+                (isDemoMode ? (
                   <div className="border bg-card p-6 text-sm text-muted-foreground">
-                    No documents in this folder.
+                    No documents yet.
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-start gap-4 border bg-card p-6">
+                    <div>
+                      <h2 className="font-medium text-foreground">
+                        Connect a terminal to start capturing work
+                      </h2>
+                      <p className="mt-1 max-w-xl text-sm leading-6 text-muted-foreground">
+                        Taskforce creates documents automatically as your
+                        connected coding agents work, so context carries across
+                        terminals and VMs.
+                      </p>
+                    </div>
+                    <Button asChild>
+                      <Link to="/v2/settings" search={{ tab: "connect-agent" }}>
+                        Connect agent
+                      </Link>
+                    </Button>
+                  </div>
+                ))}
+
+              {!isLoading && documents.length > 0 && (
+                <LibraryRecentReel
+                  documents={documents}
+                  currentUser={currentUser}
+                />
+              )}
+
+              {!isLoading &&
+                documents.length > 0 &&
+                libraryView === "files" && (
+                  <div className="grid gap-6 xl:grid-cols-[240px_minmax(0,1fr)]">
+                    <FolderNav
+                      folderTree={folderTree}
+                      selectedFolderId={selectedFolderId}
+                      setSelectedFolderId={setSelectedFolderId}
+                      allCount={documents.length}
+                      favoritesCount={favoriteDocuments.length}
+                      unfiledCount={folderCounts.unfiled}
+                      folderCounts={folderCounts.counts}
+                      loading={foldersQuery.isLoading}
+                      currentUserId={currentUser.id}
+                      demo={isDemoMode}
+                      onFolderDeleted={handleFolderDeleted}
+                    />
+                    <div className="min-w-0 pr-1">
+                      {isFolderEmpty && (
+                        <div className="border bg-card p-6 text-sm text-muted-foreground">
+                          No documents in this folder.
+                        </div>
+                      )}
+                      {!isFolderEmpty && (
+                        <InfiniteDocumentGrid
+                          documents={visibleDocuments}
+                          canFavorite={!favoriteMutation.isPending}
+                          onToggleFavorite={toggleFavorite}
+                        />
+                      )}
+                    </div>
                   </div>
                 )}
-                {!isFolderEmpty && (
-                  <InfiniteDocumentGrid
-                    documents={visibleDocuments}
-                    canFavorite={!favoriteMutation.isPending}
-                    onToggleFavorite={toggleFavorite}
-                  />
-                )}
-              </div>
-            </div>
-          )}
 
-          {!isLoading &&
-            (documents.length > 0 || folders.length > 0) &&
-            libraryView === "folders" && (
-              <div className="pr-1">
-                <FolderDirectory
-                  folderTree={folderTree}
-                  documentsByFolder={documentsByFolder}
-                  openFolderIds={openFolderIds}
-                  dragOverFolderId={dragOverFolderId}
-                  canMoveItems={canMutateLibrary}
-                  canFavorite={!favoriteMutation.isPending}
-                  currentUserId={currentUser.id}
-                  demo={isDemoMode}
-                  onToggleFolder={toggleFolderOpen}
-                  onFolderDragStart={(event, folder) => {
-                    event.stopPropagation()
-                    event.dataTransfer.effectAllowed = "move"
-                    event.dataTransfer.setData(
-                      "application/x-v2-folder",
-                      folder.id,
-                    )
-                  }}
-                  onDocumentDragStart={(event, document) => {
-                    event.dataTransfer.effectAllowed = "move"
-                    event.dataTransfer.setData(
-                      "application/x-v2-document",
-                      document.id,
-                    )
-                  }}
-                  onDocumentDragEnd={() => setDragOverFolderId(null)}
-                  onToggleFavorite={toggleFavorite}
-                  onFolderDragOver={handleFolderDragOver}
-                  onFolderDrop={handleFolderDrop}
-                  onUnfiledDrop={handleUnfiledDrop}
-                  onRootFolderDrop={handleRootFolderDrop}
-                  onFolderDragLeave={() => setDragOverFolderId(null)}
-                  onFolderDeleted={handleFolderDeleted}
-                />
-              </div>
-            )}
+              {!isLoading &&
+                (documents.length > 0 || folders.length > 0) &&
+                libraryView === "folders" && (
+                  <div className="pr-1">
+                    <FolderDirectory
+                      folderTree={folderTree}
+                      documentsByFolder={documentsByFolder}
+                      openFolderIds={openFolderIds}
+                      dragOverFolderId={dragOverFolderId}
+                      canMoveItems={canMutateLibrary}
+                      canFavorite={!favoriteMutation.isPending}
+                      currentUserId={currentUser.id}
+                      demo={isDemoMode}
+                      onToggleFolder={toggleFolderOpen}
+                      onFolderDragStart={(event, folder) => {
+                        event.stopPropagation()
+                        event.dataTransfer.effectAllowed = "move"
+                        event.dataTransfer.setData(
+                          "application/x-v2-folder",
+                          folder.id,
+                        )
+                      }}
+                      onDocumentDragStart={(event, document) => {
+                        event.dataTransfer.effectAllowed = "move"
+                        event.dataTransfer.setData(
+                          "application/x-v2-document",
+                          document.id,
+                        )
+                      }}
+                      onDocumentDragEnd={() => setDragOverFolderId(null)}
+                      onToggleFavorite={toggleFavorite}
+                      onFolderDragOver={handleFolderDragOver}
+                      onFolderDrop={handleFolderDrop}
+                      onUnfiledDrop={handleUnfiledDrop}
+                      onRootFolderDrop={handleRootFolderDrop}
+                      onFolderDragLeave={() => setDragOverFolderId(null)}
+                      onFolderDeleted={handleFolderDeleted}
+                    />
+                  </div>
+                )}
+            </>
+          )}
         </div>
       </section>
     </DocumentDeleteContext.Provider>

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -343,3 +343,78 @@ test("profiles grid shows empty state before profiles are seeded", async ({
     ),
   ).toBeVisible()
 })
+
+test("profiles list exposes a retry state instead of an empty state", async ({
+  page,
+}) => {
+  await mockAgentsShell(page)
+  let attempts = 0
+
+  await page.route("**/api/v1/v2/agents**", async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname !== "/api/v1/v2/agents") {
+      await route.fallback()
+      return
+    }
+
+    attempts += 1
+    if (attempts === 1) {
+      await route.fulfill({
+        status: 500,
+        json: { detail: "Profiles temporarily unavailable" },
+      })
+      return
+    }
+
+    await route.fulfill({ json: { items: agents } })
+  })
+
+  await page.goto("/v2/agents")
+
+  await expect(page.getByTestId("profiles-load-error")).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "No profiles yet" }),
+  ).toHaveCount(0)
+
+  await page.getByTestId("profiles-load-error").getByRole("button").click()
+
+  await expect(page.getByTestId("agents-card-grid")).toBeVisible()
+  expect(attempts).toBe(2)
+})
+
+test("profile detail exposes a retry state instead of not found", async ({
+  page,
+}) => {
+  await mockAgentsShell(page)
+  let attempts = 0
+
+  await page.route("**/api/v1/v2/agents/jensen", async (route) => {
+    attempts += 1
+    if (attempts === 1) {
+      await route.fulfill({
+        status: 500,
+        json: { detail: "Profile temporarily unavailable" },
+      })
+      return
+    }
+
+    await route.fulfill({ json: jensenDetail })
+  })
+
+  await page.goto("/v2/agents/jensen")
+
+  await expect(page.getByTestId("profile-detail-load-error")).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Profile not found" }),
+  ).toHaveCount(0)
+
+  await page
+    .getByTestId("profile-detail-load-error")
+    .getByRole("button")
+    .click()
+
+  await expect(
+    page.getByRole("heading", { name: "Jensen", level: 1 }),
+  ).toBeVisible()
+  expect(attempts).toBe(2)
+})

--- a/tests/taskforce-routing.spec.ts
+++ b/tests/taskforce-routing.spec.ts
@@ -44,7 +44,7 @@ async function mockAuth(page: Page) {
   await mockV2Documents(page)
 }
 
-for (const path of ["/", "/home", "/topics", "/cases", "/skills", "/v2/home"]) {
+for (const path of ["/", "/home", "/topics", "/cases", "/v2/home"]) {
   test(`${path} routes authenticated users to Taskforce Library`, async ({
     page,
   }) => {
@@ -61,6 +61,18 @@ for (const path of ["/", "/home", "/topics", "/cases", "/skills", "/v2/home"]) {
     await expect(page.getByTestId("v2-mode-switch")).toHaveCount(0)
   })
 }
+
+test("/skills routes authenticated users to Profiles", async ({ page }) => {
+  await mockAuth(page)
+
+  await page.goto("/skills")
+
+  await expect(page).toHaveURL(/\/v2\/agents$/)
+  await expect(
+    page.getByRole("heading", { name: "Profiles", level: 1 }),
+  ).toBeVisible()
+  await expect(page.getByRole("link", { name: "Skills" })).toHaveCount(0)
+})
 
 test("disabled Search route redirects to Library and stays out of the sidebar", async ({
   page,

--- a/tests/v2-query-errors.spec.ts
+++ b/tests/v2-query-errors.spec.ts
@@ -1,0 +1,269 @@
+import { expect, type Page, test } from "@playwright/test"
+
+const documentId = "document-retry-test"
+
+const currentUser = {
+  id: "user-1",
+  email: "alex@example.com",
+  is_active: true,
+  is_superuser: true,
+  full_name: "Alex Lee",
+  created_at: "2026-03-24T00:00:00Z",
+  v2: true,
+  subscription_tier: "free",
+}
+
+const document = {
+  id: documentId,
+  owner_id: currentUser.id,
+  organization_id: "org-1",
+  folder_id: null,
+  folder_name: null,
+  visibility: "private",
+  user_access: "owner",
+  is_favorite: false,
+  title: "Retryable document",
+  description: "A document used to verify explicit API failure states.",
+  human_summary: "The document remains available after dependent queries fail.",
+  ai_generated_summary: "A deterministic browser-test fixture.",
+  collaborators: ["Alex Lee"],
+  shared_with: [],
+  main_body: [
+    { segments: [{ text: "Retry states protect document context." }] },
+  ],
+  details_file_name: "retryable-document.details.md",
+  details_markdown_sections: [
+    {
+      anchor_id: "retry-state",
+      markdown: "## Retry state\nThe document loaded successfully.",
+    },
+  ],
+  is_demo: false,
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-12T00:00:00Z",
+}
+
+const organization = {
+  id: "org-1",
+  name: "Taskforce",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+  organization_role: "admin",
+  members: [
+    {
+      id: currentUser.id,
+      email: currentUser.email,
+      full_name: currentUser.full_name,
+      organization_role: "admin",
+    },
+    {
+      id: "user-2",
+      email: "teammate@example.com",
+      full_name: "Team Mate",
+      organization_role: "member",
+    },
+  ],
+  invitations: [],
+}
+
+test.use({
+  storageState: {
+    cookies: [],
+    origins: [],
+  },
+})
+
+async function mockShell(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "test-token")
+    window.localStorage.setItem("taskforce-demo-mode", "false")
+  })
+
+  await page.route("**/api/v1/users/**", async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname === "/api/v1/users/me") {
+      await route.fulfill({ json: currentUser })
+      return
+    }
+    if (url.pathname === "/api/v1/users/") {
+      await route.fulfill({ json: { data: [currentUser], count: 1 } })
+      return
+    }
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+
+  await page.route("**/api/v1/organizations/invitations", async (route) => {
+    await route.fulfill({ json: { data: [], count: 0 } })
+  })
+
+  await page.route(
+    "**/api/v1/v2/taskforce/documents/*/sessions**",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          scope: "organization",
+          organization_id: "org-1",
+          total: 0,
+          limit: 6,
+          offset: 0,
+          rows: [],
+        },
+      })
+    },
+  )
+}
+
+test("Library retries a failed initial load without showing empty content", async ({
+  page,
+}) => {
+  await mockShell(page)
+  let documentAttempts = 0
+
+  await page.route("**/api/v1/v2/documents/**", async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname === "/api/v1/v2/documents/folders/") {
+      await route.fulfill({ json: { data: [], count: 0 } })
+      return
+    }
+    if (url.pathname === "/api/v1/v2/documents/") {
+      documentAttempts += 1
+      if (documentAttempts === 1) {
+        await route.fulfill({
+          status: 500,
+          json: { detail: "Library temporarily unavailable" },
+        })
+        return
+      }
+      await route.fulfill({ json: { data: [document], count: 1 } })
+      return
+    }
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+
+  await page.goto("/v2/library")
+
+  await expect(page.getByTestId("library-load-error")).toBeVisible()
+  await expect(page.getByText("No documents yet.")).toHaveCount(0)
+  await expect(page.getByText("Connect a terminal")).toHaveCount(0)
+
+  await page.getByTestId("library-load-error").getByRole("button").click()
+
+  await expect(page.getByText(document.title).first()).toBeVisible()
+  expect(documentAttempts).toBe(2)
+})
+
+test("document detail retries a 500 instead of rendering not found", async ({
+  page,
+}) => {
+  await mockShell(page)
+  let documentAttempts = 0
+
+  await page.route("**/api/v1/v2/documents/**", async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname === `/api/v1/v2/documents/${documentId}`) {
+      documentAttempts += 1
+      if (documentAttempts === 1) {
+        await route.fulfill({
+          status: 500,
+          json: { detail: "Document temporarily unavailable" },
+        })
+        return
+      }
+      await route.fulfill({ json: document })
+      return
+    }
+    if (url.pathname === "/api/v1/v2/documents/folders/") {
+      await route.fulfill({ json: { data: [], count: 0 } })
+      return
+    }
+    if (url.pathname.endsWith("/shares/")) {
+      await route.fulfill({ json: { data: [], count: 0 } })
+      return
+    }
+    await route.fulfill({ json: { data: [document], count: 1 } })
+  })
+  await page.route("**/api/v1/organizations/me", async (route) => {
+    await route.fulfill({ json: organization })
+  })
+
+  await page.goto(`/v2/library/${documentId}`)
+
+  await expect(page.getByTestId("document-detail-load-error")).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Document not found" }),
+  ).toHaveCount(0)
+
+  await page
+    .getByTestId("document-detail-load-error")
+    .getByRole("button")
+    .click()
+
+  await expect(
+    page.getByRole("heading", { name: document.title }),
+  ).toBeVisible()
+  expect(documentAttempts).toBe(2)
+})
+
+test("document sharing metadata exposes a retry without losing the document", async ({
+  page,
+}) => {
+  await mockShell(page)
+  let organizationAttempts = 0
+  let shareAttempts = 0
+
+  await page.route("**/api/v1/v2/documents/**", async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname === `/api/v1/v2/documents/${documentId}`) {
+      await route.fulfill({ json: document })
+      return
+    }
+    if (url.pathname === "/api/v1/v2/documents/folders/") {
+      await route.fulfill({ json: { data: [], count: 0 } })
+      return
+    }
+    if (url.pathname.endsWith("/shares/")) {
+      shareAttempts += 1
+      if (shareAttempts === 1) {
+        await route.fulfill({
+          status: 500,
+          json: { detail: "Shares temporarily unavailable" },
+        })
+        return
+      }
+      await route.fulfill({ json: { data: [], count: 0 } })
+      return
+    }
+    await route.fulfill({ json: { data: [document], count: 1 } })
+  })
+  await page.route("**/api/v1/organizations/me", async (route) => {
+    organizationAttempts += 1
+    if (organizationAttempts === 1) {
+      await route.fulfill({
+        status: 500,
+        json: { detail: "Organization temporarily unavailable" },
+      })
+      return
+    }
+    await route.fulfill({ json: organization })
+  })
+
+  await page.goto(`/v2/library/${documentId}`)
+  await expect(
+    page.getByRole("heading", { name: document.title }),
+  ).toBeVisible()
+
+  await page.getByTestId("document-access").click()
+  await expect(page.getByTestId("document-access-load-error")).toBeVisible()
+  await expect(
+    page.getByText("No organization members available."),
+  ).toHaveCount(0)
+
+  await page
+    .getByTestId("document-access-load-error")
+    .getByRole("button")
+    .click()
+
+  await expect(page.getByText("Team Mate")).toBeVisible()
+  expect(organizationAttempts).toBe(2)
+  expect(shareAttempts).toBe(2)
+})


### PR DESCRIPTION
## Summary
- add explicit retryable API failure states for Profiles and Library list/detail views
- preserve cached profile/document data during background refetch failures
- surface organization/share metadata failures without replacing them with empty-state copy
- add deterministic mocked Chromium coverage and a frontend CI build/browser gate
- update the stale `/skills` redirect expectation to the current Profiles route

## Jira
- [TF-237](https://alexlee4190.atlassian.net/browse/TF-237)
- [TF-238](https://alexlee4190.atlassian.net/browse/TF-238)

## Validation
- `npm run build`
- `npm run test:mocked -- --workers=1` (49 passed)
- focused retry coverage (12 passed)
- Biome checks and `git diff --check`