### PR TITLE
Guard remaining Fleet rename reset paths against null name

### DIFF
--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -201,7 +201,7 @@ function AgentRow({
         <DropdownMenuContent align="end">
           <DropdownMenuItem
             onSelect={() => {
-              setRenameValue(agent.display_name)
+              setRenameValue(agent.display_name ?? "")
               setRenameOpen(true)
             }}
           >
@@ -217,7 +217,7 @@ function AgentRow({
         open={renameOpen}
         onOpenChange={(open) => {
           setRenameOpen(open)
-          if (!open) setRenameValue(agent.display_name)
+          if (!open) setRenameValue(agent.display_name ?? "")
         }}
       >
         <DialogContent>
@@ -396,7 +396,7 @@ function FleetCard({
             <DropdownMenuContent align="end">
               <DropdownMenuItem
                 onSelect={() => {
-                  setName(fleet.name)
+                  setName(fleet.name ?? "")
                   setRenaming(true)
                 }}
               >


### PR DESCRIPTION
Follow-up to #288. That PR fixed the initial-render crash on `/v2/fleet`, but the minified bundle showed two more reset paths still passing the raw nullable value:

- `AgentRow` "Rename" menu `onSelect` → `setRenameValue(agent.display_name)`
- `AgentRow` dialog `onOpenChange` → `setRenameValue(agent.display_name)`
- `FleetCard` "Rename" menu `onSelect` → `setName(fleet.name)`

Opening rename on a session with no name would set the state back to `undefined` and re-trigger `Cannot read properties of undefined (reading 'trim')`. Coalesce all three with `?? ""`.

3 lines. Page-load crash was already resolved by #288; this closes the interaction path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)