### PR TITLE
Serve /v2/fleet (and other v2 routes) as static Pages entrypoints

### DIFF
--- a/.github/workflows/deploy-frontend-pages.yml
+++ b/.github/workflows/deploy-frontend-pages.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Static route entrypoints for GitHub Pages
         run: |
-          for route in login signup landing pricing docs docs/quickstart docs/how-it-works docs/document-workflow docs/tf-flow docs/web-app docs/metrics docs/team-rollout docs/best-practices docs/faq recover-password reset-password topics cases settings admin v2 v2/home v2/library v2/library/8c9b0f48-2f3f-4e8d-9f7d-b4f0607d6a32 v2/library/5b7462e9-6b0e-4d48-81a2-07f052534a12 v2/library/0fd8a545-a3b7-4a9f-bb65-1ecf76bd8b6d v2/admin v2/agents v2/agents/jensen v2/agents/mira v2/agents/orin v2/agents/vega v2/agents/nia v2/metrics v2/metrics/methodology v2/search; do
+          for route in login signup landing pricing docs docs/quickstart docs/how-it-works docs/document-workflow docs/tf-flow docs/web-app docs/metrics docs/team-rollout docs/best-practices docs/faq recover-password reset-password topics cases settings admin v2 v2/home v2/library v2/library/8c9b0f48-2f3f-4e8d-9f7d-b4f0607d6a32 v2/library/5b7462e9-6b0e-4d48-81a2-07f052534a12 v2/library/0fd8a545-a3b7-4a9f-bb65-1ecf76bd8b6d v2/admin v2/agents v2/agents/jensen v2/agents/mira v2/agents/orin v2/agents/vega v2/agents/nia v2/metrics v2/metrics/methodology v2/search v2/fleet v2/ledger v2/settings v2/pricing; do
             mkdir -p "dist/$route"
             cp dist/index.html "dist/$route/index.html"
           done


### PR DESCRIPTION
## Problem

`https://taskforce.tools/v2/fleet` returns **HTTP 404**, even though `src/routes/v2/fleet.tsx` exists and is in the generated route tree, and the Pages deploy for #286 succeeded.

## Root cause

The `Static route entrypoints for GitHub Pages` step in `deploy-frontend-pages.yml` pre-creates `dist/<route>/index.html` from a **hardcoded route list** so direct navigations / refreshes return 200. `v2/fleet`, `v2/ledger`, `v2/settings`, and `v2/pricing` were never added to that list — so those paths fall through to the `404.html` SPA fallback and return HTTP 404 (while `/v2/home`, `/v2/search`, etc. work because they're listed).

## Fix

Add the missing static v2 routes to the list:

```
… v2/search v2/fleet v2/ledger v2/settings v2/pricing
```

Dynamic routes (`v2/fleet/$sessionId`, `v2/library/$documentId`) intentionally keep relying on the `404.html` SPA fallback, consistent with the existing approach.

## Validation

- Workflow YAML re-parses cleanly.
- After merge + Pages deploy, `GET /v2/fleet` should return 200 instead of 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)