### PR TITLE
TF-246: responsive, theme, and motion polish

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -5,16 +5,20 @@
 
 .page,
 .detail {
-  --fl-surface: var(--card);
+  --fl-surface: color-mix(in srgb, var(--card) 94%, var(--muted));
   --fl-faint: color-mix(
     in srgb,
-    var(--muted-foreground) 70%,
-    var(--background)
+    var(--muted-foreground) 88%,
+    var(--foreground)
   );
-  --fl-hair: color-mix(in srgb, var(--foreground) 8%, var(--background));
+  --fl-hair: color-mix(in srgb, var(--foreground) 12%, var(--background));
   --fl-primary-soft: color-mix(in srgb, var(--primary) 14%, var(--background));
   --fl-primary-line: color-mix(in srgb, var(--primary) 40%, var(--border));
-  --fl-attention: oklch(0.72 0.09 62);
+  --fl-attention: color-mix(
+    in oklab,
+    oklch(0.68 0.12 62) 72%,
+    var(--foreground)
+  );
 }
 
 /* ===== Roster header ===== */
@@ -22,7 +26,7 @@
   margin: 2px 0 0;
   color: var(--fl-faint);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 11.5px;
   letter-spacing: 0.01em;
 }
 
@@ -56,9 +60,12 @@
 }
 
 .fname {
+  overflow: hidden;
+  min-width: 0;
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.01em;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -94,8 +101,8 @@
   gap: 6px;
   color: var(--fl-faint);
   font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: 11px;
+  letter-spacing: 0.01em;
   white-space: nowrap;
 }
 
@@ -297,6 +304,13 @@
 .newagent svg {
   width: 13px;
   height: 13px;
+  flex-shrink: 0;
+}
+
+.newagent span {
+  overflow: hidden;
+  min-width: 0;
+  text-overflow: ellipsis;
 }
 
 .newagent:hover {
@@ -336,6 +350,7 @@
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.02em;
+  min-width: 0;
 }
 
 .back {
@@ -362,6 +377,11 @@
   white-space: nowrap;
 }
 
+.crumb > span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .dhead {
   display: flex;
   align-items: flex-start;
@@ -385,11 +405,14 @@
 }
 
 .dmeta {
+  overflow: hidden;
   margin-top: 7px;
   color: var(--fl-faint);
   font-family: var(--font-mono);
   font-size: 11.5px;
   letter-spacing: 0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dmeta b {
@@ -602,9 +625,11 @@
 }
 
 .mv {
+  overflow: hidden;
   color: var(--muted-foreground);
   text-align: left;
-  word-break: break-word;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .capPaused {
@@ -837,9 +862,15 @@
 
 /* ===== responsive ===== */
 @media (max-width: 880px) {
+  .detail {
+    overflow-y: auto;
+  }
+
   .dbody {
     display: block;
+    flex: none;
     grid-template-columns: 1fr;
+    min-height: auto;
   }
 
   .dmain,
@@ -851,26 +882,61 @@
   .drail {
     border-top: 1px solid var(--fl-hair);
   }
+
+  .dhead {
+    flex-wrap: wrap;
+  }
+
+  .dactions {
+    width: 100%;
+    margin-left: 21px;
+    flex-wrap: wrap;
+  }
 }
 
 @media (max-width: 760px) {
-  .arow {
-    grid-template-columns: 14px 1fr;
-    gap: 12px;
+  .fhead {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 7px 10px;
   }
 
-  .arow .work,
-  .arow .age {
-    grid-column: 2;
+  .frepo {
+    grid-row: 2;
+    grid-column: 1 / -1;
+  }
+
+  .fcount,
+  .fmenu {
+    margin-left: 0;
+  }
+
+  .arow {
+    grid-template-columns: 14px minmax(0, 1fr) auto;
+    gap: 12px;
+    align-items: start;
+  }
+
+  .arow .work {
+    grid-row: 2;
+    grid-column: 2 / -1;
     text-align: left;
   }
 
   .arow .age {
-    margin-top: 8px;
+    grid-row: 1;
+    grid-column: 3;
+    margin-top: 0;
   }
 
-  .dhead {
-    flex-wrap: wrap;
+  .dmain,
+  .drail {
+    padding: 24px 0 48px;
+  }
+
+  .dactions {
+    margin-left: 0;
   }
 }
 

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -55,6 +55,7 @@ const STATE_CLASS: Record<FleetStatus, string | undefined> = {
 function StatusDot({ status }: { status: FleetStatus }) {
   return (
     <span
+      data-testid="fleet-status-dot"
       className={cn(
         styles.sdot,
         styles[status],
@@ -77,7 +78,12 @@ function AgentRow({
   const docTitle = agent.active_document_id ? agent.title : null
 
   return (
-    <button type="button" className={styles.arow} onClick={() => onOpen(agent)}>
+    <button
+      type="button"
+      data-testid="fleet-agent-row"
+      className={styles.arow}
+      onClick={() => onOpen(agent)}
+    >
       <StatusDot status={status} />
       <div className={styles.who}>
         <div className={styles.nm}>{agentDisplayName(agent)}</div>
@@ -232,7 +238,7 @@ function FleetCard({
         className={styles.newagent}
       >
         <Plus />
-        New agent in {fleetTitle(fleet)}
+        <span>New agent in {fleetTitle(fleet)}</span>
       </Link>
     </section>
   )

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -67,7 +67,9 @@ function metaRow(key: string, value: string, valueClass?: string) {
   return (
     <div className={styles.metarow} key={key}>
       <span className={styles.mk}>{key}</span>
-      <span className={cn(styles.mv, valueClass)}>{value}</span>
+      <span className={cn(styles.mv, valueClass)} title={value}>
+        {value}
+      </span>
     </div>
   )
 }
@@ -139,7 +141,9 @@ function FleetAgentDetailRoute() {
     }
   })
 
-  const dmetaBits = [model, host, agent.branch].filter(Boolean)
+  const dmetaBits = [model, host, agent.branch].filter((bit): bit is string =>
+    Boolean(bit),
+  )
 
   // Activity timeline — newest-first. The live "now" step sits on top, with
   // each captured document descending below it (from the session log).
@@ -152,7 +156,7 @@ function FleetAgentDetailRoute() {
     }))
 
   return (
-    <div className={styles.detail}>
+    <div className={styles.detail} data-testid="fleet-agent-detail">
       <div className={styles.dtop}>
         <div className={styles.crumb}>
           <Link to="/v2/fleet" className={styles.back}>
@@ -165,6 +169,7 @@ function FleetAgentDetailRoute() {
 
         <div className={styles.dhead}>
           <span
+            data-testid="fleet-status-dot"
             className={cn(
               styles.sdot,
               styles[status],
@@ -175,9 +180,12 @@ function FleetAgentDetailRoute() {
             <h1>{agentDisplayName(agent)}</h1>
             {dmetaBits.length > 0 && (
               <div className={styles.dmeta}>
-                <b>{dmetaBits[0]}</b>
+                <b title={dmetaBits[0]}>{dmetaBits[0]}</b>
                 {dmetaBits.slice(1).map((bit) => (
-                  <span key={bit}> · {bit}</span>
+                  <span key={bit} title={bit}>
+                    {" "}
+                    · {bit}
+                  </span>
                 ))}
               </div>
             )}
@@ -213,7 +221,7 @@ function FleetAgentDetailRoute() {
         </div>
       </div>
 
-      <div className={styles.dbody}>
+      <div className={styles.dbody} data-testid="fleet-detail-body">
         <div className={styles.dmain}>
           {/* Working on — a waiting agent surfaces its question + reply box. */}
           {status === "waiting" && question ? (
@@ -289,7 +297,7 @@ function FleetAgentDetailRoute() {
           </div>
         </div>
 
-        <div className={styles.drail}>
+        <div className={styles.drail} data-testid="fleet-detail-rail">
           {/* Pause note — surfaces above everything when capture is paused. */}
           {capturePaused && pauseReason && (
             <div className={styles.block}>

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -165,3 +165,99 @@ test("clicking an agent row opens the session detail and back returns", async ({
   await expect(page).toHaveURL(/\/v2\/fleet$/)
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
 })
+
+for (const theme of ["light", "dark"] as const) {
+  test(`Fleet stays responsive in ${theme} theme`, async ({ page }) => {
+    await mockFleet(page)
+    await page.addInitScript((selectedTheme) => {
+      window.localStorage.setItem("vite-ui-theme", selectedTheme)
+    }, theme)
+
+    for (const width of [360, 768, 1280]) {
+      await page.setViewportSize({ width, height: 900 })
+      await page.goto("/v2/fleet")
+      await expect(page.getByRole("heading", { name: "Fleet" })).toBeVisible()
+      await expect(page.locator("html")).toHaveClass(new RegExp(theme))
+
+      const rosterOverflow = await page.evaluate(
+        () =>
+          document.documentElement.scrollWidth -
+          document.documentElement.clientWidth,
+      )
+      expect(rosterOverflow).toBeLessThanOrEqual(0)
+
+      const shellTrigger = page.locator('[data-slot="sidebar-trigger"]')
+      if (width === 360) {
+        await expect(shellTrigger).toBeVisible()
+        await expect(
+          page.getByRole("link", { name: "Profiles" }),
+        ).not.toBeVisible()
+      } else {
+        await expect(shellTrigger).not.toBeVisible()
+        await expect(page.getByRole("link", { name: "Profiles" })).toBeVisible()
+      }
+
+      const rosterColumns = await page
+        .getByTestId("fleet-agent-row")
+        .evaluate((row) => getComputedStyle(row).gridTemplateColumns)
+      expect(rosterColumns.trim().split(/\s+/)).toHaveLength(
+        width === 360 ? 3 : 4,
+      )
+
+      await page.goto("/v2/fleet/session-1")
+      await expect(
+        page.getByRole("heading", { name: "Stripe checkout wiring" }),
+      ).toBeVisible()
+
+      const detailLayout = await page.evaluate(() => {
+        const detail = document.querySelector<HTMLElement>(
+          '[data-testid="fleet-agent-detail"]',
+        )
+        const body = document.querySelector<HTMLElement>(
+          '[data-testid="fleet-detail-body"]',
+        )
+        const rail = document.querySelector<HTMLElement>(
+          '[data-testid="fleet-detail-rail"]',
+        )
+        if (!detail || !body || !rail) throw new Error("Fleet detail missing")
+
+        return {
+          overflow:
+            document.documentElement.scrollWidth -
+            document.documentElement.clientWidth,
+          detailOverflowY: getComputedStyle(detail).overflowY,
+          bodyDisplay: getComputedStyle(body).display,
+          railBorderTop: getComputedStyle(rail).borderTopWidth,
+          railBorderLeft: getComputedStyle(rail).borderLeftWidth,
+        }
+      })
+
+      expect(detailLayout.overflow).toBeLessThanOrEqual(0)
+      if (width <= 880) {
+        expect(detailLayout.detailOverflowY).toBe("auto")
+        expect(detailLayout.bodyDisplay).toBe("block")
+        expect(detailLayout.railBorderTop).toBe("1px")
+        expect(detailLayout.railBorderLeft).toBe("0px")
+        await page.getByText("Files", { exact: true }).scrollIntoViewIfNeeded()
+        await expect(page.getByText("Files", { exact: true })).toBeVisible()
+      } else {
+        expect(detailLayout.bodyDisplay).toBe("grid")
+        expect(detailLayout.railBorderTop).toBe("0px")
+        expect(detailLayout.railBorderLeft).toBe("1px")
+      }
+
+      await expect(page.getByText(/\b(?:tokens?|spend|roi)\b/i)).toHaveCount(0)
+    }
+  })
+}
+
+test("Fleet running pulse respects reduced motion", async ({ page }) => {
+  await mockFleet(page)
+  await page.emulateMedia({ reducedMotion: "reduce" })
+  await page.goto("/v2/fleet")
+
+  const animationName = await page
+    .getByTestId("fleet-status-dot")
+    .evaluate((dot) => getComputedStyle(dot).animationName)
+  expect(animationName).toBe("none")
+})


### PR DESCRIPTION
## Summary
- stack Fleet detail content and rail at tablet widths, with a scrollable one-column detail view
- collapse roster rows into the mobile two-line layout and preserve shell navigation behavior
- improve light-theme contrast, sentence-case mono labels, path clipping, and reduced-motion handling
- add responsive browser coverage at 360, 768, and 1280 px in both themes

## Validation
- `bun run build`
- `biome check` on changed files
- mocked Playwright suite: 58 passed
- visual review at 360 / 768 / 1280 px in light and dark themes
- `git diff --check`

Jira: https://alexlee4190.atlassian.net/browse/TF-246

Closes TF-246