### PR TITLE
[codex] Add Fleet agent drag and drop

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -45,6 +45,20 @@
 .fleet {
   border: 1px solid var(--border);
   background: var(--fl-surface);
+  transition:
+    border-color 120ms ease,
+    background-color 120ms ease,
+    opacity 120ms ease;
+}
+
+.fleetDropTarget {
+  border-color: var(--primary);
+  background: var(--fl-primary-soft);
+  box-shadow: inset 0 0 0 1px var(--fl-primary-line);
+}
+
+.fleetDropPending {
+  opacity: 0.72;
 }
 
 .unassigned {
@@ -122,7 +136,7 @@
 /* rows */
 .arow {
   display: grid;
-  grid-template-columns: 14px minmax(180px, 250px) minmax(0, 1fr) 64px;
+  grid-template-columns: 26px minmax(180px, 250px) minmax(0, 1fr) 64px;
   gap: 18px;
   align-items: baseline;
   width: 100%;
@@ -130,6 +144,14 @@
   border-bottom: 1px solid var(--fl-hair);
   text-align: left;
   cursor: pointer;
+}
+
+.arowDragging {
+  opacity: 0.45;
+}
+
+.arowMoving {
+  cursor: progress;
 }
 
 .arow:last-of-type {
@@ -143,6 +165,28 @@
 .arow:focus-visible {
   outline: 2px solid var(--ring);
   outline-offset: -2px;
+}
+
+.dragCell {
+  display: flex;
+  align-items: flex-start;
+  gap: 3px;
+  width: 26px;
+}
+
+.dragGrip {
+  width: 12px;
+  height: 18px;
+  flex-shrink: 0;
+  color: var(--fl-faint);
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.arow:hover .dragGrip,
+.arow:focus-visible .dragGrip,
+.arowDragging .dragGrip {
+  opacity: 1;
 }
 
 /* status dot */
@@ -913,7 +957,7 @@
   }
 
   .arow {
-    grid-template-columns: 14px minmax(0, 1fr) auto;
+    grid-template-columns: 26px minmax(0, 1fr) auto;
     gap: 12px;
     align-items: start;
   }
@@ -941,6 +985,11 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .fleet,
+  .dragGrip {
+    transition: none;
+  }
+
   .pulse {
     animation: none;
   }

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -1,12 +1,20 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
-import { MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react"
-import { type FormEvent, useState } from "react"
 import {
+  GripVertical,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Trash2,
+} from "lucide-react"
+import { type DragEvent, type FormEvent, useRef, useState } from "react"
+import {
+  assignTaskforceFleetSession,
   createTaskforceFleetSession,
   deleteTaskforceFleetSession,
   readTaskforceFleet,
   type TaskforceFleetAgent,
+  type TaskforceFleetResponse,
   type TaskforceFleetSession,
   updateTaskforceFleetSession,
 } from "@/api/v2Taskforce"
@@ -68,10 +76,22 @@ function StatusDot({ status }: { status: FleetStatus }) {
 function AgentRow({
   agent,
   onOpen,
+  onDragStart,
+  onDragEnd,
+  isDragging,
+  isMoving,
 }: {
   agent: TaskforceFleetAgent
   onOpen: (agent: TaskforceFleetAgent) => void
+  onDragStart: (
+    agent: TaskforceFleetAgent,
+    event: DragEvent<HTMLButtonElement>,
+  ) => void
+  onDragEnd: () => void
+  isDragging: boolean
+  isMoving: boolean
 }) {
+  const suppressClick = useRef(false)
   const status = agentStatus(agent)
   const age = compactPresence(agent)
   const showAgeInState = status === "waiting" || status === "idle"
@@ -81,10 +101,34 @@ function AgentRow({
     <button
       type="button"
       data-testid="fleet-agent-row"
-      className={styles.arow}
-      onClick={() => onOpen(agent)}
+      className={cn(
+        styles.arow,
+        isDragging && styles.arowDragging,
+        isMoving && styles.arowMoving,
+      )}
+      draggable={!isMoving}
+      title="Drag to move this agent to another fleet"
+      onClick={() => {
+        if (suppressClick.current) return
+        onOpen(agent)
+      }}
+      onDragStart={(event) => {
+        suppressClick.current = true
+        event.dataTransfer.effectAllowed = "move"
+        event.dataTransfer.setData("text/plain", agent.session_id)
+        onDragStart(agent, event)
+      }}
+      onDragEnd={() => {
+        onDragEnd()
+        window.setTimeout(() => {
+          suppressClick.current = false
+        }, 0)
+      }}
     >
-      <StatusDot status={status} />
+      <span className={styles.dragCell} aria-hidden="true">
+        <GripVertical className={styles.dragGrip} />
+        <StatusDot status={status} />
+      </span>
       <div className={styles.who}>
         <div className={styles.nm}>{agentDisplayName(agent)}</div>
         <div className={styles.meta}>{agentMeta(agent)}</div>
@@ -115,11 +159,31 @@ function FleetCard({
   onOpenAgent,
   onRename,
   onDelete,
+  draggingAgent,
+  dropTargetId,
+  movingSessionId,
+  onAgentDragStart,
+  onAgentDragEnd,
+  onDragOver,
+  onDropAgent,
 }: {
   fleet: TaskforceFleetSession
   onOpenAgent: (agent: TaskforceFleetAgent) => void
   onRename: (fleet: TaskforceFleetSession, name: string) => void
   onDelete: (fleet: TaskforceFleetSession) => void
+  draggingAgent: TaskforceFleetAgent | null
+  dropTargetId: string | null
+  movingSessionId: string | null
+  onAgentDragStart: (
+    agent: TaskforceFleetAgent,
+    event: DragEvent<HTMLButtonElement>,
+  ) => void
+  onAgentDragEnd: () => void
+  onDragOver: (fleetSessionId: string) => void
+  onDropAgent: (
+    agent: TaskforceFleetAgent,
+    destination: TaskforceFleetSession,
+  ) => void
 }) {
   const [renaming, setRenaming] = useState(false)
   const [name, setName] = useState(fleet.name)
@@ -127,6 +191,12 @@ function FleetCard({
   const repo = fleetRepo(fleet)
   const running = runningCount(fleet.agents)
   const total = fleet.agents.length
+  const isDropCandidate =
+    draggingAgent !== null && draggingAgent.fleet_session_id !== fleet.id
+  const isDropTarget = isDropCandidate && dropTargetId === fleet.id
+  const hasPendingMove =
+    movingSessionId !== null &&
+    fleet.agents.some((agent) => agent.session_id === movingSessionId)
 
   const submitRename = (event: FormEvent) => {
     event.preventDefault()
@@ -141,7 +211,26 @@ function FleetCard({
   }
 
   return (
-    <section className={styles.fleet}>
+    <section
+      aria-label={`${fleetTitle(fleet)} fleet`}
+      data-testid={`fleet-card-${fleet.id}`}
+      className={cn(
+        styles.fleet,
+        isDropTarget && styles.fleetDropTarget,
+        hasPendingMove && styles.fleetDropPending,
+      )}
+      onDragOver={(event) => {
+        if (!isDropCandidate) return
+        event.preventDefault()
+        event.dataTransfer.dropEffect = "move"
+        onDragOver(fleet.id)
+      }}
+      onDrop={(event) => {
+        if (!draggingAgent || !isDropCandidate) return
+        event.preventDefault()
+        onDropAgent(draggingAgent, fleet)
+      }}
+    >
       <div className={styles.fhead}>
         {renaming ? (
           <form onSubmit={submitRename} className="flex-1">
@@ -227,6 +316,10 @@ function FleetCard({
               key={agent.session_id}
               agent={agent}
               onOpen={onOpenAgent}
+              onDragStart={onAgentDragStart}
+              onDragEnd={onAgentDragEnd}
+              isDragging={draggingAgent?.session_id === agent.session_id}
+              isMoving={movingSessionId === agent.session_id}
             />
           ))
         )}
@@ -248,6 +341,9 @@ export function FleetPage() {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const [mutationError, setMutationError] = useState<unknown>(null)
+  const [draggingAgent, setDraggingAgent] =
+    useState<TaskforceFleetAgent | null>(null)
+  const [dropTargetId, setDropTargetId] = useState<string | null>(null)
 
   const fleetQuery = useQuery({
     queryKey: FLEET_QUERY_KEY,
@@ -282,6 +378,58 @@ export function FleetPage() {
     onSuccess: refreshFleet,
     onError: setMutationError,
   })
+  const moveMutation = useMutation({
+    mutationFn: ({
+      sessionId,
+      destinationId,
+    }: {
+      sessionId: string
+      destinationId: string
+    }) => assignTaskforceFleetSession(sessionId, destinationId),
+    onMutate: async ({ sessionId, destinationId }) => {
+      setMutationError(null)
+      await queryClient.cancelQueries({ queryKey: FLEET_QUERY_KEY })
+      const previous =
+        queryClient.getQueryData<TaskforceFleetResponse>(FLEET_QUERY_KEY)
+
+      queryClient.setQueryData<TaskforceFleetResponse>(
+        FLEET_QUERY_KEY,
+        (current) => {
+          if (!current) return current
+          const movingAgent = current.fleet_sessions
+            .flatMap((fleet) => fleet.agents)
+            .find((agent) => agent.session_id === sessionId)
+          if (!movingAgent) return current
+
+          return {
+            ...current,
+            fleet_sessions: current.fleet_sessions.map((fleet) => ({
+              ...fleet,
+              agents:
+                fleet.id === destinationId
+                  ? [
+                      ...fleet.agents.filter(
+                        (agent) => agent.session_id !== sessionId,
+                      ),
+                      { ...movingAgent, fleet_session_id: destinationId },
+                    ]
+                  : fleet.agents.filter(
+                      (agent) => agent.session_id !== sessionId,
+                    ),
+            })),
+          }
+        },
+      )
+      return { previous }
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(FLEET_QUERY_KEY, context.previous)
+      }
+      setMutationError(error)
+    },
+    onSettled: refreshFleet,
+  })
 
   const fleetSessions = fleetQuery.data?.fleet_sessions ?? []
   const allAgents = fleetSessions.flatMap((fleet) => fleet.agents)
@@ -308,6 +456,23 @@ export function FleetPage() {
       setMutationError(null)
       deleteMutation.mutate(fleet.id)
     }
+  }
+  const endAgentDrag = () => {
+    setDraggingAgent(null)
+    setDropTargetId(null)
+  }
+  const moveAgent = (
+    agent: TaskforceFleetAgent,
+    destination: TaskforceFleetSession,
+  ) => {
+    endAgentDrag()
+    if (agent.fleet_session_id === destination.id || moveMutation.isPending) {
+      return
+    }
+    moveMutation.mutate({
+      sessionId: agent.session_id,
+      destinationId: destination.id,
+    })
   }
 
   return (
@@ -411,6 +576,21 @@ export function FleetPage() {
                   onOpenAgent={openAgent}
                   onRename={renameFleet}
                   onDelete={deleteFleet}
+                  draggingAgent={draggingAgent}
+                  dropTargetId={dropTargetId}
+                  movingSessionId={
+                    moveMutation.isPending
+                      ? moveMutation.variables.sessionId
+                      : null
+                  }
+                  onAgentDragStart={(agent) => {
+                    setMutationError(null)
+                    setDraggingAgent(agent)
+                    setDropTargetId(null)
+                  }}
+                  onAgentDragEnd={endAgentDrag}
+                  onDragOver={setDropTargetId}
+                  onDropAgent={moveAgent}
                 />
               ))}
             </div>

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -18,7 +18,30 @@ test.use({
   },
 })
 
-async function mockFleet(page: Page) {
+async function mockFleet(
+  page: Page,
+  options: { includeDestination?: boolean } = {},
+) {
+  let agentFleetId = "fleet-1"
+  const agent = {
+    session_id: "session-1",
+    fleet_session_id: agentFleetId,
+    cwd: "/workspace/billing",
+    branch: "feature/automatic-tax",
+    repo: "billing",
+    active_document_id: "doc-1",
+    referenced_document_ids: ["doc-2"],
+    title: "Stripe checkout wiring",
+    summary_markdown: "Wiring automatic tax onto the subscription create path",
+    last_seen_at: "2026-06-12T10:20:00Z",
+    minutes_ago: 10,
+    status: "running",
+    started_at: "2026-06-12T09:42:00Z",
+    specialist_slug: "billing",
+    specialist_rule_count: 4,
+    model_id: "claude-opus-4-8",
+  }
+
   await page.addInitScript(() => {
     window.localStorage.setItem("access_token", "test-token")
   })
@@ -55,32 +78,42 @@ async function mockFleet(page: Page) {
             name: "stripe-checkout",
             created_at: "2026-06-12T10:00:00Z",
             updated_at: "2026-06-12T10:20:00Z",
-            agents: [
-              {
-                session_id: "session-1",
-                fleet_session_id: "fleet-1",
-                cwd: "/workspace/billing",
-                branch: "feature/automatic-tax",
-                repo: "billing",
-                active_document_id: "doc-1",
-                referenced_document_ids: ["doc-2"],
-                title: "Stripe checkout wiring",
-                summary_markdown:
-                  "Wiring automatic tax onto the subscription create path",
-                last_seen_at: "2026-06-12T10:20:00Z",
-                minutes_ago: 10,
-                status: "running",
-                started_at: "2026-06-12T09:42:00Z",
-                specialist_slug: "billing",
-                specialist_rule_count: 4,
-                model_id: "claude-opus-4-8",
-              },
-            ],
+            agents:
+              agentFleetId === "fleet-1"
+                ? [{ ...agent, fleet_session_id: agentFleetId }]
+                : [],
           },
+          ...(options.includeDestination
+            ? [
+                {
+                  id: "fleet-2",
+                  name: "checkout-review",
+                  created_at: "2026-06-12T10:30:00Z",
+                  updated_at: "2026-06-12T10:30:00Z",
+                  agents:
+                    agentFleetId === "fleet-2"
+                      ? [{ ...agent, fleet_session_id: agentFleetId }]
+                      : [],
+                },
+              ]
+            : []),
         ],
       },
     })
   })
+
+  await page.route(
+    "**/api/v1/v2/taskforce/session/session-1",
+    async (route) => {
+      const body = route.request().postDataJSON() as {
+        fleet_session_id: string
+      }
+      agentFleetId = body.fleet_session_id
+      await route.fulfill({
+        json: { ...agent, fleet_session_id: agentFleetId },
+      })
+    },
+  )
 
   await page.route("**/api/v1/v2/taskforce/session-log**", async (route) => {
     await route.fulfill({
@@ -164,6 +197,30 @@ test("clicking an agent row opens the session detail and back returns", async ({
   await page.getByRole("link", { name: "Fleet" }).first().click()
   await expect(page).toHaveURL(/\/v2\/fleet$/)
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
+})
+
+test("dragging an agent moves it to another fleet", async ({ page }) => {
+  await mockFleet(page, { includeDestination: true })
+  await page.goto("/v2/fleet")
+
+  const moveRequest = page.waitForRequest(
+    (request) =>
+      request.url().endsWith("/api/v1/v2/taskforce/session/session-1") &&
+      request.method() === "PATCH",
+  )
+  await page
+    .getByTestId("fleet-agent-row")
+    .dragTo(page.getByTestId("fleet-card-fleet-2"))
+
+  expect((await moveRequest).postDataJSON()).toEqual({
+    fleet_session_id: "fleet-2",
+  })
+  await expect(
+    page.getByTestId("fleet-card-fleet-1").getByTestId("fleet-agent-row"),
+  ).toHaveCount(0)
+  await expect(
+    page.getByTestId("fleet-card-fleet-2").getByTestId("fleet-agent-row"),
+  ).toContainText("Stripe checkout wiring")
 })
 
 for (const theme of ["light", "dark"] as const) {


### PR DESCRIPTION
## Summary
- make active Fleet agent rows draggable between fleet sessions
- highlight valid destination cards and optimistically move the agent while the assignment request is pending
- roll the roster back and surface the existing mutation error state if reassignment fails
- add Playwright coverage for the drag gesture, PATCH payload, and destination roster update

## Backend behavior
The frontend uses the existing `PATCH /api/v1/v2/taskforce/session/{session_id}` assignment endpoint. Backend `main` already scopes discovery to the archive's current `fleet_session_id`, preserving global documents, excluding the old fleet's scoped documents, and including the destination fleet's scoped documents after reassignment. Previously authored documents remain with their original fleet.

## Validation
- `bunx biome check --write --unsafe src/components/V2/Fleet/FleetPage.tsx src/components/V2/Fleet/FleetPage.module.css tests/fleet.spec.ts`
- `npm run build`
- `VITE_FIREBASE_API_KEY=test-api-key ... npx playwright test tests/fleet.spec.ts --config=playwright.mocked.config.ts --workers=1` (6 passed)

Backend Fleet tests were inspected but could not run locally because the configured PostgreSQL test service at `127.0.0.1:55435` was not running. No backend files changed.