### PR TITLE
Fleet session row display names and rename menu

### DIFF
--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -51,6 +51,7 @@ export interface TaskforceFleetAgent {
   repo: string | null
   active_document_id: string | null
   referenced_document_ids: string[]
+  display_name: string
   title: string | null
   summary_markdown: string
   last_seen_at: string
@@ -182,6 +183,22 @@ export function assignTaskforceFleetSession(
     },
     body: {
       fleet_session_id: fleetSessionId,
+    },
+  })
+}
+
+export function renameTaskforceSession(
+  sessionId: string,
+  displayName: string,
+): CancelablePromise<TaskforceFleetAgent> {
+  return request(OpenAPI, {
+    method: "PATCH",
+    url: "/api/v1/v2/taskforce/session/{session_id}",
+    path: {
+      session_id: sessionId,
+    },
+    body: {
+      display_name: displayName,
     },
   })
 }

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -141,14 +141,29 @@
 /* rows */
 .arow {
   display: grid;
-  grid-template-columns: 26px minmax(180px, 250px) minmax(0, 1fr) 64px;
+  grid-template-columns: 26px minmax(180px, 250px) minmax(0, 1fr) auto 64px;
   gap: 18px;
   align-items: baseline;
   width: 100%;
   padding: 16px 18px;
   border-bottom: 1px solid var(--fl-hair);
   text-align: left;
+}
+
+.arowMain {
+  display: contents;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: inherit;
   cursor: pointer;
+}
+
+.arowMenu {
+  align-self: center;
+  color: var(--fl-faint);
 }
 
 .arowDragging {
@@ -167,7 +182,11 @@
   background: var(--fl-hair);
 }
 
-.arow:focus-visible {
+.arow:focus-within {
+  background: var(--fl-hair);
+}
+
+.arowMain:focus-visible {
   outline: 2px solid var(--ring);
   outline-offset: -2px;
 }
@@ -979,18 +998,24 @@
   }
 
   .arow {
-    grid-template-columns: 26px minmax(0, 1fr) auto;
+    grid-template-columns: 26px minmax(0, 1fr) auto auto;
     gap: 12px;
     align-items: start;
   }
 
   .arow .work {
     grid-row: 2;
-    grid-column: 2 / -1;
+    grid-column: 2 / 4;
     text-align: left;
   }
 
   .arow .age {
+    grid-row: 1;
+    grid-column: 4;
+    margin-top: 0;
+  }
+
+  .arowMenu {
     grid-row: 1;
     grid-column: 3;
     margin-top: 0;

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -13,12 +13,20 @@ import {
   createTaskforceFleetSession,
   deleteTaskforceFleetSession,
   readTaskforceFleet,
+  renameTaskforceSession,
   type TaskforceFleetAgent,
   type TaskforceFleetResponse,
   type TaskforceFleetSession,
   updateTaskforceFleetSession,
 } from "@/api/v2Taskforce"
 import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -76,6 +84,7 @@ function StatusDot({ status }: { status: FleetStatus }) {
 function AgentRow({
   agent,
   onOpen,
+  onRename,
   onDragStart,
   onDragEnd,
   isDragging,
@@ -84,6 +93,7 @@ function AgentRow({
 }: {
   agent: TaskforceFleetAgent
   onOpen: (agent: TaskforceFleetAgent) => void
+  onRename: (agent: TaskforceFleetAgent, displayName: string) => void
   onDragStart: (
     agent: TaskforceFleetAgent,
     event: DragEvent<HTMLButtonElement>,
@@ -94,75 +104,165 @@ function AgentRow({
   draggable?: boolean
 }) {
   const suppressClick = useRef(false)
+  const [renameOpen, setRenameOpen] = useState(false)
+  const [renameValue, setRenameValue] = useState(agent.display_name)
   const status = agentStatus(agent)
   const age = compactPresence(agent)
   const showAgeInState = status === "waiting" || status === "idle"
   const docTitle = agent.active_document_id ? agent.title : null
+  const sessionLabel = agentDisplayName(agent)
+
+  const submitRename = (event: FormEvent) => {
+    event.preventDefault()
+    const nextName = renameValue.trim()
+    if (!nextName || nextName === agent.display_name) {
+      setRenameValue(agent.display_name)
+      setRenameOpen(false)
+      return
+    }
+    onRename(agent, nextName)
+    setRenameOpen(false)
+  }
 
   return (
-    <button
-      type="button"
+    <div
       data-testid="fleet-agent-row"
       className={cn(
         styles.arow,
         isDragging && styles.arowDragging,
         isMoving && styles.arowMoving,
       )}
-      draggable={draggable && !isMoving}
-      title={
-        draggable
-          ? "Drag to move this agent to another fleet"
-          : "View this agent session"
-      }
-      onClick={() => {
-        if (suppressClick.current) return
-        onOpen(agent)
-      }}
-      onDragStart={(event) => {
-        suppressClick.current = true
-        event.dataTransfer.effectAllowed = "move"
-        event.dataTransfer.setData("text/plain", agent.session_id)
-        onDragStart(agent, event)
-      }}
-      onDragEnd={() => {
-        onDragEnd()
-        window.setTimeout(() => {
-          suppressClick.current = false
-        }, 0)
-      }}
     >
-      <span className={styles.dragCell} aria-hidden="true">
-        <GripVertical className={styles.dragGrip} />
-        <StatusDot status={status} />
-      </span>
-      <div className={styles.who}>
-        <div className={styles.nm}>{agentDisplayName(agent)}</div>
-        <div className={styles.meta}>{agentMeta(agent)}</div>
-        {status !== "run" && (
-          <div className={cn(styles.state, STATE_CLASS[status])}>
-            {STATE_LABEL[status]}
-            {showAgeInState ? ` · ${age}` : ""}
-          </div>
-        )}
-      </div>
-      <div className={styles.work}>
-        <div className={styles.workSummary}>
-          {agent.summary_markdown || "Connected — no summary captured yet"}
+      <button
+        type="button"
+        className={styles.arowMain}
+        draggable={draggable && !isMoving}
+        title={
+          draggable
+            ? "Drag to move this agent to another fleet"
+            : "View this agent session"
+        }
+        onClick={() => {
+          if (suppressClick.current) return
+          onOpen(agent)
+        }}
+        onDragStart={(event) => {
+          suppressClick.current = true
+          event.dataTransfer.effectAllowed = "move"
+          event.dataTransfer.setData("text/plain", agent.session_id)
+          onDragStart(agent, event)
+        }}
+        onDragEnd={() => {
+          onDragEnd()
+          window.setTimeout(() => {
+            suppressClick.current = false
+          }, 0)
+        }}
+      >
+        <span className={styles.dragCell} aria-hidden="true">
+          <GripVertical className={styles.dragGrip} />
+          <StatusDot status={status} />
+        </span>
+        <div className={styles.who}>
+          <div className={styles.nm}>{sessionLabel}</div>
+          <div className={styles.meta}>{agentMeta(agent)}</div>
+          {status !== "run" && (
+            <div className={cn(styles.state, STATE_CLASS[status])}>
+              {STATE_LABEL[status]}
+              {showAgeInState ? ` · ${age}` : ""}
+            </div>
+          )}
         </div>
-        {docTitle && (
-          <div className={styles.detailLine}>
-            <span className={styles.docInline}>{docTitle}</span>
+        <div className={styles.work}>
+          <div className={styles.workSummary}>
+            {agent.summary_markdown || "No current work captured yet"}
           </div>
-        )}
-      </div>
+          {docTitle && (
+            <div className={styles.detailLine}>
+              <span className={styles.docInline}>{docTitle}</span>
+            </div>
+          )}
+        </div>
+      </button>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`${sessionLabel} actions`}
+            className={styles.arowMenu}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <MoreHorizontal />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onSelect={() => {
+              setRenameValue(agent.display_name)
+              setRenameOpen(true)
+            }}
+          >
+            <Pencil />
+            Rename
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
       <div className={styles.age}>{status === "run" ? age : ""}</div>
-    </button>
+
+      <Dialog
+        open={renameOpen}
+        onOpenChange={(open) => {
+          setRenameOpen(open)
+          if (!open) setRenameValue(agent.display_name)
+        }}
+      >
+        <DialogContent>
+          <form onSubmit={submitRename}>
+            <DialogHeader>
+              <DialogTitle>Rename session</DialogTitle>
+            </DialogHeader>
+            <div className="py-4">
+              <Input
+                value={renameValue}
+                onChange={(event) => setRenameValue(event.target.value)}
+                maxLength={120}
+                autoFocus
+                aria-label="Session name"
+              />
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setRenameOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  !renameValue.trim() ||
+                  renameValue.trim() === agent.display_name
+                }
+              >
+                Save
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
   )
 }
 
 function FleetCard({
   fleet,
   onOpenAgent,
+  onRenameAgent,
   onRename,
   onDelete,
   draggingAgent,
@@ -175,6 +275,7 @@ function FleetCard({
 }: {
   fleet: TaskforceFleetSession
   onOpenAgent: (agent: TaskforceFleetAgent) => void
+  onRenameAgent: (agent: TaskforceFleetAgent, displayName: string) => void
   onRename: (fleet: TaskforceFleetSession, name: string) => void
   onDelete: (fleet: TaskforceFleetSession) => void
   draggingAgent: TaskforceFleetAgent | null
@@ -328,6 +429,7 @@ function FleetCard({
               key={agent.session_id}
               agent={agent}
               onOpen={onOpenAgent}
+              onRename={onRenameAgent}
               onDragStart={onAgentDragStart}
               onDragEnd={onAgentDragEnd}
               isDragging={draggingAgent?.session_id === agent.session_id}
@@ -383,6 +485,17 @@ export function FleetPage() {
       fleet: TaskforceFleetSession
       name: string
     }) => updateTaskforceFleetSession(fleet.id, name),
+    onSuccess: refreshFleet,
+    onError: setMutationError,
+  })
+  const renameAgentMutation = useMutation({
+    mutationFn: ({
+      agent,
+      displayName,
+    }: {
+      agent: TaskforceFleetAgent
+      displayName: string
+    }) => renameTaskforceSession(agent.session_id, displayName),
     onSuccess: refreshFleet,
     onError: setMutationError,
   })
@@ -463,6 +576,10 @@ export function FleetPage() {
   const renameFleet = (fleet: TaskforceFleetSession, name: string) => {
     setMutationError(null)
     renameMutation.mutate({ fleet, name })
+  }
+  const renameAgent = (agent: TaskforceFleetAgent, displayName: string) => {
+    setMutationError(null)
+    renameAgentMutation.mutate({ agent, displayName })
   }
   const deleteFleet = (fleet: TaskforceFleetSession) => {
     if (
@@ -589,6 +706,7 @@ export function FleetPage() {
                   key={fleet.id}
                   fleet={fleet}
                   onOpenAgent={openAgent}
+                  onRenameAgent={renameAgent}
                   onRename={renameFleet}
                   onDelete={deleteFleet}
                   draggingAgent={draggingAgent}

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -94,11 +94,10 @@ export function hostLabel(agent: TaskforceFleetAgent): string | null {
   return (agent as FutureAgentFields).host ?? null
 }
 
-// Heading shown for an agent. Once Taskforce has captured a document the
-// document title wins; until then a brand-new session shows the model it's
-// running (e.g. "Opus 4.8") rather than the bare working-directory name.
+// Heading shown for an agent session in Fleet. The backend captures a stable
+// one-line summary at conversation start; users can rename it from the roster.
 export function agentDisplayName(agent: TaskforceFleetAgent): string {
-  return agent.title || modelLabel(agent.model_id) || repoLabel(agent)
+  return agent.display_name || modelLabel(agent.model_id) || repoLabel(agent)
 }
 
 export function agentModelName(agent: TaskforceFleetAgent): string {

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -31,6 +31,7 @@ async function mockFleet(
     repo: "billing",
     active_document_id: "doc-1",
     referenced_document_ids: ["doc-2"],
+    display_name: "Wiring automatic tax on Stripe checkout",
     title: "Stripe checkout wiring",
     summary_markdown: "Wiring automatic tax onto the subscription create path",
     last_seen_at: "2026-06-12T10:20:00Z",
@@ -117,9 +118,15 @@ async function mockFleet(
     "**/api/v1/v2/taskforce/session/session-1",
     async (route) => {
       const body = route.request().postDataJSON() as {
-        fleet_session_id: string
+        fleet_session_id?: string
+        display_name?: string
       }
-      agentFleetId = body.fleet_session_id
+      if (body.fleet_session_id) {
+        agentFleetId = body.fleet_session_id
+      }
+      if (body.display_name) {
+        agent.display_name = body.display_name
+      }
       await route.fulfill({
         json: { ...agent, fleet_session_id: agentFleetId },
       })
@@ -220,11 +227,13 @@ test("clicking an agent row opens the session detail and back returns", async ({
   await mockFleet(page)
   await page.goto("/v2/fleet")
 
-  await page.getByText("Stripe checkout wiring").first().click()
+  await page.getByText("Wiring automatic tax on Stripe checkout").first().click()
 
   await expect(page).toHaveURL(/\/v2\/fleet\/session-1$/)
   await expect(
-    page.getByRole("heading", { name: "Stripe checkout wiring" }),
+    page.getByRole("heading", {
+      name: "Wiring automatic tax on Stripe checkout",
+    }),
   ).toBeVisible()
   await expect(page.getByText("Working on")).toBeVisible()
   await expect(page.getByText("Activity")).toBeVisible()
@@ -236,6 +245,29 @@ test("clicking an agent row opens the session detail and back returns", async ({
   await page.getByRole("link", { name: "Fleet" }).first().click()
   await expect(page).toHaveURL(/\/v2\/fleet$/)
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
+})
+
+test("agent session can be renamed from the row menu", async ({ page }) => {
+  await mockFleet(page)
+  await page.goto("/v2/fleet")
+
+  await page
+    .getByRole("button", {
+      name: "Wiring automatic tax on Stripe checkout actions",
+    })
+    .click()
+  await page.getByRole("menuitem", { name: "Rename" }).click()
+  await page.getByLabel("Session name").fill("Checkout tax rollout")
+  const renameRequest = page.waitForRequest(
+    (request) =>
+      request.url().endsWith("/api/v1/v2/taskforce/session/session-1") &&
+      request.method() === "PATCH",
+  )
+  await page.getByRole("button", { name: "Save" }).click()
+  expect((await renameRequest).postDataJSON()).toEqual({
+    display_name: "Checkout tax rollout",
+  })
+  await expect(page.getByText("Checkout tax rollout")).toBeVisible()
 })
 
 test("activity timeline shows per-turn entries newest-first and links to the Ledger", async ({
@@ -292,7 +324,7 @@ test("dragging an agent moves it to another fleet", async ({ page }) => {
   ).toHaveCount(0)
   await expect(
     page.getByTestId("fleet-card-fleet-2").getByTestId("fleet-agent-row"),
-  ).toContainText("Stripe checkout wiring")
+  ).toContainText("Wiring automatic tax on Stripe checkout")
 })
 
 for (const theme of ["light", "dark"] as const) {


### PR DESCRIPTION
## Summary
- Show backend `display_name` as the Fleet agent session label instead of document title or last prompt.
- Add a three-dot row menu with Rename, wired to `PATCH /v2/taskforce/session/{session_id}`.
- Keep current work in the work column via `summary_markdown`.

## Test plan
- [x] Updated Fleet Playwright tests for display names and rename flow
- [ ] Fleet e2e in CI


Made with [Cursor](https://cursor.com)