### PR TITLE
Use sentence case for public eyebrows

### DIFF
--- a/src/components/V2/LandingTerminal.tsx
+++ b/src/components/V2/LandingTerminal.tsx
@@ -463,19 +463,24 @@ export function LandingTerminal({
         aria-hidden={!summaryVisible || !bodyVisible}
       >
         <div>
-          <div className="uppercase tracking-[0.16em] text-zinc-500">
+          <div
+            data-testid="landing-terminal-summary-label"
+            className="font-medium tracking-[0.01em] text-zinc-500"
+          >
             recorded
           </div>
           <div className="mt-1 text-zinc-200">{scenario.summary.profile}</div>
         </div>
         <div>
-          <div className="uppercase tracking-[0.16em] text-zinc-500">saved</div>
+          <div className="font-medium tracking-[0.01em] text-zinc-500">
+            saved
+          </div>
           <div className="mt-1 text-sm font-semibold text-[#c9a8ff] tabular-nums">
             {scenario.summary.saved}
           </div>
         </div>
         <div>
-          <div className="uppercase tracking-[0.16em] text-zinc-500">
+          <div className="font-medium tracking-[0.01em] text-zinc-500">
             metrics
           </div>
           <div className="mt-1 text-zinc-200">session link ready →</div>

--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -68,7 +68,10 @@ function LandingExpressive() {
       <section className="grid min-h-[calc(100svh-5.46875rem)] md:grid-cols-2">
         <div className="relative flex flex-col justify-start border-b border-zinc-200 px-5 py-8 dark:border-white/10 md:border-r md:border-b-0 md:px-8 md:py-10">
           <div className="max-w-2xl">
-            <div className="font-mono text-[0.85rem] font-medium uppercase tracking-[0.22em] text-[#8447ff]">
+            <div
+              data-testid="landing-eyebrow"
+              className="font-mono text-[0.72rem] font-medium tracking-[0.01em] text-[#8447ff]"
+            >
               AI work memory for engineering teams
             </div>
             <h1 className="mt-4 max-w-[14ch] text-5xl font-semibold leading-[0.96] tracking-[-0.035em] text-balance md:text-6xl lg:text-7xl">
@@ -111,19 +114,28 @@ function LandingExpressive() {
           </div>
           <dl className="mt-3 grid font-mono text-[0.85rem] text-zinc-500 dark:text-zinc-400 sm:grid-cols-3">
             <div className="border-b border-zinc-200 py-3 last:border-b-0 sm:border-r sm:border-b-0 sm:px-4 sm:first:pl-0 sm:last:border-r-0 dark:border-white/10">
-              <dt className="uppercase tracking-[0.16em]">Example outcome</dt>
+              <dt
+                data-testid="landing-summary-label"
+                className="text-[0.72rem] font-medium tracking-[0.01em]"
+              >
+                Example outcome
+              </dt>
               <dd className="mt-1 font-sans text-[1.09375rem] font-semibold leading-snug text-zinc-950 dark:text-white">
                 Prior work reused
               </dd>
             </div>
             <div className="border-b border-zinc-200 py-3 last:border-b-0 sm:border-r sm:border-b-0 sm:px-4 sm:first:pl-0 sm:last:border-r-0 dark:border-white/10">
-              <dt className="uppercase tracking-[0.16em]">Example context</dt>
+              <dt className="text-[0.72rem] font-medium tracking-[0.01em]">
+                Example context
+              </dt>
               <dd className="mt-1 font-sans text-[1.09375rem] font-semibold leading-snug text-zinc-950 dark:text-white">
                 Profile + docs restored
               </dd>
             </div>
             <div className="border-b border-zinc-200 py-3 last:border-b-0 sm:border-r sm:border-b-0 sm:px-4 sm:first:pl-0 sm:last:border-r-0 dark:border-white/10">
-              <dt className="uppercase tracking-[0.16em]">Metrics</dt>
+              <dt className="text-[0.72rem] font-medium tracking-[0.01em]">
+                Metrics
+              </dt>
               <dd className="mt-1 font-sans text-[1.09375rem] font-semibold leading-snug text-zinc-950 dark:text-white">
                 Illustrative only
               </dd>

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -63,7 +63,10 @@ function PublicPricing() {
 
       <section className="mx-auto max-w-6xl px-5 py-12 md:px-8 md:py-16">
         <div className="max-w-3xl space-y-3">
-          <div className="font-mono text-[0.85rem] font-medium uppercase tracking-[0.22em] text-[#8447ff]">
+          <div
+            data-testid="public-pricing-eyebrow"
+            className="font-mono text-[0.72rem] font-medium tracking-[0.01em] text-[#8447ff]"
+          >
             Pricing
           </div>
           <h1 className="text-2xl font-semibold leading-tight tracking-[-0.025em] md:whitespace-nowrap md:text-4xl">
@@ -82,7 +85,10 @@ function PublicPricing() {
                 plan.highlighted && "bg-zinc-50 dark:bg-zinc-900/40",
               )}
             >
-              <p className="font-mono text-[0.7rem] font-medium uppercase tracking-[0.18em] text-zinc-500 dark:text-zinc-400">
+              <p
+                data-testid="public-plan-eyebrow"
+                className="font-mono text-[0.7rem] font-medium tracking-[0.01em] text-zinc-500 dark:text-zinc-400"
+              >
                 {plan.eyebrow}
               </p>
               <h2 className="mt-2 text-2xl font-semibold">{plan.name}</h2>

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -23,6 +23,13 @@ test("/landing renders the expressive Taskforce demo page", async ({
       name: /stop re-explaining your codebase/i,
     }),
   ).toBeVisible()
+  for (const testId of [
+    "landing-eyebrow",
+    "landing-summary-label",
+    "landing-terminal-summary-label",
+  ]) {
+    await expect(page.getByTestId(testId)).toHaveCSS("text-transform", "none")
+  }
   await expect(
     page.getByText("/tf Stripe is double-charging users on plan upgrades", {
       exact: false,
@@ -40,4 +47,17 @@ test("/landing renders the expressive Taskforce demo page", async ({
     "href",
     "/login",
   )
+})
+
+test("/pricing uses sentence-case calmer mono eyebrows", async ({ page }) => {
+  await page.goto("/pricing")
+
+  await expect(page.getByTestId("public-pricing")).toBeVisible()
+  await expect(page.getByTestId("public-pricing-eyebrow")).toHaveCSS(
+    "text-transform",
+    "none",
+  )
+  for (const eyebrow of await page.getByTestId("public-plan-eyebrow").all()) {
+    await expect(eyebrow).toHaveCSS("text-transform", "none")
+  }
 })


### PR DESCRIPTION
## Summary
- remove uppercase transforms and wide tracking from the public landing eyebrow and summary labels
- apply the same calmer mono treatment to terminal summary labels and public pricing eyebrows
- add browser assertions that these labels render with `text-transform: none`

## Verification
- `npm run build`
- `npm run test:mocked` (54 passed)
- desktop visual check for `/landing` and `/pricing`