### PR TITLE
Hide documentation link from landing page

### DIFF
--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -39,12 +39,6 @@ function LandingExpressive() {
         </Link>
         <div className="flex items-center gap-5 font-mono text-[0.796875rem] text-zinc-500 dark:text-zinc-400">
           <Link
-            to="/docs"
-            className="hidden hover:text-zinc-950 dark:hover:text-white sm:inline"
-          >
-            Documentation
-          </Link>
-          <Link
             to="/pricing"
             className="hidden hover:text-zinc-950 dark:hover:text-white sm:inline"
           >

--- a/tests/docs.spec.ts
+++ b/tests/docs.spec.ts
@@ -69,13 +69,13 @@ test("docs code blocks copy and mobile navigation opens", async ({ page }) => {
   ).toBeVisible()
 })
 
-test("expressive landing links to documentation beside pricing", async ({
+test("expressive landing hides documentation while keeping pricing", async ({
   page,
 }) => {
   await page.goto("/landing")
 
   const documentation = page.getByRole("link", { name: "Documentation" })
   const pricing = page.getByRole("link", { name: "Pricing" })
-  await expect(documentation).toHaveAttribute("href", "/docs")
+  await expect(documentation).toHaveCount(0)
   await expect(pricing).toHaveAttribute("href", "/pricing")
 })


### PR DESCRIPTION
## Summary
- remove the Documentation link from the public landing-page navigation
- keep all documentation routes and hosted deployment entries unchanged
- update the browser regression test to assert the link stays hidden while Pricing remains available

## Reason
The documentation should remain directly hosted but should not be promoted from the frontend navigation for now.

## Validation
- `bun run build`
- `bunx biome check src/routes/landing.tsx tests/docs.spec.ts`
- `VITE_FIREBASE_API_KEY=test-api-key VITE_FIREBASE_AUTH_DOMAIN=test.firebaseapp.com VITE_FIREBASE_PROJECT_ID=test-project VITE_FIREBASE_MESSAGING_SENDER_ID=123456789 VITE_FIREBASE_APP_ID=1:123456789:web:test npx playwright test tests/docs.spec.ts --config=playwright.mocked.config.ts` (4 passed)