### PR TITLE
Fix /v2/fleet crash on agents with null display_name

### DIFF
--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -105,7 +105,7 @@ function AgentRow({
 }) {
   const suppressClick = useRef(false)
   const [renameOpen, setRenameOpen] = useState(false)
-  const [renameValue, setRenameValue] = useState(agent.display_name)
+  const [renameValue, setRenameValue] = useState(agent.display_name ?? "")
   const status = agentStatus(agent)
   const age = compactPresence(agent)
   const showAgeInState = status === "waiting" || status === "idle"
@@ -116,7 +116,7 @@ function AgentRow({
     event.preventDefault()
     const nextName = renameValue.trim()
     if (!nextName || nextName === agent.display_name) {
-      setRenameValue(agent.display_name)
+      setRenameValue(agent.display_name ?? "")
       setRenameOpen(false)
       return
     }
@@ -293,7 +293,7 @@ function FleetCard({
   ) => void
 }) {
   const [renaming, setRenaming] = useState(false)
-  const [name, setName] = useState(fleet.name)
+  const [name, setName] = useState(fleet.name ?? "")
 
   const repo = fleetRepo(fleet)
   const running = runningCount(fleet.agents)
@@ -312,7 +312,7 @@ function FleetCard({
     event.preventDefault()
     const nextName = name.trim()
     if (!nextName || nextName === fleet.name) {
-      setName(fleet.name)
+      setName(fleet.name ?? "")
       setRenaming(false)
       return
     }


### PR DESCRIPTION
## Symptom

`/v2/fleet` rendered the route error boundary ("Oops! Something went wrong") with:

```
TypeError: Cannot read properties of undefined (reading 'trim')
  at Ae (fleet-*.js)   // FleetPage rename Save button
```

(This surfaced right after #287 made the route reachable; it is a pre-existing bug, not caused by that PR.)

## Root cause

`AgentRow` and `FleetCard` seed their rename `useState` directly from `agent.display_name` / `fleet.name`. Those fields are nullable — `agentDisplayName()` and `fleetTitle()` already guard them — so an agent with no `display_name` makes `renameValue` `undefined`. The rename dialog's Save button renders `!renameValue.trim()` unconditionally, so the `.trim()` throws during render and trips the error boundary.

## Fix

Seed and reset the rename state with `?? ""` so `renameValue` / `name` are always strings:

- `useState(agent.display_name ?? "")`
- `useState(fleet.name ?? "")`
- the two reset paths likewise

4 lines changed. `tsc -p tsconfig.build.json` is clean for `FleetPage.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)