### PR TITLE
Calmer mono: drop all-caps labels across the Taskforce webapp

### DIFF
--- a/src/components/V2/Agents/AgentProfileCard.tsx
+++ b/src/components/V2/Agents/AgentProfileCard.tsx
@@ -48,7 +48,7 @@ function AgentStats({ stats }: { stats: Stat[] }) {
           >
             {stat.value}
           </div>
-          <div className="mt-[3px] font-mono text-[9.5px] uppercase tracking-[0.12em] text-foreground/70">
+          <div className="mt-[3px] font-mono text-[9.5px] tracking-[0.01em] text-foreground/70">
             {stat.label}
           </div>
         </div>
@@ -88,7 +88,7 @@ export function AgentProfileCard({ agent }: { agent: AgentSpecialistSummary }) {
             </div>
             <AgentStatusBadge status={agent.status} className="h-6 shrink-0" />
           </div>
-          <div className="mt-[3px] font-mono text-[10px] uppercase tracking-[0.12em] text-foreground/70">
+          <div className="mt-[3px] font-mono text-[10px] tracking-[0.01em] text-foreground/70">
             {agent.role}
           </div>
         </div>

--- a/src/components/V2/Agents/agentsTypography.ts
+++ b/src/components/V2/Agents/agentsTypography.ts
@@ -34,7 +34,7 @@ export const AGENT_ROUTE_CHIP_CLASS =
 export const AGENT_DESCRIPTION_CLASS = "text-sm leading-5 text-muted-foreground"
 
 export const AGENT_STAT_LABEL_CLASS =
-  "text-xs uppercase tracking-wide text-muted-foreground"
+  "text-xs tracking-[0.01em] text-muted-foreground"
 
 export const AGENT_STAT_VALUE_CLASS =
   "text-sm font-semibold tabular-nums text-foreground"
@@ -44,7 +44,7 @@ export const AGENT_SECTION_TITLE_CLASS = "text-sm font-semibold text-foreground"
 export const AGENT_SECTION_META_CLASS = "text-xs text-muted-foreground"
 
 export const AGENT_TABLE_HEADER_CLASS =
-  "text-xs uppercase tracking-wide text-muted-foreground"
+  "text-xs tracking-[0.01em] text-muted-foreground"
 
 export const AGENT_FEATURE_STRIP_VALUE_CLASS =
   "text-2xl font-semibold tabular-nums text-foreground"

--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -79,8 +79,8 @@
   font-size: 12px;
   /* Match Tailwind text-xs (16px) so the title stacks identically to Profiles. */
   line-height: 1rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  text-transform: none;
   color: var(--tf-muted-fg);
 }
 .h1 {
@@ -160,8 +160,8 @@
   border-bottom: 1px solid var(--tf-border);
   font-family: var(--font-mono);
   font-size: 12px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  text-transform: none;
   color: var(--tf-faint-fg);
 }
 
@@ -176,8 +176,8 @@
 .dayLbl {
   font-family: var(--font-mono);
   font-size: 12px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  text-transform: none;
   color: var(--tf-fg);
   font-weight: 500;
 }
@@ -416,8 +416,8 @@
 .eyebrow {
   font-family: var(--font-mono);
   font-size: 12px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  text-transform: none;
   color: var(--tf-muted-fg);
 }
 .tHead h2 {
@@ -465,7 +465,7 @@
   font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 0.06em;
-  text-transform: uppercase;
+  text-transform: none;
   color: var(--tf-faint-fg);
   padding-top: 14px;
   display: flex;
@@ -598,8 +598,8 @@
 .grp {
   font-family: var(--font-mono);
   font-size: 12px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  text-transform: none;
   color: var(--tf-faint-fg);
   margin: 20px 0 9px;
 }
@@ -652,7 +652,7 @@
   font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 0.04em;
-  text-transform: uppercase;
+  text-transform: none;
 }
 .flagStale {
   color: var(--tf-warn);
@@ -671,7 +671,7 @@
   font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 0.04em;
-  text-transform: uppercase;
+  text-transform: none;
   padding: 8px 11px;
   border: 1px solid var(--tf-border);
   color: var(--tf-muted-fg);

--- a/src/components/V2/Library/LibraryRecentReel.tsx
+++ b/src/components/V2/Library/LibraryRecentReel.tsx
@@ -72,7 +72,7 @@ function RecentCard({
     >
       <div
         className={cn(
-          "mb-1.5 font-mono text-[9px] uppercase tracking-[0.14em]",
+          "mb-1.5 font-mono text-[9px] tracking-[0.01em]",
           DOCUMENT_SCOPE_TEXT[scope],
         )}
       >
@@ -148,7 +148,7 @@ export function LibraryRecentReel({
   return (
     <section aria-label="Recently accessed" className="shrink-0">
       <div className="mb-3">
-        <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-foreground">
+        <span className="font-mono text-[10px] tracking-[0.01em] text-foreground">
           Recently accessed
         </span>
       </div>

--- a/src/components/V2/Metrics/MetricsPage.tsx
+++ b/src/components/V2/Metrics/MetricsPage.tsx
@@ -733,7 +733,7 @@ function ExperimentalMetricsPage({
 
       <section className="border border-border bg-background text-foreground">
         <div className="px-5 py-6 md:px-7">
-          <div className="font-mono text-xs uppercase tracking-[0.18em] opacity-70">
+          <div className="font-mono text-xs tracking-[0.01em] opacity-70">
             Tokens saved · {windowCopy.label}
           </div>
           <div className="mt-3 text-6xl font-semibold leading-[0.9] tracking-tight tabular-nums md:text-7xl">
@@ -892,7 +892,7 @@ function ExperimentalSessionMetrics({
                 <Link
                   to="/v2/agents/$slug"
                   params={{ slug: sessionSavings.specialist_slug }}
-                  className="mt-3 inline-flex items-center gap-1.5 border border-border px-2.5 py-1 font-mono text-xs uppercase tracking-[0.12em] text-foreground hover:bg-muted"
+                  className="mt-3 inline-flex items-center gap-1.5 border border-border px-2.5 py-1 font-mono text-xs tracking-[0.01em] text-foreground hover:bg-muted"
                 >
                   Selected profile:{" "}
                   <span className="font-semibold normal-case tracking-normal">
@@ -916,7 +916,7 @@ function ExperimentalSessionMetrics({
         <div className="flex flex-col gap-6">
       <section className="grid border border-border bg-background text-foreground lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
         <div className="px-5 py-6 md:px-7">
-          <div className="font-mono text-xs uppercase tracking-[0.18em] opacity-70">
+          <div className="font-mono text-xs tracking-[0.01em] opacity-70">
             Session tokens saved
           </div>
           <div className="mt-3 text-6xl font-semibold leading-[0.9] tracking-tight tabular-nums md:text-7xl">
@@ -953,7 +953,7 @@ function ExperimentalSessionMetrics({
 
       <section className="grid border border-border md:grid-cols-[10rem_minmax(0,1fr)]">
         <div className="border-b border-border bg-muted/40 p-4 md:border-r md:border-b-0">
-          <div className="font-mono text-xs uppercase tracking-[0.16em] text-primary">
+          <div className="font-mono text-xs tracking-[0.01em] text-primary">
             Session insights
           </div>
         </div>
@@ -1017,7 +1017,7 @@ function ExperimentalMetricTile({
 
   return (
     <div className="border border-border bg-background p-4">
-      <div className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+      <div className="font-mono text-xs tracking-[0.01em] text-muted-foreground">
         {definition.display_name}
       </div>
       <div className="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
@@ -1058,7 +1058,7 @@ function ExperimentalRatioCell({
       <div className="truncate text-lg font-semibold tracking-tight tabular-nums">
         {value}
       </div>
-      <div className="mt-1 font-mono text-xs uppercase tracking-[0.12em] opacity-70">
+      <div className="mt-1 font-mono text-xs tracking-[0.01em] opacity-70">
         {label}
       </div>
     </div>
@@ -1078,7 +1078,7 @@ function ExperimentalBreakdownPanel({
 
   return (
     <section className="border border-border bg-background p-4">
-      <div className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+      <div className="font-mono text-xs tracking-[0.01em] text-muted-foreground">
         {kicker}
       </div>
       <h2 className="mt-1 text-sm font-semibold">{title}</h2>
@@ -1130,7 +1130,7 @@ function ExperimentalSessionLog({
 }) {
   return (
     <section className="border border-border bg-background p-4">
-      <div className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+      <div className="font-mono text-xs tracking-[0.01em] text-muted-foreground">
         Consult log
       </div>
       <h2 className="mt-1 text-sm font-semibold">Documents consulted</h2>
@@ -1149,7 +1149,7 @@ function ExperimentalSessionLog({
         </p>
       ) : (
         <div className="mt-3 divide-y divide-border/70">
-          <div className="grid grid-cols-[minmax(0,1.4fr)_4rem_5rem_7rem] gap-4 px-1 py-2 font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground max-md:hidden">
+          <div className="grid grid-cols-[minmax(0,1.4fr)_4rem_5rem_7rem] gap-4 px-1 py-2 font-mono text-xs tracking-[0.01em] text-muted-foreground max-md:hidden">
             <div>Document</div>
             <div>Score</div>
             <div>Band</div>

--- a/src/components/V2/ScopeFilterBar.tsx
+++ b/src/components/V2/ScopeFilterBar.tsx
@@ -34,7 +34,7 @@ export function ScopeFilterBar<TKey extends string>({
   return (
     <div
       className={cn(
-        "flex flex-wrap items-stretch border-y border-border font-mono text-[11px] uppercase tracking-[0.1em]",
+        "flex flex-wrap items-stretch border-y border-border font-mono text-[11px] tracking-[0.01em]",
         className,
       )}
     >

--- a/src/components/V2/Search/ByokSetup.tsx
+++ b/src/components/V2/Search/ByokSetup.tsx
@@ -49,7 +49,7 @@ export function ByokSetup({ onSaved }: { onSaved: () => void }) {
         </p>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
           <div className="sm:w-40">
-            <div className="mb-1 text-xs uppercase text-muted-foreground">
+            <div className="mb-1 text-xs text-muted-foreground">
               Provider
             </div>
             <Select
@@ -68,7 +68,7 @@ export function ByokSetup({ onSaved }: { onSaved: () => void }) {
           <div className="flex-1">
             <label
               htmlFor="taskforce-byok-api-key"
-              className="mb-1 block text-xs uppercase text-muted-foreground"
+              className="mb-1 block text-xs text-muted-foreground"
             >
               API key
             </label>

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -660,7 +660,7 @@ export function TaskforcePlaceholder({
   return (
     <section className="flex min-h-0 flex-1 items-start">
       <div className="w-full max-w-3xl border-l border-border pl-5">
-        <p className="mb-3 text-xs font-medium uppercase text-muted-foreground">
+        <p className="mb-3 text-xs font-medium text-muted-foreground">
           {eyebrow}
         </p>
         <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>

--- a/src/components/V2/v2PageShell.ts
+++ b/src/components/V2/v2PageShell.ts
@@ -31,7 +31,7 @@ export const V2_PAGE_CONTENT_FIXED = cn(
 
 /** Tab page meta line (e.g. "7d · personal") — page title lives in the h1 below. */
 export const V2_TAB_EYEBROW_CLASS =
-  "font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground"
+  "font-mono text-xs tracking-[0.01em] text-muted-foreground"
 
 /** Sticky page header inside a padded scroll area (offsets `p-6` padding). */
 export const V2_STICKY_HEADER_CLASS = cn(

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -78,7 +78,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-muted-foreground h-11 px-4 text-left align-middle text-xs font-semibold uppercase tracking-wider whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-muted-foreground h-11 px-4 text-left align-middle text-xs font-semibold tracking-[0.01em] whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -164,7 +164,7 @@ function Instructions({ instructions }: { instructions: string[] }) {
         meta={`${instructions.length} rules`}
       />
       <div className="mt-3 border border-black/10 bg-zinc-50 dark:border-white/12 dark:bg-white/5">
-        <div className="flex items-center justify-between border-b border-black/10 px-3 py-2 text-xs uppercase tracking-wide text-zinc-400 dark:border-white/12 dark:text-zinc-500">
+        <div className="flex items-center justify-between border-b border-black/10 px-3 py-2 text-xs tracking-[0.01em] text-zinc-400 dark:border-white/12 dark:text-zinc-500">
           <span>system prompt</span>
           <span className="text-[#8447ff]">live</span>
         </div>
@@ -182,7 +182,7 @@ function Instructions({ instructions }: { instructions: string[] }) {
           type="button"
           onClick={() => setExpanded((value) => !value)}
           aria-expanded={expanded}
-          className="flex w-full items-center justify-between border-t border-black/10 px-3 py-2 text-xs uppercase tracking-wide text-[#8447ff] transition-colors hover:bg-[#8447ff]/5 dark:border-white/12"
+          className="flex w-full items-center justify-between border-t border-black/10 px-3 py-2 text-xs tracking-[0.01em] text-[#8447ff] transition-colors hover:bg-[#8447ff]/5 dark:border-white/12"
         >
           <span>{expanded ? "Collapse" : "Expand"}</span>
           {expanded ? (
@@ -207,7 +207,7 @@ function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
       <div className="mt-2 overflow-x-auto">
         <table className="w-full min-w-[42rem] border-collapse text-sm">
           <thead>
-            <tr className="border-b border-black/10 text-xs uppercase tracking-wide text-zinc-400 dark:border-white/12 dark:text-zinc-500">
+            <tr className="border-b border-black/10 text-xs tracking-[0.01em] text-zinc-400 dark:border-white/12 dark:text-zinc-500">
               <th className="py-2 pr-3 text-left font-medium">Session</th>
               <th className="px-3 text-left font-medium">Repo</th>
               <th className="px-3 text-right font-medium">Saved</th>
@@ -260,7 +260,7 @@ function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
       <div className="mt-2 overflow-x-auto">
         <table className="w-full min-w-[42rem] border-collapse text-sm">
           <thead>
-            <tr className="border-b border-black/10 text-xs uppercase tracking-wide text-zinc-400 dark:border-white/12 dark:text-zinc-500">
+            <tr className="border-b border-black/10 text-xs tracking-[0.01em] text-zinc-400 dark:border-white/12 dark:text-zinc-500">
               <th className="py-2 pr-3 text-left font-medium">Document</th>
               <th className="px-3 text-left font-medium">Anchor</th>
               <th className="py-2 px-3 text-right font-medium">Reason</th>
@@ -311,7 +311,7 @@ function RecentInvocations({ agent }: { agent: AgentSpecialistDetail }) {
       <div className="mt-2 overflow-x-auto">
         <table className="w-full min-w-[38rem] border-collapse text-sm">
           <thead>
-            <tr className="border-b border-black/10 text-xs uppercase tracking-wide text-zinc-400 dark:border-white/12 dark:text-zinc-500">
+            <tr className="border-b border-black/10 text-xs tracking-[0.01em] text-zinc-400 dark:border-white/12 dark:text-zinc-500">
               <th className="py-2 pr-3 text-left font-medium">Query</th>
               <th className="px-3 text-left font-medium">Repo</th>
               <th className="px-3 text-right font-medium">Saved</th>

--- a/src/routes/v2/ledger.tsx
+++ b/src/routes/v2/ledger.tsx
@@ -42,7 +42,7 @@ function TaskforceLedger() {
       <section className={V2_PAGE_FRAME} data-testid="ledger-team-only">
         <div className={V2_PAGE_BODY}>
           <div className="max-w-2xl border-l border-border pl-5">
-            <p className="mb-3 font-mono text-xs uppercase tracking-[0.14em] text-muted-foreground">
+            <p className="mb-3 font-mono text-xs tracking-[0.01em] text-muted-foreground">
               Ledger for teams
             </p>
             <h1 className="text-2xl font-semibold">Create or join a team</h1>

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -339,7 +339,7 @@ function MarkdownBlocks({
                 variant === "report" && level === 1 && "text-xl font-semibold",
                 variant === "report" &&
                   level === 2 &&
-                  "border-t border-border pt-5 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-muted-foreground",
+                  "border-t border-border pt-5 font-mono text-[0.68rem] font-semibold tracking-[0.01em] text-muted-foreground",
                 variant === "report" &&
                   level === 3 &&
                   "text-base font-semibold",
@@ -939,7 +939,7 @@ function TaskforceDocumentDetail() {
             isSplit && "md:shrink-0",
           )}
         >
-          <div className="flex items-center justify-between gap-3 font-mono text-[0.66rem] uppercase tracking-[0.14em] text-muted-foreground">
+          <div className="flex items-center justify-between gap-3 font-mono text-[0.66rem] tracking-[0.01em] text-muted-foreground">
             <div className="flex min-w-0 items-center gap-2">
               <Link
                 to="/v2/library"
@@ -1168,7 +1168,7 @@ function DocumentProvenanceStrip({
     <section className="border-b border-border py-3">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <div className="font-mono text-[0.66rem] uppercase tracking-[0.14em] text-muted-foreground">
+          <div className="font-mono text-[0.66rem] tracking-[0.01em] text-muted-foreground">
             Sessions / Reused by
           </div>
           <div className="mt-1 text-xs text-muted-foreground">
@@ -1294,7 +1294,7 @@ function DocumentMetadata({
   const sharedCount = shares.length
 
   return (
-    <div className="mt-4 flex flex-wrap items-center gap-3 py-2 font-mono text-[0.66rem] uppercase tracking-[0.08em] text-muted-foreground">
+    <div className="mt-4 flex flex-wrap items-center gap-3 py-2 font-mono text-[0.66rem] tracking-[0.01em] text-muted-foreground">
       <DocumentDateField
         label="Created"
         value={document.created_at}
@@ -1318,7 +1318,7 @@ function DocumentMetadata({
           onSelect={onMoveFolder}
           onCreateFolder={onCreateFolder}
           triggerLabel={document.folder_name ?? "Unfiled"}
-          triggerClassName="h-7 px-2 font-mono text-[0.66rem] uppercase tracking-[0.08em] [&_svg]:size-3"
+          triggerClassName="h-7 px-2 font-mono text-[0.66rem] tracking-[0.01em] [&_svg]:size-3"
         />
       ) : (
         <span className="inline-flex min-w-0 items-center gap-1.5 text-muted-foreground">
@@ -1361,7 +1361,7 @@ function DocumentMetadata({
         aria-pressed={document.is_favorite}
         onClick={onToggleFavorite}
         data-testid="document-favorite"
-        className="h-7 px-2 font-mono text-[0.66rem] uppercase tracking-[0.08em]"
+        className="h-7 px-2 font-mono text-[0.66rem] tracking-[0.01em]"
       >
         <Star
           className={cn(
@@ -1495,7 +1495,7 @@ function DocumentAccessDropdown({
           variant="outline"
           size="sm"
           data-testid="document-access"
-          className="h-7 px-2 font-mono text-[0.66rem] uppercase tracking-[0.08em] [&_svg]:size-3"
+          className="h-7 px-2 font-mono text-[0.66rem] tracking-[0.01em] [&_svg]:size-3"
         >
           <Share2 className="size-4" />
           {persistedCount > 0
@@ -1636,7 +1636,7 @@ function ViewToggle({
       aria-selected={active}
       data-state={active ? "active" : "inactive"}
       onClick={onClick}
-      className="inline-flex items-center justify-center gap-1.5 border-r border-border px-3 py-1 font-mono text-[0.62rem] uppercase tracking-[0.12em] text-muted-foreground transition-colors last:border-r-0 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=active]:bg-muted data-[state=active]:text-foreground"
+      className="inline-flex items-center justify-center gap-1.5 border-r border-border px-3 py-1 font-mono text-[0.62rem] tracking-[0.01em] text-muted-foreground transition-colors last:border-r-0 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=active]:bg-muted data-[state=active]:text-foreground"
     >
       {label}
     </button>
@@ -1949,7 +1949,7 @@ function DetailsPane({
     >
       <div
         className={cn(
-          "flex items-center justify-between gap-3 border-b border-border bg-muted/30 px-4 py-2 font-mono text-[0.66rem] uppercase tracking-[0.12em] text-muted-foreground",
+          "flex items-center justify-between gap-3 border-b border-border bg-muted/30 px-4 py-2 font-mono text-[0.66rem] tracking-[0.01em] text-muted-foreground",
           isSplit && "md:shrink-0",
         )}
       >

--- a/src/routes/v2/pricing.tsx
+++ b/src/routes/v2/pricing.tsx
@@ -62,7 +62,7 @@ function TaskforcePricing({ currentUser }: { currentUser: UserPublic }) {
     <section className="flex min-h-0 flex-1 overflow-y-auto">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 py-8">
         <div className="space-y-3">
-          <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          <p className="text-sm font-medium tracking-[0.01em] text-muted-foreground">
             Taskforce Membership
           </p>
           <h1 className="text-2xl font-semibold tracking-tight md:whitespace-nowrap md:text-3xl">
@@ -90,7 +90,7 @@ function TaskforcePricing({ currentUser }: { currentUser: UserPublic }) {
                 <CardHeader className="gap-3">
                   <div className="flex items-start justify-between gap-3">
                     <div className="space-y-1">
-                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      <p className="text-xs font-medium tracking-[0.01em] text-muted-foreground">
                         {plan.eyebrow}
                       </p>
                       <CardTitle className="text-2xl">{plan.name}</CardTitle>


### PR DESCRIPTION
Extends the sentence-case **"Calmer mono"** treatment (already applied to the Fleet tab and docs site) to the rest of the V2 Taskforce app. Removes the strained ALL-CAPS on mono eyebrows / micro-labels / table headers and tightens the wide letter-spacing (0.12–0.20em) to `0.01em`, keeping the mono font, size, and color.

Fixes the example reported: the **"5 active across team"** tab eyebrow (and every other tab eyebrow) via the shared `V2_TAB_EYEBROW_CLASS`.

### Scope (14 files, surgical in-place swaps — 51/51)
- Shared: `V2_TAB_EYEBROW_CLASS` (drives all tab eyebrows), `ui/table.tsx` `<TableHead>`
- `Metrics`, `Agents` (profile cards + `agentsTypography`), `Library` (recent reel + `library.$documentId`), `Ledger` (page + module css), `Search` BYOK, `ScopeFilterBar`, `TaskforceShell` placeholder, `v2/ledger`, `v2/pricing`

Underlying label text was already proper-cased (e.g. "API key", "Session / Repo / Saved / When"), so it reads cleanly without the CSS `uppercase`.

**Left untouched:** public landing/marketing pages and the deprecated v1 surfaces.

### Verification
- `tsc -p tsconfig.build.json` ✅
- `vite build` ✅
- Kept the diff surgical: `MetricsPage.tsx` has pre-existing biome formatting drift on unrelated lines that I deliberately did **not** sweep into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)