### PR TITLE
TF-247: Fleet activity timeline — per-turn entries + Ledger links (frontend)

### DIFF
--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -30,6 +30,19 @@ export interface TaskforceSessionLogResponse {
   entries: TaskforceSessionLogEntry[]
 }
 
+export interface TaskforceSessionActivityEntry {
+  id: string
+  occurred_at: string
+  prompt: string
+  response_summary: string | null
+  ledger_href: string | null
+}
+
+export interface TaskforceSessionActivityResponse {
+  session_id: string
+  entries: TaskforceSessionActivityEntry[]
+}
+
 export interface TaskforceFleetAgent {
   session_id: string
   fleet_session_id: string
@@ -90,6 +103,24 @@ export function readTaskforceSessionLog(
   return request(OpenAPI, {
     method: "GET",
     url: "/api/v1/v2/taskforce/session-log",
+    query: {
+      session_id: args.sessionId,
+      limit: args.limit ?? 50,
+    },
+  })
+}
+
+export interface ReadTaskforceSessionActivityArgs {
+  sessionId: string
+  limit?: number
+}
+
+export function readTaskforceSessionActivity(
+  args: ReadTaskforceSessionActivityArgs,
+): CancelablePromise<TaskforceSessionActivityResponse> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/taskforce/session-activity",
     query: {
       session_id: args.sessionId,
       limit: args.limit ?? 50,

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -638,6 +638,23 @@
   color: var(--foreground);
 }
 
+.tsub {
+  margin-top: 4px;
+  color: var(--fl-faint);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.tevLink {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.tevLink:hover .tx {
+  color: var(--primary);
+}
+
 /* rail blocks */
 .block {
   margin-bottom: 26px;

--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -435,6 +435,12 @@
   grid-template-columns: 74px 1fr;
   gap: 0;
 }
+/* Highlighted target of a Fleet activity deep-link (?at=…). */
+.evHighlight .evC {
+  background: var(--tf-primary-soft, color-mix(in srgb, var(--tf-primary) 10%, transparent));
+  border-left-color: var(--tf-primary);
+  box-shadow: -2px 0 0 0 var(--tf-primary);
+}
 .evT {
   font-family: var(--font-mono);
   font-size: 12px;

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -5,9 +5,11 @@ import {
   type CSSProperties,
   type FormEvent,
   type ReactNode,
+  type RefObject,
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react"
 
@@ -58,6 +60,7 @@ type LedgerSearchFilters = {
   session_id?: string
   specialist?: string
   sort?: LedgerSort
+  at?: string
 }
 
 type DayGroup = {
@@ -379,6 +382,7 @@ export function LedgerPage({
         {selectedSessionId ? (
           <div className={styles.app}>
             <LedgerDetail
+              anchorAt={searchFilters.at}
               detail={detailQuery.data}
               demo={isDemoMode}
               isError={detailQuery.isError}
@@ -582,19 +586,62 @@ function LedgerRow({
   )
 }
 
+/**
+ * Index of the transcript line whose timestamp is closest to `at`, or -1.
+ *
+ * Best-effort anchor for a Fleet activity deep-link: transcript lines have no
+ * stable id, and the activity timestamp (recorded at /discover) and the
+ * transcript timestamp (recorded at /observe) come from different writes, so
+ * this lands the reader near — not exactly on — the backing turn (TF-247).
+ */
+function closestEventIndex(
+  events: LedgerTranscriptEvent[],
+  at: string | undefined,
+): number {
+  if (!at || events.length === 0) return -1
+  const target = new Date(at).getTime()
+  if (Number.isNaN(target)) return -1
+  let best = -1
+  let bestDelta = Number.POSITIVE_INFINITY
+  events.forEach((event, index) => {
+    if (!event.occurred_at) return
+    const stamp = new Date(event.occurred_at).getTime()
+    if (Number.isNaN(stamp)) return
+    const delta = Math.abs(stamp - target)
+    if (delta < bestDelta) {
+      bestDelta = delta
+      best = index
+    }
+  })
+  return best
+}
+
 function LedgerDetail({
+  anchorAt,
   detail,
   demo,
   isError,
   isLoading,
   onBack,
 }: {
+  anchorAt?: string
   detail?: LedgerSessionDetail
   demo: boolean
   isError: boolean
   isLoading: boolean
   onBack: () => void
 }) {
+  const anchorIndex = useMemo(
+    () => closestEventIndex(detail?.transcript_events ?? [], anchorAt),
+    [detail?.transcript_events, anchorAt],
+  )
+  const anchorRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    if (anchorIndex >= 0) {
+      anchorRef.current?.scrollIntoView({ block: "center" })
+    }
+  }, [anchorIndex])
+
   if (isLoading) {
     return (
       <div className={styles.detail}>
@@ -648,8 +695,10 @@ function LedgerDetail({
           {detail.transcript_events.length > 0 ? (
             detail.transcript_events.map((event, index) => (
               <TranscriptEvent
+                anchorRef={index === anchorIndex ? anchorRef : undefined}
                 detail={detail}
                 event={event}
+                highlighted={index === anchorIndex}
                 key={`${event.kind}-${event.occurred_at ?? index}-${index}`}
               />
             ))
@@ -666,17 +715,22 @@ function LedgerDetail({
 }
 
 function TranscriptEvent({
+  anchorRef,
   detail,
   event,
+  highlighted,
 }: {
+  anchorRef?: RefObject<HTMLDivElement | null>
   detail: LedgerSessionDetail
   event: LedgerTranscriptEvent
+  highlighted?: boolean
 }) {
   const time = formatTimeOfDay(event.occurred_at)
+  const anchorProps = { highlighted, rootRef: anchorRef }
 
   if (event.kind === "prompt") {
     return (
-      <EventShell modifier={styles.evPrompt} time={time}>
+      <EventShell modifier={styles.evPrompt} time={time} {...anchorProps}>
         <div className={styles.lab}>
           <b>{eventWho(event, detail)} asked</b>
         </div>
@@ -687,7 +741,7 @@ function TranscriptEvent({
 
   if (event.kind === "reply") {
     return (
-      <EventShell modifier={styles.evReply} time={time}>
+      <EventShell modifier={styles.evReply} time={time} {...anchorProps}>
         <div className={styles.lab}>
           <b>{agentLabel(detail)}</b> replied
         </div>
@@ -700,7 +754,7 @@ function TranscriptEvent({
     const failed = event.exit_code !== null && event.exit_code !== 0
     const repo = event.repo ?? detail.repo
     return (
-      <EventShell time={time}>
+      <EventShell time={time} {...anchorProps}>
         <div className={styles.lab}>ran command</div>
         <div className={styles.cmd}>
           <div className={styles.cmdLine}>
@@ -726,7 +780,7 @@ function TranscriptEvent({
 
   if (event.kind === "edit") {
     return (
-      <EventShell time={time}>
+      <EventShell time={time} {...anchorProps}>
         <div className={styles.lab}>edited file</div>
         <div className={styles.edit}>
           <span className={styles.editFile}>{event.file}</span>
@@ -743,7 +797,7 @@ function TranscriptEvent({
   }
 
   return (
-    <EventShell modifier={styles.evNote} time={time}>
+    <EventShell modifier={styles.evNote} time={time} {...anchorProps}>
       <div className={styles.noteTxt}>● {event.note ?? event.text}</div>
     </EventShell>
   )
@@ -751,15 +805,22 @@ function TranscriptEvent({
 
 function EventShell({
   children,
+  highlighted,
   modifier,
+  rootRef,
   time,
 }: {
   children: ReactNode
+  highlighted?: boolean
   modifier?: string
+  rootRef?: RefObject<HTMLDivElement | null>
   time: string
 }) {
   return (
-    <div className={cn(styles.ev, modifier)}>
+    <div
+      className={cn(styles.ev, modifier, highlighted && styles.evHighlight)}
+      ref={rootRef}
+    >
       <div className={styles.evT}>{time}</div>
       <div className={styles.evC}>{children}</div>
     </div>

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -4,7 +4,7 @@ import { BookOpen, ChevronLeft, ScrollText } from "lucide-react"
 import { readV2Document } from "@/api/v2Documents"
 import {
   readTaskforceFleet,
-  readTaskforceSessionLog,
+  readTaskforceSessionActivity,
   type TaskforceFleetAgent,
   type TaskforceFleetResponse,
 } from "@/api/v2Taskforce"
@@ -81,9 +81,10 @@ function FleetAgentDetailRoute() {
     queryFn: readTaskforceFleet,
     refetchInterval: 30_000,
   })
-  const logQuery = useQuery({
-    queryKey: ["v2-taskforce-session-log", { sessionId }],
-    queryFn: () => readTaskforceSessionLog({ sessionId }),
+  const activityQuery = useQuery({
+    queryKey: ["v2-taskforce-session-activity", { sessionId }],
+    queryFn: () => readTaskforceSessionActivity({ sessionId }),
+    refetchInterval: 30_000,
   })
 
   const located = locateAgent(fleetQuery.data, sessionId)
@@ -145,15 +146,12 @@ function FleetAgentDetailRoute() {
     Boolean(bit),
   )
 
-  // Activity timeline — newest-first. The live "now" step sits on top, with
-  // each captured document descending below it (from the session log).
-  const captures = [...(logQuery.data?.entries ?? [])]
-    .sort((a, b) => b.occurred_at.localeCompare(a.occurred_at))
-    .map((entry) => ({
-      key: `${entry.query_id}-${entry.document_id}`,
-      time: formatClockTime(entry.occurred_at),
-      text: `Captured update to ${entry.title}`,
-    }))
+  // Activity timeline — newest-first. The live "now" step sits on top; below it
+  // each captured turn (user prompt + a summary of the agent's response),
+  // deep-linking to the Ledger line that backs it (TF-247).
+  const activityEntries = [...(activityQuery.data?.entries ?? [])].sort(
+    (a, b) => b.occurred_at.localeCompare(a.occurred_at),
+  )
 
   return (
     <div className={styles.detail} data-testid="fleet-agent-detail">
@@ -269,7 +267,7 @@ function FleetAgentDetailRoute() {
             </div>
           )}
 
-          {/* Activity — newest-first, derived from the session log. */}
+          {/* Activity — durable per-turn timeline, newest-first (TF-247). */}
           <div className={styles.section}>
             <div className={styles.seclabel}>Activity</div>
             <div className={styles.timeline}>
@@ -280,17 +278,50 @@ function FleetAgentDetailRoute() {
                   {agent.summary_markdown || "Active in this session"}
                 </div>
               </div>
-              {captures.map((event) => (
-                <div className={styles.tev} key={event.key}>
-                  <span className={styles.tdot} />
-                  <div className={styles.tt}>{event.time}</div>
-                  <div className={styles.tx}>{event.text}</div>
-                </div>
-              ))}
-              {logQuery.isLoading && (
+              {activityEntries.map((entry) => {
+                const body = (
+                  <>
+                    <span className={styles.tdot} />
+                    <div className={styles.tt}>
+                      {formatClockTime(entry.occurred_at)}
+                    </div>
+                    <div className={styles.tx}>{entry.prompt}</div>
+                    {entry.response_summary && (
+                      <div className={styles.tsub}>
+                        {entry.response_summary}
+                      </div>
+                    )}
+                  </>
+                )
+                // The Ledger is org-only; ledger_href is null otherwise, so the
+                // row renders plain. When present we navigate to the session and
+                // anchor at this turn's timestamp (transcript lines have no id).
+                return entry.ledger_href ? (
+                  <Link
+                    key={entry.id}
+                    to="/v2/ledger"
+                    search={{ session_id: sessionId, at: entry.occurred_at }}
+                    className={cn(styles.tev, styles.tevLink)}
+                    title="Open the backing Ledger line"
+                  >
+                    {body}
+                  </Link>
+                ) : (
+                  <div className={styles.tev} key={entry.id}>
+                    {body}
+                  </div>
+                )
+              })}
+              {activityQuery.isLoading && (
                 <div className={styles.tev}>
                   <span className={styles.tdot} />
                   <div className={styles.tx}>Loading session activity…</div>
+                </div>
+              )}
+              {!activityQuery.isLoading && activityEntries.length === 0 && (
+                <div className={styles.tev}>
+                  <span className={styles.tdot} />
+                  <div className={styles.tx}>No activity captured yet.</div>
                 </div>
               )}
             </div>

--- a/src/routes/v2/ledger.tsx
+++ b/src/routes/v2/ledger.tsx
@@ -19,6 +19,10 @@ const searchSchema = z.object({
   session_id: z.string().optional(),
   specialist: z.string().optional(),
   sort: z.enum(["newest", "oldest"]).optional(),
+  // Timestamp anchor (ISO) used to highlight the transcript line a Fleet
+  // activity entry deep-links to. Transcript lines have no stable id, so the
+  // detail view highlights the line whose occurred_at is closest (TF-247).
+  at: z.string().optional(),
 })
 
 export const Route = createFileRoute("/v2/ledger")({

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -136,6 +136,34 @@ async function mockFleet(
     })
   })
 
+  await page.route(
+    "**/api/v1/v2/taskforce/session-activity**",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          session_id: "session-1",
+          entries: [
+            {
+              id: "act-2",
+              occurred_at: "2026-06-12T10:18:00Z",
+              prompt: "Add the automatic tax line item",
+              response_summary: "Wired automatic tax onto subscription create",
+              ledger_href:
+                "/v2/ledger?session_id=session-1&at=2026-06-12T10:18:00Z",
+            },
+            {
+              id: "act-1",
+              occurred_at: "2026-06-12T10:02:00Z",
+              prompt: "Investigate the Stripe checkout flow",
+              response_summary: null,
+              ledger_href: null,
+            },
+          ],
+        },
+      })
+    },
+  )
+
   await page.route("**/api/v1/v2/documents/**", async (route) => {
     await route.fulfill({
       json: {
@@ -197,6 +225,39 @@ test("clicking an agent row opens the session detail and back returns", async ({
   await page.getByRole("link", { name: "Fleet" }).first().click()
   await expect(page).toHaveURL(/\/v2\/fleet$/)
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
+})
+
+test("activity timeline shows per-turn entries newest-first and links to the Ledger", async ({
+  page,
+}) => {
+  await mockFleet(page)
+  await page.goto("/v2/fleet/session-1")
+
+  // Both captured turns render, with the agent's response summary as subtext.
+  const newest = page.getByText("Add the automatic tax line item")
+  const oldest = page.getByText("Investigate the Stripe checkout flow")
+  await expect(newest).toBeVisible()
+  await expect(oldest).toBeVisible()
+  await expect(
+    page.getByText("Wired automatic tax onto subscription create"),
+  ).toBeVisible()
+
+  // Newest-on-top ordering: the live "now" head sits above both turns, and the
+  // newer turn precedes the older one in the DOM.
+  const timeline = page.getByText("now", { exact: true })
+  await expect(timeline).toBeVisible()
+  const newestBox = await newest.boundingBox()
+  const oldestBox = await oldest.boundingBox()
+  expect(newestBox && oldestBox && newestBox.y < oldestBox.y).toBe(true)
+
+  // The org-available turn deep-links to the Ledger, anchored at its timestamp.
+  const ledgerLink = page.getByRole("link", {
+    name: "Add the automatic tax line item",
+  })
+  const href = await ledgerLink.getAttribute("href")
+  expect(href).toContain("/v2/ledger?")
+  expect(href).toContain("session_id=session-1")
+  expect(href).toContain("at=")
 })
 
 test("dragging an agent moves it to another fleet", async ({ page }) => {


### PR DESCRIPTION
## Why

The Fleet **agent-session detail** "Activity" section (TF-242) could only show a single live **"now"** step plus document-capture rows. The history of what an agent worked on was never visible. This wires the durable per-turn history (captured by the backend PR) into that section so Fleet reads as a quick, glanceable timeline — newest on top — with a path into the Ledger for anyone who wants the full backing detail.

> Pairs with backend **al-exe/EnderAI#142** (the `session-activity` endpoint). Merge that first.

## What

- **API client** (`src/api/v2Taskforce.ts`): `TaskforceSessionActivityEntry` / `...Response` types + `readTaskforceSessionActivity`.
- **Activity timeline** (`src/routes/v2/fleet.$sessionId.tsx`): replaces the session-log-derived "Captured update to X" rows with real per-turn entries — the user **prompt** as the headline and the agent's **response summary** as subtext — newest-first, with the live "now" head retained. Empty/loading states included.
- **Ledger deep-links:** each turn with a `ledger_href` links to `/v2/ledger?session_id=…&at=…`. The Ledger route (`src/routes/v2/ledger.tsx`) gains an optional `at` anchor; `LedgerPage` highlights + scrolls to the transcript line whose `occurred_at` is closest. Turns render plain (no link) for users without an organization, since the Ledger is org-only.

## Notes

- **Best-effort line anchor:** Ledger transcript lines have no stable id, and the activity timestamp (`/discover`) and transcript timestamp (`/observe`) come from different writes, so the highlight lands *near* the backing turn, not exactly on it. The deep-link to the correct **session** is exact.

## Testing

- `bunx tsc -p tsconfig.build.json --noEmit` clean; biome clean on all changed TS/TSX (the CSS `:global` parser warnings are pre-existing on `main`).
- `tests/fleet.spec.ts` extended: asserts the timeline renders entries newest-first with prompt + response subtext and that an org turn deep-links to the Ledger. **fleet + ledger mocked Playwright specs pass (10/10).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)