### PR TITLE
TF-245: consume Fleet agent enrichment

### DIFF
--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -42,7 +42,10 @@ export interface TaskforceFleetAgent {
   summary_markdown: string
   last_seen_at: string
   minutes_ago: number
+  status: "running" | "waiting" | "paused" | "idle"
+  started_at: string | null
   specialist_slug: string | null
+  specialist_rule_count: number | null
   model_id: string | null
 }
 

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -5,15 +5,10 @@ import type {
 
 /**
  * Calm-roster status model from the Claude Design "Fleet Mission Control"
- * handoff. The design surfaces four states; today the backend only lets us
- * distinguish `run` vs `idle` from `minutes_ago`, so `waiting`/`paused` are
- * typed-but-degraded until TF-245 (backend enrichment) lands an explicit
- * status/capture field on the agent payload.
+ * handoff. The API spells the active state `running`; this presentation model
+ * keeps the shorter `run` key used by the CSS module.
  */
 export type FleetStatus = "run" | "waiting" | "paused" | "idle"
-
-/** Minutes within which an agent counts as actively running. */
-const RUNNING_WINDOW_MINUTES = 5
 
 /** Quiet word shown next to a non-running status dot. */
 export const STATE_LABEL: Record<FleetStatus, string> = {
@@ -23,61 +18,56 @@ export const STATE_LABEL: Record<FleetStatus, string> = {
   idle: "idle",
 }
 
-// Optional richer fields the backend does not expose yet (TF-245). Read
-// defensively so the UI lights up automatically once the contract grows.
-type EnrichedAgent = TaskforceFleetAgent & {
-  status?: FleetStatus
+// Ingestion does not capture these fields yet. Keep the accessors defensive so
+// the detail route can adopt them without fabricating data in the API.
+type FutureAgentFields = TaskforceFleetAgent & {
   question?: string | null
   capture?: "on" | "paused"
   pause_reason?: string | null
   host?: string | null
-  started_at?: string | null
   files?: { name: string; state: "new" | "modified" }[]
   specialist_name?: string | null
-  specialist_rule_count?: number | null
 }
 
 export function agentStatus(agent: TaskforceFleetAgent): FleetStatus {
-  const explicit = (agent as EnrichedAgent).status
-  if (explicit) return explicit
-  return agent.minutes_ago < RUNNING_WINDOW_MINUTES ? "run" : "idle"
+  return agent.status === "running" ? "run" : agent.status
 }
 
 export function isRunning(agent: TaskforceFleetAgent): boolean {
   return agentStatus(agent) === "run"
 }
 
-/** Backend-enrichment accessors — return undefined/null while degraded. */
+/** Future enrichment accessors return empty values while ingestion is absent. */
 export function agentQuestion(agent: TaskforceFleetAgent): string | null {
-  return (agent as EnrichedAgent).question ?? null
+  return (agent as FutureAgentFields).question ?? null
 }
 
 export function agentCapturePaused(agent: TaskforceFleetAgent): boolean {
-  return (agent as EnrichedAgent).capture === "paused"
+  return (agent as FutureAgentFields).capture === "paused"
 }
 
 export function agentPauseReason(agent: TaskforceFleetAgent): string | null {
-  return (agent as EnrichedAgent).pause_reason ?? null
+  return (agent as FutureAgentFields).pause_reason ?? null
 }
 
 export function agentStartedAt(agent: TaskforceFleetAgent): string | null {
-  return (agent as EnrichedAgent).started_at ?? null
+  return agent.started_at
 }
 
 export function agentFiles(
   agent: TaskforceFleetAgent,
 ): { name: string; state: "new" | "modified" }[] {
-  return (agent as EnrichedAgent).files ?? []
+  return (agent as FutureAgentFields).files ?? []
 }
 
 export function agentSpecialistName(agent: TaskforceFleetAgent): string | null {
-  return (agent as EnrichedAgent).specialist_name ?? null
+  return (agent as FutureAgentFields).specialist_name ?? null
 }
 
 export function agentSpecialistRuleCount(
   agent: TaskforceFleetAgent,
 ): number | null {
-  return (agent as EnrichedAgent).specialist_rule_count ?? null
+  return agent.specialist_rule_count
 }
 
 // Turn a raw harness model id into a human label, e.g.
@@ -96,9 +86,9 @@ export function repoLabel(agent: TaskforceFleetAgent): string {
   return agent.repo || cwdParts[cwdParts.length - 1] || "Unknown repo"
 }
 
-/** Machine label, e.g. "mbp-16". Degrades to null until TF-245. */
+/** Machine label, e.g. "mbp-16". Not captured by ingestion yet. */
 export function hostLabel(agent: TaskforceFleetAgent): string | null {
-  return (agent as EnrichedAgent).host ?? null
+  return (agent as FutureAgentFields).host ?? null
 }
 
 // Heading shown for an agent. Once Taskforce has captured a document the
@@ -112,7 +102,7 @@ export function agentModelName(agent: TaskforceFleetAgent): string {
   return modelLabel(agent.model_id) || "Connected agent"
 }
 
-/** Mono identity meta — "Opus 4.8 · mbp-16", host omitted while degraded. */
+/** Mono identity meta — "Opus 4.8 · mbp-16", host omitted when unavailable. */
 export function agentMeta(agent: TaskforceFleetAgent): string {
   return [agentModelName(agent), hostLabel(agent)].filter(Boolean).join(" · ")
 }

--- a/src/routes/v2/fleet.tsx
+++ b/src/routes/v2/fleet.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Outlet, useRouterState } from "@tanstack/react-router"
 
 import { FleetPage } from "@/components/V2/Fleet/FleetPage"
 
@@ -14,5 +14,9 @@ export const Route = createFileRoute("/v2/fleet")({
 })
 
 function FleetRoute() {
-  return <FleetPage />
+  const isDetailRoute = useRouterState({
+    select: (state) => state.location.pathname !== "/v2/fleet",
+  })
+
+  return isDetailRoute ? <Outlet /> : <FleetPage />
 }

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -68,8 +68,11 @@ async function mockFleet(page: Page) {
                 summary_markdown:
                   "Wiring automatic tax onto the subscription create path",
                 last_seen_at: "2026-06-12T10:20:00Z",
-                minutes_ago: 1,
+                minutes_ago: 10,
+                status: "running",
+                started_at: "2026-06-12T09:42:00Z",
                 specialist_slug: "billing",
+                specialist_rule_count: 4,
                 model_id: "claude-opus-4-8",
               },
             ],
@@ -116,8 +119,9 @@ test("Fleet renders the calm roster from live API data", async ({ page }) => {
   await page.goto("/v2/fleet")
 
   await expect(page.getByRole("heading", { name: "Fleet" })).toBeVisible()
-  await expect(page.getByText("stripe-checkout")).toBeVisible()
+  await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
   await expect(page.getByText("Opus 4.8")).toBeVisible()
+  await expect(page.getByText("10m")).toBeVisible()
   await expect(
     page.getByText("Wiring automatic tax onto the subscription create path"),
   ).toBeVisible()
@@ -152,10 +156,12 @@ test("clicking an agent row opens the session detail and back returns", async ({
   ).toBeVisible()
   await expect(page.getByText("Working on")).toBeVisible()
   await expect(page.getByText("Activity")).toBeVisible()
-  await expect(page.getByText("Session", { exact: true })).toBeVisible()
+  await expect(page.getByText("Session", { exact: true }).first()).toBeVisible()
+  await expect(page.getByText("4 conventions applied")).toBeVisible()
+  await expect(page.getByText("Started")).toBeVisible()
 
   // Breadcrumb returns to the roster.
   await page.getByRole("link", { name: "Fleet" }).first().click()
   await expect(page).toHaveURL(/\/v2\/fleet$/)
-  await expect(page.getByText("stripe-checkout")).toBeVisible()
+  await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
 })


### PR DESCRIPTION
## Summary
- add backend `status`, `started_at`, and `specialist_rule_count` to the maintained Fleet API contract
- remove the client-side five-minute status heuristic and consume server status directly
- render persisted start time and specialist convention count through existing detail components
- fix the nested Fleet detail route so `/v2/fleet/$sessionId` renders its outlet
- tighten Fleet browser coverage around backend status and enriched detail data

The generated client command was run against the TF-245 backend schema. Its output would replace maintained form-encoding compatibility and add more than 12,000 unrelated stale-schema lines, so that unrelated generated churn is not included; `src/api/v2Taskforce.ts` remains the repository's maintained Fleet contract.

Jira: https://alexlee4190.atlassian.net/browse/TF-245
Backend PR: https://github.com/al-exe/EnderAI/pull/141

## Validation
- `tsc -p tsconfig.build.json --noEmit`
- `biome check` on changed files
- `vite build`
- `playwright test tests/fleet.spec.ts --config=playwright.mocked.config.ts --workers=1` (`2 passed`, with CI-style placeholder Firebase config)