### PR TITLE
Add Codex Fleet hook setup

### DIFF
--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -96,6 +96,19 @@ function buildClaudeCodeConnectSnippet(
   ].join("\n")
 }
 
+function buildCodexConnectSnippet(
+  mcpToken: string,
+  backendUrl: string,
+): string {
+  const installerUrl = `${backendUrl.replace(/\/$/, "")}/api/v1/v2/taskforce/install-codex.sh`
+
+  return [
+    `printf '%s\\n' '${mcpToken}' > ~/.taskforce_mcp_token && \\`,
+    "chmod 600 ~/.taskforce_mcp_token && \\",
+    `curl -fsSL '${installerUrl}' | bash`,
+  ].join("\n")
+}
+
 function buildAgentInstructionSnippet({
   v2Enabled,
 }: {
@@ -416,6 +429,9 @@ const ConnectAgent = () => {
   const claudeCodeConnectSnippet = hasFreshToken
     ? buildClaudeCodeConnectSnippet(mcpToken, import.meta.env.VITE_API_URL)
     : null
+  const codexConnectSnippet = hasFreshToken
+    ? buildCodexConnectSnippet(mcpToken, import.meta.env.VITE_API_URL)
+    : null
   const reconnectClientSnippet =
     "# Start a fresh terminal, then restart or reconnect your AI client after saving the MCP config."
   const aiAssistedSetupSnippet =
@@ -525,13 +541,14 @@ const ConnectAgent = () => {
           {clientSnippet && persistentShellSnippet ? (
             <div className={styles.tokenSection}>
               <div>
-                <h3 className={styles.sectionTitle}>2. Connect Claude Code</h3>
+                <h3 className={styles.sectionTitle}>
+                  2. Connect Claude Code or Codex
+                </h3>
                 <p className={styles.mutedText}>
                   Run this once in every terminal or VM you want Taskforce to
-                  remember. This single command saves your token and installs
-                  prior-work discovery, automatic capture, and Claude Code cost
-                  tracking. The installer is idempotent, preserves existing
-                  Claude Code settings, and takes effect after restart.
+                  remember. Choose the installer for the coding agent you use.
+                  Both preserve existing hook settings and take effect after
+                  restart.
                 </p>
               </div>
 
@@ -555,6 +572,28 @@ const ConnectAgent = () => {
                 testId="connect-agent-claude-code"
                 featured
               />
+
+              <SnippetBlock
+                title="Connect Codex"
+                description="Persists the credential and installs Fleet registration plus prior-work discovery hooks."
+                snippet={codexConnectSnippet ?? ""}
+                copiedText={copiedText}
+                onCopy={(value) => {
+                  void copy(value)
+                }}
+                testId="connect-agent-codex"
+                featured
+              />
+
+              <Alert>
+                <Shield className={styles.icon} />
+                <AlertTitle>Trust Codex hooks once</AlertTitle>
+                <AlertDescription>
+                  After installing, restart Codex, run `/hooks`, trust the
+                  Taskforce hooks, then start a new Codex session. New sessions
+                  will appear in Fleet immediately.
+                </AlertDescription>
+              </Alert>
 
               <div>
                 <h3 className={styles.sectionTitle}>3. Advanced MCP setup</h3>
@@ -645,8 +684,8 @@ const ConnectAgent = () => {
               <KeyRound className={styles.icon} />
               <AlertTitle>Create your first agent credential</AlertTitle>
               <AlertDescription>
-                Create a credential, then connect each Claude Code terminal or
-                VM with one command.
+                Create a credential, then connect each Claude Code or Codex
+                terminal or VM with one command.
               </AlertDescription>
             </Alert>
           )}

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -76,7 +76,10 @@ export function modelLabel(modelId: string | null): string | null {
   if (!modelId) return null
   const [family, ...rest] = modelId.replace(/^claude-/, "").split("-")
   if (!family) return null
-  const name = family.charAt(0).toUpperCase() + family.slice(1)
+  const name =
+    family.toLowerCase() === "gpt"
+      ? "GPT"
+      : family.charAt(0).toUpperCase() + family.slice(1)
   const version = rest.join(".")
   return version ? `${name} ${version}` : name
 }

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -704,7 +704,7 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   await expect(
     page.getByText("Optional: persist the token across new terminals"),
   ).toHaveCount(0)
-  await expect(page.getByText("2. Connect Claude Code")).toBeVisible()
+  await expect(page.getByText("2. Connect Claude Code or Codex")).toBeVisible()
   const claudeCodeSetup = page.getByTestId("connect-agent-claude-code")
   await expect(claudeCodeSetup).toContainText(
     "printf '%s\\n' 'mcp-token-abc' > ~/.taskforce_mcp_token",
@@ -717,6 +717,17 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   )
   await expect(claudeCodeSetup).not.toContainText("github.com")
   await expect(claudeCodeSetup).not.toContainText("raw.githubusercontent.com")
+  const codexSetup = page.getByTestId("connect-agent-codex")
+  await expect(codexSetup).toContainText(
+    "printf '%s\\n' 'mcp-token-abc' > ~/.taskforce_mcp_token",
+  )
+  await expect(codexSetup).toContainText(
+    "https://enderai-backend.onrender.com/api/v1/v2/taskforce/install-codex.sh",
+  )
+  await expect(page.getByText("Trust Codex hooks once")).toBeVisible()
+  await expect(
+    page.getByText("New sessions will appear in Fleet immediately."),
+  ).toBeVisible()
   await expect(page.getByText("3. Advanced MCP setup")).toBeVisible()
   await expect(
     page.getByRole("tab", { name: "AI-assisted MCP" }),
@@ -859,6 +870,7 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
     page.getByText('export TASKFORCE_MCP_TOKEN="PASTE_MCP_TOKEN_HERE"'),
   ).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-claude-code")).toHaveCount(0)
+  await expect(page.getByTestId("connect-agent-codex")).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-persistent-shell")).toHaveCount(
     0,
   )


### PR DESCRIPTION
## What changed
- add a one-command Codex hook installer beside the existing Claude Code setup
- explain Codex's one-time `/hooks` trust step and immediate Fleet registration behavior
- render GPT model ids with the expected uppercase label in Fleet
- extend settings coverage for the generated Codex command and token lifecycle

## Validation
- Biome formatting/check on changed files
- production frontend build passed
- targeted Playwright test was attempted, but the local harness did not render the Settings tabs before timeout

## Dependency
Requires the backend `install-codex.sh` and session heartbeat endpoint from the matching EnderAI PR.
