### PR TITLE
Fleet Mission Control: calm roster + agent session detail (foundation)

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -1,287 +1,175 @@
-.pageBody {
-  --fleet-grid: 176px minmax(0, 1.05fr) minmax(0, 1.1fr) 48px;
-  --fleet-hairline: color-mix(
+/* Fleet — calm roster + agent session detail.
+   Ported from the Claude Design "Fleet Mission Control" handoff onto the app's
+   semantic tokens (Geist + JetBrains Mono + #8447ff + globally sharp corners).
+   Neutral palette, one accent (purple) used sparingly. No metric noise. */
+
+.page,
+.detail {
+  --fl-surface: var(--card);
+  --fl-faint: color-mix(
     in srgb,
-    var(--foreground) 10%,
+    var(--muted-foreground) 70%,
     var(--background)
   );
-  --fleet-faint: color-mix(
-    in srgb,
-    var(--muted-foreground) 66%,
-    var(--background)
-  );
-
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
+  --fl-hair: color-mix(in srgb, var(--foreground) 8%, var(--background));
+  --fl-primary-soft: color-mix(in srgb, var(--primary) 14%, var(--background));
+  --fl-primary-line: color-mix(in srgb, var(--primary) 40%, var(--border));
+  --fl-attention: oklch(0.72 0.09 62);
 }
 
-.overview {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 8px 0;
-}
-
-.overviewSummary {
-  color: var(--muted-foreground);
+/* ===== Roster header ===== */
+.summaryLine {
+  margin: 2px 0 0;
+  color: var(--fl-faint);
   font-family: var(--font-mono);
   font-size: 12px;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
 }
 
-.overviewSummary strong {
-  color: var(--foreground);
-  font-weight: 600;
+.summaryLine .lead {
+  color: var(--muted-foreground);
 }
 
-.liveLabel {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  color: var(--fleet-faint);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.liveLabel::before {
-  width: 6px;
-  height: 6px;
-  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten live indicators. */
-  border-radius: 999px !important;
-  background: var(--primary);
-  content: "";
-  animation: fleet-ping 2s ease-out infinite;
-}
-
-.sessionList {
+/* ===== Fleet group (enclosed session card) ===== */
+.fleetList {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 20px;
   padding-bottom: 24px;
 }
 
-.session {
+.fleet {
   border: 1px solid var(--border);
-  background: var(--background);
-  padding: 20px 22px;
+  background: var(--fl-surface);
 }
 
-.sessionHeader {
+.unassigned {
+  border-style: dashed;
+}
+
+.fhead {
   display: flex;
   align-items: baseline;
-  gap: 8px;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--fl-hair);
 }
 
-.sessionOpen {
-  min-width: 0;
-  flex: 1;
+.fname {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+.fnameButton {
   text-align: left;
 }
 
-.sessionOpen:focus-visible,
-.instanceOpen:focus-visible,
-.workingOn:focus-visible,
-.document:focus-visible {
+.fnameButton:focus-visible {
   outline: 2px solid var(--ring);
   outline-offset: 2px;
 }
 
-.sessionTitle {
+.frepo {
   overflow: hidden;
-  margin: 0;
-  font-size: 15px;
-  line-height: 1.4;
-  font-weight: 600;
-  letter-spacing: -0.014em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.sessionMenu,
-.instanceMenu {
-  color: var(--fleet-faint);
-}
-
-.renameForm {
-  display: flex;
-  min-width: 0;
-  flex: 1;
-  gap: 8px;
-}
-
-.sessionSummary {
-  margin: 5px 0 0;
-  color: var(--fleet-faint);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.04em;
-}
-
-.instances {
-  margin-top: 16px;
-}
-
-.columns,
-.instance {
-  display: grid;
-  grid-template-columns: var(--fleet-grid);
-  gap: 18px;
-}
-
-.columns {
-  padding-bottom: 9px;
-  color: var(--fleet-faint);
-  font-family: var(--font-mono);
-  font-size: 8.5px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-}
-
-.alignRight {
-  text-align: right;
-}
-
-.instance {
-  align-items: baseline;
-  padding: 13px 0;
-  border-top: 1px solid var(--fleet-hairline);
-}
-
-.identity {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: 3px;
-}
-
-.instanceOpen {
-  display: flex;
-  min-width: 0;
-  flex: 1;
-  align-items: baseline;
-  gap: 9px;
-  text-align: left;
-}
-
-.statusDot {
-  width: 6px;
-  height: 6px;
-  flex-shrink: 0;
-  transform: translateY(-1px);
-  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten status indicators. */
-  border-radius: 999px !important;
-  background: var(--fleet-faint);
-}
-
-.runningDot {
-  background: var(--primary);
-  animation: fleet-ping 2s ease-out infinite;
-}
-
-.modelBlock,
-.workingOn,
-.documents {
-  min-width: 0;
-}
-
-.model {
-  overflow: hidden;
-  margin: 0;
-  color: var(--foreground);
+  color: var(--fl-faint);
   font-family: var(--font-mono);
   font-size: 11px;
+  letter-spacing: 0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.frepo b {
+  color: var(--muted-foreground);
   font-weight: 400;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.status {
-  margin-top: 4px;
-  color: var(--fleet-faint);
-  font-family: var(--font-mono);
-  font-size: 9px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.idleStatus {
-  color: var(--foreground);
-  font-weight: 500;
-}
-
-.workingOn {
-  display: -webkit-box;
-  overflow: hidden;
-  color: var(--foreground);
-  font-size: 12.5px;
-  line-height: 1.45;
-  text-align: left;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-}
-
-.muted {
-  color: var(--fleet-faint);
-}
-
-.documents {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.document {
-  display: flex;
-  min-width: 0;
-  align-items: baseline;
-  gap: 8px;
-  color: inherit;
-  text-align: left;
-}
-
-.documentTitle {
-  overflow: hidden;
-  color: var(--foreground);
-  font-size: 11.5px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.documentMode {
+.fcount {
+  display: inline-flex;
   flex-shrink: 0;
-  color: var(--fleet-faint);
-  font-family: var(--font-mono);
-  font-size: 8.5px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.noDocuments,
-.emptySession {
-  color: var(--fleet-faint);
+  align-items: center;
+  margin-left: auto;
+  gap: 6px;
+  color: var(--fl-faint);
   font-family: var(--font-mono);
   font-size: 10px;
-}
-
-.elapsed {
-  color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  font-variant-numeric: tabular-nums;
-  text-align: right;
+  letter-spacing: 0.08em;
   white-space: nowrap;
 }
 
-.emptySession {
-  padding: 22px 0 8px;
-  border-top: 1px solid var(--fleet-hairline);
+.pin {
+  width: 5px;
+  height: 5px;
+  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten status indicators. */
+  border-radius: 999px !important;
+  background: var(--primary);
 }
 
-@keyframes fleet-ping {
+.fmenu {
+  margin-left: 4px;
+  color: var(--fl-faint);
+}
+
+/* rows */
+.arow {
+  display: grid;
+  grid-template-columns: 14px minmax(180px, 250px) minmax(0, 1fr) 64px;
+  gap: 18px;
+  align-items: baseline;
+  width: 100%;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--fl-hair);
+  text-align: left;
+  cursor: pointer;
+}
+
+.arow:last-of-type {
+  border-bottom: 0;
+}
+
+.arow:hover {
+  background: var(--fl-hair);
+}
+
+.arow:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
+/* status dot */
+.sdot {
+  width: 7px;
+  height: 7px;
+  align-self: start;
+  margin-top: 6px;
+  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten status indicators. */
+  border-radius: 999px !important;
+}
+
+.run {
+  background: var(--primary);
+}
+
+.pulse {
+  animation: fleet-pulse 2.6s ease-in-out infinite;
+}
+
+.idle {
+  background: var(--fl-faint);
+}
+
+.paused {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px var(--fl-faint);
+}
+
+.waiting {
+  background: var(--fl-attention);
+}
+
+@keyframes fleet-pulse {
   0%,
   100% {
     opacity: 1;
@@ -291,47 +179,703 @@
   }
 }
 
-@media (max-width: 960px) {
-  .pageBody {
-    --fleet-grid: 155px minmax(0, 1fr) minmax(0, 0.9fr) 40px;
+/* identity */
+.who {
+  min-width: 0;
+}
+
+.nm {
+  overflow: hidden;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta {
+  margin-top: 4px;
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.01em;
+}
+
+.state {
+  margin-top: 7px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.02em;
+}
+
+.stateWaiting {
+  color: var(--fl-attention);
+}
+
+.statePaused,
+.stateIdle {
+  color: var(--fl-faint);
+}
+
+/* work */
+.work {
+  min-width: 0;
+}
+
+.workSummary {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+}
+
+.detailLine {
+  display: flex;
+  align-items: center;
+  margin-top: 6px;
+  gap: 8px;
+  flex-wrap: wrap;
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.file {
+  color: var(--muted-foreground);
+}
+
+.more {
+  color: var(--fl-faint);
+}
+
+.docInline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--fl-faint);
+}
+
+.docInline::before {
+  width: 3px;
+  height: 3px;
+  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten dot separators. */
+  border-radius: 999px !important;
+  background: var(--fl-faint);
+  content: "";
+}
+
+/* age */
+.age {
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+/* new-agent (card footer) */
+.newagent {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 11px 18px;
+  border-top: 1px solid var(--fl-hair);
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.newagent svg {
+  width: 13px;
+  height: 13px;
+}
+
+.newagent:hover {
+  background: var(--fl-hair);
+  color: var(--muted-foreground);
+}
+
+.emptyRows {
+  padding: 18px;
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+/* ============================================================
+   Agent session detail
+   ============================================================ */
+.detail {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.dtop {
+  flex-shrink: 0;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--fl-hair);
+}
+
+.crumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 20px;
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+}
+
+.back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted-foreground);
+}
+
+.back svg {
+  width: 13px;
+  height: 13px;
+}
+
+.back:hover {
+  color: var(--foreground);
+}
+
+.sep {
+  color: var(--border);
+}
+
+.crumb span {
+  white-space: nowrap;
+}
+
+.dhead {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.dhead .sdot {
+  margin-top: 9px;
+}
+
+.dtitle {
+  min-width: 0;
+  flex: 1;
+}
+
+.dtitle h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+.dmeta {
+  margin-top: 7px;
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.01em;
+}
+
+.dmeta b {
+  color: var(--muted-foreground);
+  font-weight: 400;
+}
+
+.dstate {
+  margin-top: 7px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.02em;
+}
+
+.dactions {
+  display: flex;
+  flex-shrink: 0;
+  gap: 8px;
+}
+
+.dbody {
+  display: grid;
+  flex: 1;
+  grid-template-columns: minmax(0, 1fr) 286px;
+  min-height: 0;
+}
+
+.dmain {
+  overflow-y: auto;
+  padding: 30px 36px 70px;
+  min-height: 0;
+}
+
+.drail {
+  overflow-y: auto;
+  padding: 30px 28px 70px;
+  border-left: 1px solid var(--fl-hair);
+  min-height: 0;
+}
+
+.seclabel {
+  margin-bottom: 14px;
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.section {
+  margin-bottom: 34px;
+}
+
+.section:last-child {
+  margin-bottom: 0;
+}
+
+.nowtask {
+  color: var(--foreground);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.question {
+  padding: 16px 18px;
+  border: 1px solid var(--border);
+  background: var(--fl-surface);
+}
+
+.questionText {
+  color: var(--foreground);
+  font-size: 14.5px;
+  line-height: 1.6;
+}
+
+.reply {
+  display: flex;
+  align-items: center;
+  margin-top: 14px;
+  gap: 8px;
+}
+
+.reply input {
+  flex: 1;
+  height: 34px;
+  padding: 0 11px;
+  border: 1px solid var(--border);
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  outline: none;
+}
+
+.reply input:focus {
+  border-color: var(--fl-primary-line);
+}
+
+.reply input::placeholder {
+  color: var(--fl-faint);
+}
+
+.reply button {
+  height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--fl-primary-line);
+  background: var(--fl-primary-soft);
+  color: var(--foreground);
+  font-size: 12.5px;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+/* activity timeline */
+.timeline {
+  position: relative;
+  padding-left: 20px;
+}
+
+.timeline::before {
+  position: absolute;
+  top: 6px;
+  bottom: 8px;
+  left: 3px;
+  width: 1px;
+  background: var(--fl-hair);
+  content: "";
+}
+
+.tev {
+  position: relative;
+  padding: 0 0 18px;
+}
+
+.tev:last-child {
+  padding-bottom: 0;
+}
+
+.tdot {
+  position: absolute;
+  top: 5px;
+  left: -20px;
+  width: 7px;
+  height: 7px;
+  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten timeline dots. */
+  border-radius: 999px !important;
+  background: var(--fl-faint);
+  box-shadow: 0 0 0 3px var(--background);
+}
+
+.tevRun .tdot,
+.tevNow .tdot {
+  background: var(--primary);
+}
+
+.tevWait .tdot,
+.tevPause .tdot {
+  background: var(--fl-attention);
+}
+
+.tt {
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.02em;
+}
+
+.tx {
+  margin-top: 3px;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.tevNow .tx {
+  color: var(--foreground);
+}
+
+/* rail blocks */
+.block {
+  margin-bottom: 26px;
+}
+
+.block:last-child {
+  margin-bottom: 0;
+}
+
+.metarow {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--fl-hair);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.metarow:last-child {
+  border-bottom: 0;
+}
+
+.mk {
+  color: var(--fl-faint);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.mv {
+  color: var(--muted-foreground);
+  text-align: left;
+  word-break: break-word;
+}
+
+.capPaused {
+  color: var(--fl-attention);
+}
+
+.fileitem {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--fl-hair);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.fileitem:last-child {
+  border-bottom: 0;
+}
+
+.fn {
+  overflow: hidden;
+  flex: 1;
+  color: var(--muted-foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fs {
+  flex-shrink: 0;
+  color: var(--fl-faint);
+  font-size: 10.5px;
+  letter-spacing: 0.01em;
+}
+
+.fsNew {
+  color: var(--primary);
+}
+
+.empty {
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.doccard {
+  display: block;
+  width: 100%;
+  padding: 13px 15px;
+  border: 1px solid var(--border);
+  background: var(--fl-surface);
+  text-align: left;
+  cursor: pointer;
+}
+
+.doccard:hover {
+  border-color: var(--fl-primary-line);
+}
+
+.dmode {
+  color: var(--primary);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.01em;
+}
+
+.dttl {
+  margin-top: 6px;
+  color: var(--foreground);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.dupd {
+  margin-top: 5px;
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+}
+
+.ctxitem {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--fl-hair);
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+}
+
+.ctxitem:last-child {
+  border-bottom: 0;
+}
+
+.ctxitem::before {
+  width: 3px;
+  height: 3px;
+  flex-shrink: 0;
+  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten list bullets. */
+  border-radius: 999px !important;
+  background: var(--fl-faint);
+  content: "";
+}
+
+/* agent profile card */
+.profcard {
+  padding: 13px 14px;
+  border: 1px solid var(--border);
+  background: var(--fl-surface);
+}
+
+.pfTop {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.pfAv {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  place-items: center;
+  border: 1px solid var(--fl-primary-line);
+  background: var(--fl-primary-soft);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.pfId {
+  min-width: 0;
+}
+
+.pfNm {
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.pfSub {
+  margin-top: 2px;
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+}
+
+.pfMeta {
+  margin-top: 11px;
+  padding-top: 10px;
+  border-top: 1px solid var(--fl-hair);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+}
+
+.pauserail {
+  padding: 13px 15px;
+  border: 1px solid var(--border);
+  background: var(--fl-surface);
+}
+
+.prH {
+  margin-bottom: 7px;
+  color: var(--fl-attention);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.prB {
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.prAct {
+  display: inline-block;
+  margin-top: 12px;
+  padding: 6px 11px;
+  border: 1px solid var(--border);
+  background: var(--background);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.prAct:hover {
+  border-color: var(--fl-primary-line);
+  color: var(--foreground);
+}
+
+/* ===== ghost action button ===== */
+.ghost {
+  display: inline-flex;
+  align-items: center;
+  height: 32px;
+  gap: 7px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted-foreground);
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.ghost svg {
+  width: 13px;
+  height: 13px;
+}
+
+.ghost:hover {
+  border-color: var(--fl-primary-line);
+  color: var(--foreground);
+}
+
+.ghost:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.ghost:disabled:hover {
+  border-color: var(--border);
+  color: var(--muted-foreground);
+}
+
+/* ===== responsive ===== */
+@media (max-width: 880px) {
+  .dbody {
+    display: block;
+    grid-template-columns: 1fr;
+  }
+
+  .dmain,
+  .drail {
+    overflow: visible;
+    border-left: 0;
+  }
+
+  .drail {
+    border-top: 1px solid var(--fl-hair);
   }
 }
 
 @media (max-width: 760px) {
-  .liveLabel,
-  .columns {
-    display: none;
+  .arow {
+    grid-template-columns: 14px 1fr;
+    gap: 12px;
   }
 
-  .session {
-    padding: 18px;
-  }
-
-  .instance {
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 10px 16px;
-    padding: 16px 0;
-  }
-
-  .identity {
-    grid-column: 1;
-  }
-
-  .elapsed {
+  .arow .work,
+  .arow .age {
     grid-column: 2;
-    grid-row: 1;
+    text-align: left;
   }
 
-  .workingOn,
-  .documents {
-    grid-column: 1 / -1;
-    padding-left: 15px;
+  .arow .age {
+    margin-top: 8px;
+  }
+
+  .dhead {
+    flex-wrap: wrap;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .liveLabel::before,
-  .runningDot {
+  .pulse {
     animation: none;
   }
 }

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -1,263 +1,126 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { Link, useNavigate } from "@tanstack/react-router"
+import { MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react"
+import { type FormEvent, useState } from "react"
 import {
-  useMutation,
-  useQueries,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query"
-import { Link } from "@tanstack/react-router"
-import {
-  BookOpen,
-  Bot,
-  ChevronDown,
-  FileText,
-  FolderKanban,
-  MoreHorizontal,
-  Pencil,
-  Plus,
-  ScrollText,
-  Trash2,
-} from "lucide-react"
-import { type FormEvent, useMemo, useState } from "react"
-import { readV2Document } from "@/api/v2Documents"
-import {
-  assignTaskforceFleetSession,
   createTaskforceFleetSession,
   deleteTaskforceFleetSession,
   readTaskforceFleet,
-  readTaskforceSessionLog,
   type TaskforceFleetAgent,
   type TaskforceFleetSession,
   updateTaskforceFleetSession,
 } from "@/api/v2Taskforce"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet"
-import {
   V2_PAGE_BODY,
   V2_PAGE_FRAME,
   V2_STICKY_HEADER_CLASS,
-  V2_TAB_EYEBROW_CLASS,
 } from "@/components/V2/v2PageShell"
 import { cn } from "@/lib/utils"
 import styles from "./FleetPage.module.css"
+import {
+  agentDisplayName,
+  agentMeta,
+  agentStatus,
+  compactPresence,
+  type FleetStatus,
+  fleetRepo,
+  fleetTitle,
+  runningCount,
+  STATE_LABEL,
+  waitingCount,
+} from "./fleetStatus"
 
 const FLEET_QUERY_KEY = ["v2-taskforce-fleet"] as const
-
-type DetailSelection =
-  | { kind: "agent"; agent: TaskforceFleetAgent }
-  | { kind: "fleet"; fleet: TaskforceFleetSession }
-  | null
 
 function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Something went wrong."
 }
 
-function presenceLabel(agent: TaskforceFleetAgent) {
-  if (agent.minutes_ago < 1) return "Active now"
-  if (agent.minutes_ago === 1) return "Active 1 minute ago"
-  return `Active ${agent.minutes_ago} minutes ago`
+const STATE_CLASS: Record<FleetStatus, string | undefined> = {
+  run: undefined,
+  waiting: styles.stateWaiting,
+  paused: styles.statePaused,
+  idle: styles.stateIdle,
 }
 
-function repoLabel(agent: TaskforceFleetAgent) {
-  const cwdParts = agent.cwd?.split("/").filter(Boolean) ?? []
-  return agent.repo || cwdParts[cwdParts.length - 1] || "Unknown repo"
-}
-
-// Turn a raw harness model id into a human label, e.g.
-// "claude-opus-4-8" -> "Opus 4.8", "claude-fable-5" -> "Fable 5".
-function modelLabel(modelId: string | null): string | null {
-  if (!modelId) return null
-  const [family, ...rest] = modelId.replace(/^claude-/, "").split("-")
-  if (!family) return null
-  const name = family.charAt(0).toUpperCase() + family.slice(1)
-  const version = rest.join(".")
-  return version ? `${name} ${version}` : name
-}
-
-// Heading shown for an agent. Once Taskforce has captured a document the
-// document title wins; until then a brand-new session shows the model it's
-// running (e.g. "Opus 4.8") rather than the bare working-directory name.
-function agentDisplayName(agent: TaskforceFleetAgent) {
-  return agent.title || modelLabel(agent.model_id) || repoLabel(agent)
-}
-
-function agentModelName(agent: TaskforceFleetAgent) {
-  return modelLabel(agent.model_id) || "Connected agent"
-}
-
-function compactPresence(agent: TaskforceFleetAgent) {
-  if (agent.minutes_ago < 1) return "now"
-  return `${agent.minutes_ago}m`
-}
-
-function fleetSummary(agents: TaskforceFleetAgent[]) {
-  const running = agents.filter((agent) => agent.minutes_ago < 5).length
-  const idle = agents.length - running
-  const details = [
-    running > 0 ? `${running} running` : "",
-    idle > 0 ? `${idle} idle` : "",
-  ].filter(Boolean)
-
-  return `${agents.length} ${agents.length === 1 ? "instance" : "instances"}${
-    details.length ? ` · ${details.join(" · ")}` : ""
-  }`
-}
-
-function AgentCard({
-  agent,
-  fleetSessions,
-  isMoving,
-  onMove,
-  onCreateSession,
-  onOpen,
-}: {
-  agent: TaskforceFleetAgent
-  fleetSessions: TaskforceFleetSession[]
-  isMoving: boolean
-  onMove: (agent: TaskforceFleetAgent, fleetSessionId: string) => void
-  onCreateSession: (agent: TaskforceFleetAgent) => void
-  onOpen: (agent: TaskforceFleetAgent) => void
-}) {
-  const isLive = agent.minutes_ago < 5
-
+function StatusDot({ status }: { status: FleetStatus }) {
   return (
-    <article className={styles.instance}>
-      <div className={styles.identity}>
-        <button
-          type="button"
-          className={styles.instanceOpen}
-          onClick={() => onOpen(agent)}
-        >
-          <span
-            className={cn(styles.statusDot, isLive && styles.runningDot)}
-            title={presenceLabel(agent)}
-          />
-          <div className={styles.modelBlock}>
-            <h3 className={styles.model}>{agentModelName(agent)}</h3>
-            <div className={cn(styles.status, !isLive && styles.idleStatus)}>
-              {isLive ? "Running" : "Idle"}
-            </div>
-          </div>
-        </button>
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              disabled={isMoving}
-              aria-label={`Move ${agent.title || agent.session_id}`}
-              className={styles.instanceMenu}
-            >
-              <ChevronDown />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuLabel>Move to</DropdownMenuLabel>
-            {fleetSessions.map((fleetSession) => (
-              <DropdownMenuItem
-                key={fleetSession.id}
-                disabled={agent.fleet_session_id === fleetSession.id}
-                onSelect={() => onMove(agent, fleetSession.id)}
-              >
-                <FolderKanban />
-                {fleetSession.name}
-              </DropdownMenuItem>
-            ))}
-            <DropdownMenuItem onSelect={() => onCreateSession(agent)}>
-              <Plus />
-              New session
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-
-      <button
-        type="button"
-        className={cn(styles.workingOn, !isLive && styles.muted)}
-        onClick={() => onOpen(agent)}
-      >
-        {agent.summary_markdown ||
-          `Connected in ${repoLabel(agent)}${
-            agent.branch ? ` on ${agent.branch}` : ""
-          }`}
-      </button>
-
-      <div className={styles.documents}>
-        {agent.active_document_id ? (
-          <Link
-            to="/v2/library/$documentId"
-            params={{ documentId: agent.active_document_id }}
-            className={styles.document}
-          >
-            <span className={styles.documentTitle}>
-              {agent.title || "Active Taskforce document"}
-            </span>
-            <span className={styles.documentMode}>writing</span>
-          </Link>
-        ) : (
-          <span className={styles.noDocuments}>No active document</span>
-        )}
-        {agent.referenced_document_ids.length > 0 && (
-          <button
-            type="button"
-            className={styles.document}
-            onClick={() => onOpen(agent)}
-          >
-            <span className={styles.documentTitle}>
-              {agent.referenced_document_ids.length} referenced{" "}
-              {agent.referenced_document_ids.length === 1
-                ? "document"
-                : "documents"}
-            </span>
-            <span className={styles.documentMode}>reading</span>
-          </button>
-        )}
-      </div>
-
-      <div className={styles.elapsed}>{compactPresence(agent)}</div>
-    </article>
+    <span
+      className={cn(
+        styles.sdot,
+        styles[status],
+        status === "run" && styles.pulse,
+      )}
+    />
   )
 }
 
-function FleetBox({
+function AgentRow({
+  agent,
+  onOpen,
+}: {
+  agent: TaskforceFleetAgent
+  onOpen: (agent: TaskforceFleetAgent) => void
+}) {
+  const status = agentStatus(agent)
+  const age = compactPresence(agent)
+  const showAgeInState = status === "waiting" || status === "idle"
+  const docTitle = agent.active_document_id ? agent.title : null
+
+  return (
+    <button type="button" className={styles.arow} onClick={() => onOpen(agent)}>
+      <StatusDot status={status} />
+      <div className={styles.who}>
+        <div className={styles.nm}>{agentDisplayName(agent)}</div>
+        <div className={styles.meta}>{agentMeta(agent)}</div>
+        {status !== "run" && (
+          <div className={cn(styles.state, STATE_CLASS[status])}>
+            {STATE_LABEL[status]}
+            {showAgeInState ? ` · ${age}` : ""}
+          </div>
+        )}
+      </div>
+      <div className={styles.work}>
+        <div className={styles.workSummary}>
+          {agent.summary_markdown || "Connected — no summary captured yet"}
+        </div>
+        {docTitle && (
+          <div className={styles.detailLine}>
+            <span className={styles.docInline}>{docTitle}</span>
+          </div>
+        )}
+      </div>
+      <div className={styles.age}>{status === "run" ? age : ""}</div>
+    </button>
+  )
+}
+
+function FleetCard({
   fleet,
-  allFleetSessions,
-  isMoving,
-  onMove,
-  onCreateSession,
   onOpenAgent,
-  onOpenFleet,
   onRename,
   onDelete,
 }: {
   fleet: TaskforceFleetSession
-  allFleetSessions: TaskforceFleetSession[]
-  isMoving: boolean
-  onMove: (agent: TaskforceFleetAgent, fleetSessionId: string) => void
-  onCreateSession: (agent: TaskforceFleetAgent) => void
   onOpenAgent: (agent: TaskforceFleetAgent) => void
-  onOpenFleet: (fleet: TaskforceFleetSession) => void
   onRename: (fleet: TaskforceFleetSession, name: string) => void
   onDelete: (fleet: TaskforceFleetSession) => void
 }) {
   const [renaming, setRenaming] = useState(false)
   const [name, setName] = useState(fleet.name)
+
+  const repo = fleetRepo(fleet)
+  const running = runningCount(fleet.agents)
+  const total = fleet.agents.length
 
   const submitRename = (event: FormEvent) => {
     event.preventDefault()
@@ -272,29 +135,44 @@ function FleetBox({
   }
 
   return (
-    <section className={styles.session}>
-      <div className={styles.sessionHeader}>
+    <section className={styles.fleet}>
+      <div className={styles.fhead}>
         {renaming ? (
-          <form onSubmit={submitRename} className={styles.renameForm}>
+          <form onSubmit={submitRename} className="flex-1">
             <Input
               value={name}
               onChange={(event) => setName(event.target.value)}
               maxLength={120}
               autoFocus
-              aria-label="Fleet session name"
+              aria-label="Fleet name"
+              className="h-7"
             />
-            <Button type="submit" size="sm">
-              Save
-            </Button>
           </form>
         ) : (
-          <button
-            type="button"
-            className={styles.sessionOpen}
-            onClick={() => onOpenFleet(fleet)}
-          >
-            <h2 className={styles.sessionTitle}>{fleet.name}</h2>
-          </button>
+          <span className={styles.fname}>{fleetTitle(fleet)}</span>
+        )}
+
+        {!renaming &&
+          (repo ? (
+            <span className={styles.frepo}>
+              <b>{repo.repo}</b>
+              {repo.branch ? ` · ${repo.branch}` : ""}
+            </span>
+          ) : (
+            <span className={styles.frepo}>no repo bound</span>
+          ))}
+
+        {!renaming && (
+          <span className={styles.fcount}>
+            {running > 0 ? (
+              <>
+                <span className={styles.pin} />
+                {running} active · {total}
+              </>
+            ) : (
+              `${total} ${total === 1 ? "agent" : "agents"}`
+            )}
+          </span>
         )}
 
         {!renaming && (
@@ -303,8 +181,8 @@ function FleetBox({
               <Button
                 variant="ghost"
                 size="icon-sm"
-                aria-label="Fleet session actions"
-                className={styles.sessionMenu}
+                aria-label={`${fleetTitle(fleet)} actions`}
+                className={styles.fmenu}
               >
                 <MoreHorizontal />
               </Button>
@@ -319,6 +197,7 @@ function FleetBox({
                 <Pencil />
                 Rename
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem
                 variant="destructive"
                 onSelect={() => onDelete(fleet)}
@@ -330,228 +209,38 @@ function FleetBox({
           </DropdownMenu>
         )}
       </div>
-      <p className={styles.sessionSummary}>{fleetSummary(fleet.agents)}</p>
 
-      <div className={styles.instances}>
-        <div className={styles.columns} aria-hidden="true">
-          <div>Instance</div>
-          <div>Working on</div>
-          <div>Documents</div>
-          <div className={styles.alignRight}>Time</div>
-        </div>
+      <div>
         {fleet.agents.length === 0 ? (
-          <div className={styles.emptySession}>
-            Move an active agent here to group its work.
+          <div className={styles.emptyRows}>
+            No active agents in this fleet yet.
           </div>
         ) : (
           fleet.agents.map((agent) => (
-            <AgentCard
+            <AgentRow
               key={agent.session_id}
               agent={agent}
-              fleetSessions={allFleetSessions}
-              isMoving={isMoving}
-              onMove={onMove}
-              onCreateSession={onCreateSession}
               onOpen={onOpenAgent}
             />
           ))
         )}
       </div>
+
+      <Link
+        to="/v2/settings"
+        search={{ tab: "connect-agent" }}
+        className={styles.newagent}
+      >
+        <Plus />
+        New agent in {fleetTitle(fleet)}
+      </Link>
     </section>
-  )
-}
-
-function AgentDetail({ agent }: { agent: TaskforceFleetAgent }) {
-  const logQuery = useQuery({
-    queryKey: ["v2-taskforce-session-log", { sessionId: agent.session_id }],
-    queryFn: () => readTaskforceSessionLog({ sessionId: agent.session_id }),
-  })
-
-  return (
-    <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
-      <SheetHeader className="border-b">
-        <SheetTitle>{agentDisplayName(agent)}</SheetTitle>
-        <SheetDescription>{presenceLabel(agent)}</SheetDescription>
-      </SheetHeader>
-      <div className="space-y-6 px-4 pb-6">
-        <div className="flex flex-wrap gap-2">
-          {agent.specialist_slug && (
-            <Badge variant="outline">{agent.specialist_slug}</Badge>
-          )}
-          {agent.repo && <Badge variant="secondary">{agent.repo}</Badge>}
-          {agent.branch && <Badge variant="secondary">{agent.branch}</Badge>}
-        </div>
-
-        <Button asChild className="w-full">
-          <Link to="/v2/ledger" search={{ session_id: agent.session_id }}>
-            <ScrollText />
-            View session in Ledger
-          </Link>
-        </Button>
-
-        <section>
-          <h3 className="text-sm font-semibold">Current work</h3>
-          <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-muted-foreground">
-            {agent.summary_markdown || "No summary has been captured yet."}
-          </p>
-        </section>
-
-        {agent.cwd && (
-          <section>
-            <h3 className="text-sm font-semibold">Working directory</h3>
-            <code className="mt-2 block overflow-x-auto bg-muted p-3 text-xs">
-              {agent.cwd}
-            </code>
-          </section>
-        )}
-
-        {agent.active_document_id && (
-          <Button asChild variant="outline">
-            <Link
-              to="/v2/library/$documentId"
-              params={{ documentId: agent.active_document_id }}
-            >
-              <BookOpen />
-              Open active document
-            </Link>
-          </Button>
-        )}
-
-        <section>
-          <h3 className="text-sm font-semibold">
-            Contributed Taskforce documents
-          </h3>
-          {logQuery.isLoading ? (
-            <p className="mt-2 text-sm text-muted-foreground">
-              Loading session log…
-            </p>
-          ) : logQuery.error ? (
-            <p className="mt-2 text-sm text-destructive">
-              {errorMessage(logQuery.error)}
-            </p>
-          ) : logQuery.data?.entries.length ? (
-            <div className="mt-3 space-y-2">
-              {logQuery.data.entries.map((entry) => (
-                <Link
-                  key={`${entry.query_id}-${entry.document_id}`}
-                  to="/v2/library/$documentId"
-                  params={{ documentId: entry.document_id }}
-                  className="block border border-border p-3 transition-colors hover:bg-muted/50"
-                >
-                  <div className="flex items-center gap-2">
-                    <FileText className="size-4 text-muted-foreground" />
-                    <span className="text-sm font-medium">{entry.title}</span>
-                  </div>
-                  <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">
-                    {entry.summary_markdown}
-                  </p>
-                </Link>
-              ))}
-            </div>
-          ) : (
-            <p className="mt-2 text-sm text-muted-foreground">
-              No consulted documents are recorded for this session yet.
-            </p>
-          )}
-        </section>
-      </div>
-    </SheetContent>
-  )
-}
-
-function FleetDetail({ fleet }: { fleet: TaskforceFleetSession }) {
-  const documentIds = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          fleet.agents.flatMap((agent) => [
-            ...(agent.active_document_id ? [agent.active_document_id] : []),
-            ...agent.referenced_document_ids,
-          ]),
-        ),
-      ),
-    [fleet.agents],
-  )
-  const documentQueries = useQueries({
-    queries: documentIds.map((documentId) => ({
-      queryKey: ["v2-document", { documentId }],
-      queryFn: () => readV2Document(documentId),
-    })),
-  })
-
-  return (
-    <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
-      <SheetHeader className="border-b">
-        <SheetTitle>{fleet.name}</SheetTitle>
-        <SheetDescription>
-          {fleet.agents.length} active agent
-          {fleet.agents.length === 1 ? "" : "s"}
-        </SheetDescription>
-      </SheetHeader>
-      <div className="space-y-6 px-4 pb-6">
-        <section>
-          <h3 className="text-sm font-semibold">Members</h3>
-          <div className="mt-3 space-y-2">
-            {fleet.agents.length ? (
-              fleet.agents.map((agent) => (
-                <div
-                  key={agent.session_id}
-                  className="border border-border p-3"
-                >
-                  <div className="flex items-center gap-2 text-sm font-medium">
-                    <Bot className="size-4 text-muted-foreground" />
-                    {agentDisplayName(agent)}
-                  </div>
-                  <p className="mt-1 font-mono text-[10px] text-muted-foreground">
-                    {repoLabel(agent)}
-                    {agent.branch ? ` · ${agent.branch}` : ""}
-                  </p>
-                </div>
-              ))
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                No active members.
-              </p>
-            )}
-          </div>
-        </section>
-
-        <section>
-          <h3 className="text-sm font-semibold">Contributed documents</h3>
-          <div className="mt-3 space-y-2">
-            {documentIds.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                No documents have been captured for this session yet.
-              </p>
-            ) : (
-              documentQueries.map((query, index) => {
-                const documentId = documentIds[index]
-                return (
-                  <Link
-                    key={documentId}
-                    to="/v2/library/$documentId"
-                    params={{ documentId }}
-                    className="flex items-center gap-3 border border-border p-3 transition-colors hover:bg-muted/50"
-                  >
-                    <FileText className="size-4 text-muted-foreground" />
-                    <span className="min-w-0 truncate text-sm font-medium">
-                      {query.data?.title ||
-                        (query.isLoading ? "Loading…" : documentId)}
-                    </span>
-                  </Link>
-                )
-              })
-            )}
-          </div>
-        </section>
-      </div>
-    </SheetContent>
   )
 }
 
 export function FleetPage() {
   const queryClient = useQueryClient()
-  const [detail, setDetail] = useState<DetailSelection>(null)
+  const navigate = useNavigate()
   const [mutationError, setMutationError] = useState<unknown>(null)
 
   const fleetQuery = useQuery({
@@ -563,30 +252,8 @@ export function FleetPage() {
   const refreshFleet = () =>
     queryClient.invalidateQueries({ queryKey: FLEET_QUERY_KEY })
 
-  const assignMutation = useMutation({
-    mutationFn: ({
-      sessionId,
-      fleetSessionId,
-    }: {
-      sessionId: string
-      fleetSessionId: string
-    }) => assignTaskforceFleetSession(sessionId, fleetSessionId),
-    onSuccess: refreshFleet,
-    onError: setMutationError,
-  })
   const createMutation = useMutation({
-    mutationFn: ({ agentSessionId }: { agentSessionId?: string }) =>
-      createTaskforceFleetSession().then(async (fleetSession) => {
-        if (agentSessionId) {
-          try {
-            await assignTaskforceFleetSession(agentSessionId, fleetSession.id)
-          } catch (error) {
-            await deleteTaskforceFleetSession(fleetSession.id)
-            throw error
-          }
-        }
-        return fleetSession
-      }),
+    mutationFn: () => createTaskforceFleetSession(),
     onSuccess: () => {
       setMutationError(null)
       refreshFleet()
@@ -606,34 +273,42 @@ export function FleetPage() {
   })
   const deleteMutation = useMutation({
     mutationFn: deleteTaskforceFleetSession,
-    onSuccess: () => {
-      setDetail(null)
-      refreshFleet()
-    },
+    onSuccess: refreshFleet,
     onError: setMutationError,
   })
 
   const fleetSessions = fleetQuery.data?.fleet_sessions ?? []
-  const activeSessionCount = fleetSessions.length
-  const activeAgentCount = fleetSessions.reduce(
-    (total, fleet) => total + fleet.agents.length,
-    0,
-  )
-  const runningAgentCount = fleetSessions.reduce(
-    (total, fleet) =>
-      total + fleet.agents.filter((agent) => agent.minutes_ago < 5).length,
-    0,
-  )
+  const allAgents = fleetSessions.flatMap((fleet) => fleet.agents)
+  const running = runningCount(allAgents)
+  const waiting = waitingCount(allAgents)
 
-  const moveAgent = (agent: TaskforceFleetAgent, fleetSessionId: string) => {
+  const summaryBits = [`${running} running`]
+  if (waiting) summaryBits.push(`${waiting} waiting for input`)
+
+  const openAgent = (agent: TaskforceFleetAgent) =>
+    navigate({
+      to: "/v2/fleet/$sessionId",
+      params: { sessionId: agent.session_id },
+    })
+
+  const renameFleet = (fleet: TaskforceFleetSession, name: string) => {
     setMutationError(null)
-    assignMutation.mutate({ sessionId: agent.session_id, fleetSessionId })
+    renameMutation.mutate({ fleet, name })
+  }
+  const deleteFleet = (fleet: TaskforceFleetSession) => {
+    if (
+      window.confirm(`Delete "${fleetTitle(fleet)}"? Its agents will detach.`)
+    ) {
+      setMutationError(null)
+      deleteMutation.mutate(fleet.id)
+    }
   }
 
   return (
     <section
       className={cn(
         V2_PAGE_FRAME,
+        styles.page,
         "-mb-6 bg-background font-sans text-foreground md:-mb-8",
       )}
     >
@@ -641,57 +316,49 @@ export function FleetPage() {
         <div
           className={cn(
             V2_STICKY_HEADER_CLASS,
-            "flex flex-col gap-6 border-b-0 pb-0",
+            "flex flex-col gap-1 border-b-0 pb-4",
           )}
         >
-          <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <header className="flex items-start justify-between gap-4">
             <div>
-              <p className={V2_TAB_EYEBROW_CLASS}>
-                {activeSessionCount} active session
-                {activeSessionCount === 1 ? "" : "s"} · {activeAgentCount}{" "}
-                active agent{activeAgentCount === 1 ? "" : "s"}
+              <h1 className="text-2xl font-semibold tracking-tight">Fleet</h1>
+              <p className={styles.summaryLine}>
+                <span className={styles.lead}>
+                  {allAgents.length}{" "}
+                  {allAgents.length === 1 ? "agent" : "agents"}
+                </span>{" "}
+                · {summaryBits.join(" · ")} · {fleetSessions.length}{" "}
+                {fleetSessions.length === 1 ? "fleet" : "fleets"}
               </p>
-              <h1 className="mt-1 text-2xl font-semibold tracking-tight">
-                Fleet
-              </h1>
             </div>
             <Button
-              className="w-fit"
+              variant="outline"
+              className="w-fit shrink-0"
+              disabled={createMutation.isPending}
               onClick={() => {
                 setMutationError(null)
-                createMutation.mutate({})
+                createMutation.mutate()
               }}
-              disabled={createMutation.isPending}
             >
               <Plus />
-              {createMutation.isPending ? "Creating…" : "New session"}
+              New fleet
             </Button>
           </header>
-          <div className={cn(styles.overview, "border-y border-border")}>
-            <div className={styles.overviewSummary}>
-              <strong>{activeSessionCount}</strong>{" "}
-              {activeSessionCount === 1 ? "session" : "sessions"} ·{" "}
-              <strong>{activeAgentCount}</strong>{" "}
-              {activeAgentCount === 1 ? "instance" : "instances"} ·{" "}
-              <strong>{runningAgentCount}</strong> running
-            </div>
-            <div className={styles.liveLabel}>Live activity</div>
-          </div>
         </div>
 
-        <div className={styles.pageBody}>
+        <div className="flex min-h-0 flex-col pt-6">
           {Boolean(mutationError) && (
-            <div className="border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+            <div className="mb-4 border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
               {errorMessage(mutationError)}
             </div>
           )}
 
           {fleetQuery.isLoading ? (
-            <div className={styles.sessionList}>
+            <div className={styles.fleetList}>
               {[0, 1, 2].map((item) => (
                 <div
                   key={item}
-                  className="h-48 animate-pulse border bg-muted/30"
+                  className="h-40 animate-pulse border border-border bg-muted/20"
                 />
               ))}
             </div>
@@ -712,7 +379,7 @@ export function FleetPage() {
               </Button>
             </div>
           ) : fleetSessions.length === 0 ? (
-            <div className="flex flex-col items-start gap-4 border bg-card p-6">
+            <div className="flex flex-col items-start gap-4 border border-border bg-card p-6">
               <div>
                 <h2 className="font-medium text-foreground">
                   Connect a terminal to start capturing work
@@ -730,52 +397,20 @@ export function FleetPage() {
               </Button>
             </div>
           ) : (
-            <div className={styles.sessionList}>
+            <div className={styles.fleetList}>
               {fleetSessions.map((fleet) => (
-                <FleetBox
+                <FleetCard
                   key={fleet.id}
                   fleet={fleet}
-                  allFleetSessions={fleetSessions}
-                  isMoving={assignMutation.isPending}
-                  onMove={moveAgent}
-                  onCreateSession={(selectedAgent) => {
-                    setMutationError(null)
-                    createMutation.mutate({
-                      agentSessionId: selectedAgent.session_id,
-                    })
-                  }}
-                  onOpenAgent={(agent) => setDetail({ kind: "agent", agent })}
-                  onOpenFleet={(selectedFleet) =>
-                    setDetail({ kind: "fleet", fleet: selectedFleet })
-                  }
-                  onRename={(selectedFleet, name) => {
-                    setMutationError(null)
-                    renameMutation.mutate({ fleet: selectedFleet, name })
-                  }}
-                  onDelete={(selectedFleet) => {
-                    if (
-                      window.confirm(
-                        `Delete "${selectedFleet.name}"? Its agents will move to the default session.`,
-                      )
-                    ) {
-                      setMutationError(null)
-                      deleteMutation.mutate(selectedFleet.id)
-                    }
-                  }}
+                  onOpenAgent={openAgent}
+                  onRename={renameFleet}
+                  onDelete={deleteFleet}
                 />
               ))}
             </div>
           )}
         </div>
       </div>
-
-      <Sheet
-        open={detail !== null}
-        onOpenChange={(open) => !open && setDetail(null)}
-      >
-        {detail?.kind === "agent" && <AgentDetail agent={detail.agent} />}
-        {detail?.kind === "fleet" && <FleetDetail fleet={detail.fleet} />}
-      </Sheet>
     </section>
   )
 }

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -1,0 +1,157 @@
+import type {
+  TaskforceFleetAgent,
+  TaskforceFleetSession,
+} from "@/api/v2Taskforce"
+
+/**
+ * Calm-roster status model from the Claude Design "Fleet Mission Control"
+ * handoff. The design surfaces four states; today the backend only lets us
+ * distinguish `run` vs `idle` from `minutes_ago`, so `waiting`/`paused` are
+ * typed-but-degraded until TF-245 (backend enrichment) lands an explicit
+ * status/capture field on the agent payload.
+ */
+export type FleetStatus = "run" | "waiting" | "paused" | "idle"
+
+/** Minutes within which an agent counts as actively running. */
+const RUNNING_WINDOW_MINUTES = 5
+
+/** Quiet word shown next to a non-running status dot. */
+export const STATE_LABEL: Record<FleetStatus, string> = {
+  run: "running",
+  waiting: "waiting for input",
+  paused: "capture paused",
+  idle: "idle",
+}
+
+// Optional richer fields the backend does not expose yet (TF-245). Read
+// defensively so the UI lights up automatically once the contract grows.
+type EnrichedAgent = TaskforceFleetAgent & {
+  status?: FleetStatus
+  question?: string | null
+  capture?: "on" | "paused"
+  pause_reason?: string | null
+  host?: string | null
+  started_at?: string | null
+  files?: { name: string; state: "new" | "modified" }[]
+  specialist_name?: string | null
+  specialist_rule_count?: number | null
+}
+
+export function agentStatus(agent: TaskforceFleetAgent): FleetStatus {
+  const explicit = (agent as EnrichedAgent).status
+  if (explicit) return explicit
+  return agent.minutes_ago < RUNNING_WINDOW_MINUTES ? "run" : "idle"
+}
+
+export function isRunning(agent: TaskforceFleetAgent): boolean {
+  return agentStatus(agent) === "run"
+}
+
+/** Backend-enrichment accessors — return undefined/null while degraded. */
+export function agentQuestion(agent: TaskforceFleetAgent): string | null {
+  return (agent as EnrichedAgent).question ?? null
+}
+
+export function agentCapturePaused(agent: TaskforceFleetAgent): boolean {
+  return (agent as EnrichedAgent).capture === "paused"
+}
+
+export function agentPauseReason(agent: TaskforceFleetAgent): string | null {
+  return (agent as EnrichedAgent).pause_reason ?? null
+}
+
+export function agentStartedAt(agent: TaskforceFleetAgent): string | null {
+  return (agent as EnrichedAgent).started_at ?? null
+}
+
+export function agentFiles(
+  agent: TaskforceFleetAgent,
+): { name: string; state: "new" | "modified" }[] {
+  return (agent as EnrichedAgent).files ?? []
+}
+
+export function agentSpecialistName(agent: TaskforceFleetAgent): string | null {
+  return (agent as EnrichedAgent).specialist_name ?? null
+}
+
+export function agentSpecialistRuleCount(
+  agent: TaskforceFleetAgent,
+): number | null {
+  return (agent as EnrichedAgent).specialist_rule_count ?? null
+}
+
+// Turn a raw harness model id into a human label, e.g.
+// "claude-opus-4-8" -> "Opus 4.8", "claude-fable-5" -> "Fable 5".
+export function modelLabel(modelId: string | null): string | null {
+  if (!modelId) return null
+  const [family, ...rest] = modelId.replace(/^claude-/, "").split("-")
+  if (!family) return null
+  const name = family.charAt(0).toUpperCase() + family.slice(1)
+  const version = rest.join(".")
+  return version ? `${name} ${version}` : name
+}
+
+export function repoLabel(agent: TaskforceFleetAgent): string {
+  const cwdParts = agent.cwd?.split("/").filter(Boolean) ?? []
+  return agent.repo || cwdParts[cwdParts.length - 1] || "Unknown repo"
+}
+
+/** Machine label, e.g. "mbp-16". Degrades to null until TF-245. */
+export function hostLabel(agent: TaskforceFleetAgent): string | null {
+  return (agent as EnrichedAgent).host ?? null
+}
+
+// Heading shown for an agent. Once Taskforce has captured a document the
+// document title wins; until then a brand-new session shows the model it's
+// running (e.g. "Opus 4.8") rather than the bare working-directory name.
+export function agentDisplayName(agent: TaskforceFleetAgent): string {
+  return agent.title || modelLabel(agent.model_id) || repoLabel(agent)
+}
+
+export function agentModelName(agent: TaskforceFleetAgent): string {
+  return modelLabel(agent.model_id) || "Connected agent"
+}
+
+/** Mono identity meta — "Opus 4.8 · mbp-16", host omitted while degraded. */
+export function agentMeta(agent: TaskforceFleetAgent): string {
+  return [agentModelName(agent), hostLabel(agent)].filter(Boolean).join(" · ")
+}
+
+export function compactPresence(agent: TaskforceFleetAgent): string {
+  if (agent.minutes_ago < 1) return "now"
+  if (agent.minutes_ago < 60) return `${agent.minutes_ago}m`
+  const hours = Math.floor(agent.minutes_ago / 60)
+  const minutes = agent.minutes_ago % 60
+  return minutes ? `${hours}h ${minutes}m` : `${hours}h`
+}
+
+export function presenceLabel(agent: TaskforceFleetAgent): string {
+  if (agent.minutes_ago < 1) return "Active now"
+  if (agent.minutes_ago === 1) return "Active 1 minute ago"
+  return `Active ${agent.minutes_ago} minutes ago`
+}
+
+/** Display name for a fleet (server may create nameless fleets). */
+export function fleetTitle(fleet: TaskforceFleetSession): string {
+  return fleet.name?.trim() || "Untitled fleet"
+}
+
+/** Repo/branch shown on a fleet card header, derived from its agents. */
+export function fleetRepo(
+  fleet: TaskforceFleetSession,
+): { repo: string; branch: string | null } | null {
+  for (const agent of fleet.agents) {
+    if (agent.repo) {
+      return { repo: agent.repo, branch: agent.branch }
+    }
+  }
+  return null
+}
+
+export function runningCount(agents: TaskforceFleetAgent[]): number {
+  return agents.filter(isRunning).length
+}
+
+export function waitingCount(agents: TaskforceFleetAgent[]): number {
+  return agents.filter((agent) => agentStatus(agent) === "waiting").length
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -40,6 +40,7 @@ import { Route as LayoutCasesRouteImport } from './routes/_layout/cases'
 import { Route as LayoutAdminRouteImport } from './routes/_layout/admin'
 import { Route as V2MetricsMethodologyRouteImport } from './routes/v2/metrics.methodology'
 import { Route as V2LibraryDocumentIdRouteImport } from './routes/v2/library.$documentId'
+import { Route as V2FleetSessionIdRouteImport } from './routes/v2/fleet.$sessionId'
 import { Route as V2AgentsSlugRouteImport } from './routes/v2/agents.$slug'
 
 const V2Route = V2RouteImport.update({
@@ -196,6 +197,11 @@ const V2LibraryDocumentIdRoute = V2LibraryDocumentIdRouteImport.update({
   path: '/$documentId',
   getParentRoute: () => V2LibraryRoute,
 } as any)
+const V2FleetSessionIdRoute = V2FleetSessionIdRouteImport.update({
+  id: '/$sessionId',
+  path: '/$sessionId',
+  getParentRoute: () => V2FleetRoute,
+} as any)
 const V2AgentsSlugRoute = V2AgentsSlugRouteImport.update({
   id: '/$slug',
   path: '/$slug',
@@ -221,7 +227,7 @@ export interface FileRoutesByFullPath {
   '/docs/$slug': typeof DocsSlugRoute
   '/v2/admin': typeof V2AdminRoute
   '/v2/agents': typeof V2AgentsRouteWithChildren
-  '/v2/fleet': typeof V2FleetRoute
+  '/v2/fleet': typeof V2FleetRouteWithChildren
   '/v2/home': typeof V2HomeRoute
   '/v2/ledger': typeof V2LedgerRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
@@ -232,6 +238,7 @@ export interface FileRoutesByFullPath {
   '/docs/': typeof DocsIndexRoute
   '/v2/': typeof V2IndexRoute
   '/v2/agents/$slug': typeof V2AgentsSlugRoute
+  '/v2/fleet/$sessionId': typeof V2FleetSessionIdRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
 }
@@ -252,7 +259,7 @@ export interface FileRoutesByTo {
   '/docs/$slug': typeof DocsSlugRoute
   '/v2/admin': typeof V2AdminRoute
   '/v2/agents': typeof V2AgentsRouteWithChildren
-  '/v2/fleet': typeof V2FleetRoute
+  '/v2/fleet': typeof V2FleetRouteWithChildren
   '/v2/home': typeof V2HomeRoute
   '/v2/ledger': typeof V2LedgerRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
@@ -263,6 +270,7 @@ export interface FileRoutesByTo {
   '/docs': typeof DocsIndexRoute
   '/v2': typeof V2IndexRoute
   '/v2/agents/$slug': typeof V2AgentsSlugRoute
+  '/v2/fleet/$sessionId': typeof V2FleetSessionIdRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
 }
@@ -287,7 +295,7 @@ export interface FileRoutesById {
   '/docs/$slug': typeof DocsSlugRoute
   '/v2/admin': typeof V2AdminRoute
   '/v2/agents': typeof V2AgentsRouteWithChildren
-  '/v2/fleet': typeof V2FleetRoute
+  '/v2/fleet': typeof V2FleetRouteWithChildren
   '/v2/home': typeof V2HomeRoute
   '/v2/ledger': typeof V2LedgerRoute
   '/v2/library': typeof V2LibraryRouteWithChildren
@@ -298,6 +306,7 @@ export interface FileRoutesById {
   '/docs/': typeof DocsIndexRoute
   '/v2/': typeof V2IndexRoute
   '/v2/agents/$slug': typeof V2AgentsSlugRoute
+  '/v2/fleet/$sessionId': typeof V2FleetSessionIdRoute
   '/v2/library/$documentId': typeof V2LibraryDocumentIdRoute
   '/v2/metrics/methodology': typeof V2MetricsMethodologyRoute
 }
@@ -333,6 +342,7 @@ export interface FileRouteTypes {
     | '/docs/'
     | '/v2/'
     | '/v2/agents/$slug'
+    | '/v2/fleet/$sessionId'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
   fileRoutesByTo: FileRoutesByTo
@@ -364,6 +374,7 @@ export interface FileRouteTypes {
     | '/docs'
     | '/v2'
     | '/v2/agents/$slug'
+    | '/v2/fleet/$sessionId'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
   id:
@@ -398,6 +409,7 @@ export interface FileRouteTypes {
     | '/docs/'
     | '/v2/'
     | '/v2/agents/$slug'
+    | '/v2/fleet/$sessionId'
     | '/v2/library/$documentId'
     | '/v2/metrics/methodology'
   fileRoutesById: FileRoutesById
@@ -634,6 +646,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof V2LibraryDocumentIdRouteImport
       parentRoute: typeof V2LibraryRoute
     }
+    '/v2/fleet/$sessionId': {
+      id: '/v2/fleet/$sessionId'
+      path: '/$sessionId'
+      fullPath: '/v2/fleet/$sessionId'
+      preLoaderRoute: typeof V2FleetSessionIdRouteImport
+      parentRoute: typeof V2FleetRoute
+    }
     '/v2/agents/$slug': {
       id: '/v2/agents/$slug'
       path: '/$slug'
@@ -689,6 +708,17 @@ const V2AgentsRouteWithChildren = V2AgentsRoute._addFileChildren(
   V2AgentsRouteChildren,
 )
 
+interface V2FleetRouteChildren {
+  V2FleetSessionIdRoute: typeof V2FleetSessionIdRoute
+}
+
+const V2FleetRouteChildren: V2FleetRouteChildren = {
+  V2FleetSessionIdRoute: V2FleetSessionIdRoute,
+}
+
+const V2FleetRouteWithChildren =
+  V2FleetRoute._addFileChildren(V2FleetRouteChildren)
+
 interface V2LibraryRouteChildren {
   V2LibraryDocumentIdRoute: typeof V2LibraryDocumentIdRoute
 }
@@ -716,7 +746,7 @@ const V2MetricsRouteWithChildren = V2MetricsRoute._addFileChildren(
 interface V2RouteChildren {
   V2AdminRoute: typeof V2AdminRoute
   V2AgentsRoute: typeof V2AgentsRouteWithChildren
-  V2FleetRoute: typeof V2FleetRoute
+  V2FleetRoute: typeof V2FleetRouteWithChildren
   V2HomeRoute: typeof V2HomeRoute
   V2LedgerRoute: typeof V2LedgerRoute
   V2LibraryRoute: typeof V2LibraryRouteWithChildren
@@ -730,7 +760,7 @@ interface V2RouteChildren {
 const V2RouteChildren: V2RouteChildren = {
   V2AdminRoute: V2AdminRoute,
   V2AgentsRoute: V2AgentsRouteWithChildren,
-  V2FleetRoute: V2FleetRoute,
+  V2FleetRoute: V2FleetRouteWithChildren,
   V2HomeRoute: V2HomeRoute,
   V2LedgerRoute: V2LedgerRoute,
   V2LibraryRoute: V2LibraryRouteWithChildren,

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -1,0 +1,265 @@
+import { useQuery } from "@tanstack/react-query"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { BookOpen, ChevronLeft, ScrollText } from "lucide-react"
+import {
+  readTaskforceFleet,
+  type TaskforceFleetAgent,
+  type TaskforceFleetResponse,
+} from "@/api/v2Taskforce"
+import { Button } from "@/components/ui/button"
+import styles from "@/components/V2/Fleet/FleetPage.module.css"
+import {
+  agentDisplayName,
+  agentSpecialistName,
+  agentStatus,
+  compactPresence,
+  type FleetStatus,
+  fleetTitle,
+  hostLabel,
+  modelLabel,
+  presenceLabel,
+  STATE_LABEL,
+} from "@/components/V2/Fleet/fleetStatus"
+import { cn } from "@/lib/utils"
+
+const FLEET_QUERY_KEY = ["v2-taskforce-fleet"] as const
+
+export const Route = createFileRoute("/v2/fleet/$sessionId")({
+  component: FleetAgentDetailRoute,
+  head: () => ({
+    meta: [{ title: "Taskforce | Agent session" }],
+  }),
+})
+
+type Located = { agent: TaskforceFleetAgent; fleetName: string }
+
+function locateAgent(
+  data: TaskforceFleetResponse | undefined,
+  sessionId: string,
+): Located | null {
+  if (!data) return null
+  for (const fleet of data.fleet_sessions) {
+    const agent = fleet.agents.find(
+      (candidate) => candidate.session_id === sessionId,
+    )
+    if (agent) return { agent, fleetName: fleetTitle(fleet) }
+  }
+  return null
+}
+
+const STATE_CLASS: Record<FleetStatus, string | undefined> = {
+  run: undefined,
+  waiting: styles.stateWaiting,
+  paused: styles.statePaused,
+  idle: styles.stateIdle,
+}
+
+function metaRow(key: string, value: string, valueClass?: string) {
+  return (
+    <div className={styles.metarow} key={key}>
+      <span className={styles.mk}>{key}</span>
+      <span className={cn(styles.mv, valueClass)}>{value}</span>
+    </div>
+  )
+}
+
+function FleetAgentDetailRoute() {
+  const { sessionId } = Route.useParams()
+  const fleetQuery = useQuery({
+    queryKey: FLEET_QUERY_KEY,
+    queryFn: readTaskforceFleet,
+    refetchInterval: 30_000,
+  })
+
+  const located = locateAgent(fleetQuery.data, sessionId)
+
+  if (fleetQuery.isLoading) {
+    return (
+      <div className={cn(styles.detail, "items-center justify-center")}>
+        <p className="text-sm text-muted-foreground">Loading session…</p>
+      </div>
+    )
+  }
+
+  if (!located) {
+    return (
+      <div className={cn(styles.detail, "items-start gap-4")}>
+        <p className="text-sm text-muted-foreground">
+          {fleetQuery.error
+            ? "This session could not be loaded."
+            : "This agent is no longer active."}
+        </p>
+        <Button asChild variant="outline">
+          <Link to="/v2/fleet">Back to Fleet</Link>
+        </Button>
+      </div>
+    )
+  }
+
+  const { agent, fleetName } = located
+  const status = agentStatus(agent)
+  const age = compactPresence(agent)
+  const model = modelLabel(agent.model_id)
+  const host = hostLabel(agent)
+  const specialist = agentSpecialistName(agent) ?? agent.specialist_slug
+  const referencedCount = agent.referenced_document_ids.length
+
+  const dmetaBits = [model, host, agent.branch].filter(Boolean)
+
+  return (
+    <div className={styles.detail}>
+      <div className={styles.dtop}>
+        <div className={styles.crumb}>
+          <Link to="/v2/fleet" className={styles.back}>
+            <ChevronLeft />
+            Fleet
+          </Link>
+          <span className={styles.sep}>/</span>
+          <span>{fleetName}</span>
+        </div>
+
+        <div className={styles.dhead}>
+          <span
+            className={cn(
+              styles.sdot,
+              styles[status],
+              status === "run" && styles.pulse,
+            )}
+          />
+          <div className={styles.dtitle}>
+            <h1>{agentDisplayName(agent)}</h1>
+            {dmetaBits.length > 0 && (
+              <div className={styles.dmeta}>
+                <b>{dmetaBits[0]}</b>
+                {dmetaBits.slice(1).map((bit) => (
+                  <span key={bit}> · {bit}</span>
+                ))}
+              </div>
+            )}
+            <div className={cn(styles.dstate, STATE_CLASS[status])}>
+              {status === "run"
+                ? `running · ${age}`
+                : `${STATE_LABEL[status]} · ${age}`}
+            </div>
+          </div>
+          <div className={styles.dactions}>
+            <Button asChild variant="ghost" className={styles.ghost}>
+              <Link
+                to="/v2/ledger"
+                search={{ session_id: agent.session_id }}
+                title={presenceLabel(agent)}
+              >
+                <ScrollText />
+                View in Ledger
+              </Link>
+            </Button>
+            {agent.active_document_id && (
+              <Button asChild variant="ghost" className={styles.ghost}>
+                <Link
+                  to="/v2/library/$documentId"
+                  params={{ documentId: agent.active_document_id }}
+                >
+                  <BookOpen />
+                  Open document
+                </Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.dbody}>
+        <div className={styles.dmain}>
+          {/* Working on */}
+          <div className={styles.section}>
+            <div className={styles.seclabel}>Working on</div>
+            <div className={styles.nowtask}>
+              {agent.summary_markdown ||
+                "No summary has been captured for this session yet."}
+            </div>
+          </div>
+
+          {/* Document */}
+          {agent.active_document_id && (
+            <div className={styles.section}>
+              <div className={styles.seclabel}>Document</div>
+              <Link
+                to="/v2/library/$documentId"
+                params={{ documentId: agent.active_document_id }}
+                className={styles.doccard}
+              >
+                <div className={styles.dmode}>writing</div>
+                <div className={styles.dttl}>
+                  {agent.title || "Active Taskforce document"}
+                </div>
+                <div className={styles.dupd}>Captured by this session</div>
+              </Link>
+            </div>
+          )}
+
+          {/* Activity timeline — full session-log derivation is TF-242. */}
+          <div className={styles.section}>
+            <div className={styles.seclabel}>Activity</div>
+            <div className={styles.timeline}>
+              <div className={cn(styles.tev, styles.tevNow)}>
+                <span className={styles.tdot} />
+                <div className={styles.tt}>now</div>
+                <div className={styles.tx}>
+                  {agent.summary_markdown || "Active in this session"}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.drail}>
+          {/* Profile in use — degrades to specialist slug until TF-245. */}
+          {specialist && (
+            <div className={styles.block}>
+              <div className={styles.seclabel}>Profile in use</div>
+              <div className={styles.profcard}>
+                <div className={styles.pfTop}>
+                  <span className={styles.pfAv}>
+                    {specialist.slice(0, 2).toUpperCase()}
+                  </span>
+                  <div className={styles.pfId}>
+                    <div className={styles.pfNm}>{specialist}</div>
+                    <div className={styles.pfSub}>specialist</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Session meta */}
+          <div className={styles.block}>
+            <div className={styles.seclabel}>Session</div>
+            {metaRow("Fleet", fleetName)}
+            {agent.branch && metaRow("Branch", agent.branch)}
+            {(host || agent.repo) &&
+              metaRow("Host", host ?? (agent.repo as string))}
+            {model && metaRow("Model", model)}
+            {metaRow("Session", agent.session_id)}
+          </div>
+
+          {/* Context in use — title resolution is TF-243. */}
+          {referencedCount > 0 && (
+            <div className={styles.block}>
+              <div className={styles.seclabel}>Context in use</div>
+              <div className={styles.ctxitem}>
+                {referencedCount} referenced{" "}
+                {referencedCount === 1 ? "document" : "documents"}
+              </div>
+            </div>
+          )}
+
+          {/* Files — backend exposes no files-touched list yet (TF-245). */}
+          <div className={styles.block}>
+            <div className={styles.seclabel}>Files</div>
+            <div className={styles.empty}>No files touched yet</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Reskins **/v2/fleet** to the calm minimalist *Fleet Mission Control* design from the Claude Design handoff (claude.ai/design). Implements the foundation; the detail panes, e2e, backend enrichment, and polish are tracked as **TF-242…TF-246** under epic **TF-241** for Codex.

## Design intent
From the design chat transcripts, the user explicitly rejected the metric-heavy direction (ROI bar, tokens, spend, sparklines, collision/stall alerts) — *"so much red, it looks like an alerts page… no metrics about tokens here."* The landing design is a **calm roster** (status dot + agent + what it's working on + age, sessions as enclosed cards) and a **full-page two-pane session detail**. "Calmer mono" labels (sentence case, ~11px, tight tracking), one accent used sparingly.

## What's here
- **CSS module** ported from the handoff `fleet.css` onto the app's semantic tokens (Geist + JetBrains Mono + `#8447ff` + globally sharp corners) — light/dark safe.
- **`fleetStatus.ts`** — status model (`run`/`idle` derived from `minutes_ago` today; `waiting`/`paused` typed for TF-245) + data-mapping helpers, all degrade-aware.
- **Roster (`FleetPage.tsx`)** — enclosed fleet cards (name · repo · branch · N active · total), calm status-dot rows, summary line, create / rename / delete, row → detail navigation. Aligned to the current no-`unassigned` fleet API.
- **Detail route `/v2/fleet/$sessionId`** — fixed-top header (breadcrumb back, status dot, model · host · branch, Ledger / document actions) + two-pane independent-scroll body. Wires Working-on, Document, Profile, Session meta, Context; degrades Activity timeline / Files / Host / waiting+reply until the backend supplies them.

## Data approach: wire real + degrade
Everything the `/taskforce/fleet` API exposes is wired; fields it doesn't (waiting/paused, capture-paused reason, files-touched, host, started-at, activity timeline) degrade cleanly and are covered by **TF-245**.

## Verification
- `tsc -p tsconfig.build.json` ✅
- `biome check` ✅
- `vite build` ✅

## Follow-ups (Codex)
- TF-242 detail left pane (Working on / Document / Activity timeline from session-log)
- TF-243 detail right rail (Profile / Session / Files / Context title resolution)
- TF-244 Playwright e2e (roster → detail)
- TF-245 backend enrichment (status / capture / files / host / started_at)
- TF-246 responsive + light-theme + reduced-motion polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)