### PR TITLE
[codex] Show the canonical timeline in Fleet and Ledger

### DIFF
--- a/src/api/v2Ledger.ts
+++ b/src/api/v2Ledger.ts
@@ -28,6 +28,7 @@ export type LedgerTranscriptEventKind =
   | "note"
 
 export interface LedgerTranscriptEvent {
+  id: string
   kind: LedgerTranscriptEventKind
   occurred_at: string | null
   role: string | null

--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -1,5 +1,6 @@
 import { type CancelablePromise, OpenAPI } from "@/client"
 import { request } from "@/client/core/request"
+import type { LedgerTranscriptEvent } from "./v2Ledger"
 
 export interface TaskforceSessionSavingsResponse {
   session_id: string
@@ -30,11 +31,8 @@ export interface TaskforceSessionLogResponse {
   entries: TaskforceSessionLogEntry[]
 }
 
-export interface TaskforceSessionActivityEntry {
-  id: string
+export interface TaskforceSessionActivityEntry extends LedgerTranscriptEvent {
   occurred_at: string
-  prompt: string
-  response_summary: string | null
   ledger_href: string | null
 }
 

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -651,6 +651,12 @@
   letter-spacing: 0.02em;
 }
 
+.tkind {
+  margin-left: 8px;
+  color: var(--muted-foreground);
+  text-transform: uppercase;
+}
+
 .tx {
   margin-top: 3px;
   color: var(--muted-foreground);

--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -435,12 +435,6 @@
   grid-template-columns: 74px 1fr;
   gap: 0;
 }
-/* Highlighted target of a Fleet activity deep-link (?at=…). */
-.evHighlight .evC {
-  background: var(--tf-primary-soft, color-mix(in srgb, var(--tf-primary) 10%, transparent));
-  border-left-color: var(--tf-primary);
-  box-shadow: -2px 0 0 0 var(--tf-primary);
-}
 .evT {
   font-family: var(--font-mono);
   font-size: 12px;
@@ -454,6 +448,15 @@
   padding: 0 0 18px 20px;
   position: relative;
   min-width: 0;
+}
+/* Highlighted target of a Fleet activity deep-link (?event_id=…). */
+.evHighlight .evC {
+  background: var(
+    --tf-primary-soft,
+    color-mix(in srgb, var(--tf-primary) 10%, transparent)
+  );
+  border-left-color: var(--tf-primary);
+  box-shadow: -2px 0 0 0 var(--tf-primary);
 }
 .evC::before {
   content: "";

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -56,11 +56,11 @@ type LedgerSearchFilters = {
   actor_id?: string
   client?: string
   cross_boundary?: boolean
+  event_id?: string
   q?: string
   session_id?: string
   specialist?: string
   sort?: LedgerSort
-  at?: string
 }
 
 type DayGroup = {
@@ -79,6 +79,7 @@ function cleanLedgerSearch(filters: LedgerSearchFilters): LedgerSearchFilters {
     actor_id: filters.actor_id || undefined,
     client: filters.client || undefined,
     cross_boundary: filters.cross_boundary || undefined,
+    event_id: filters.session_id ? filters.event_id || undefined : undefined,
     q: filters.q || undefined,
     session_id: filters.session_id || undefined,
     specialist: filters.specialist || undefined,
@@ -357,7 +358,9 @@ export function LedgerPage({
   useEffect(() => {
     if (!selectedSessionId) return
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setLedgerSearch({ session_id: undefined })
+      if (event.key === "Escape") {
+        setLedgerSearch({ event_id: undefined, session_id: undefined })
+      }
     }
     window.addEventListener("keydown", onKeyDown)
     return () => window.removeEventListener("keydown", onKeyDown)
@@ -368,7 +371,11 @@ export function LedgerPage({
 
   const onSearchSubmit = (event: FormEvent) => {
     event.preventDefault()
-    setLedgerSearch({ q: search.trim() || undefined, session_id: undefined })
+    setLedgerSearch({
+      event_id: undefined,
+      q: search.trim() || undefined,
+      session_id: undefined,
+    })
   }
 
   return (
@@ -382,12 +389,14 @@ export function LedgerPage({
         {selectedSessionId ? (
           <div className={styles.app}>
             <LedgerDetail
-              anchorAt={searchFilters.at}
+              anchorEventId={searchFilters.event_id}
               detail={detailQuery.data}
               demo={isDemoMode}
               isError={detailQuery.isError}
               isLoading={detailQuery.isLoading}
-              onBack={() => setLedgerSearch({ session_id: undefined })}
+              onBack={() =>
+                setLedgerSearch({ event_id: undefined, session_id: undefined })
+              }
             />
           </div>
         ) : (
@@ -462,7 +471,10 @@ export function LedgerPage({
                 isError={ledgerQuery.isError}
                 isLoading={ledgerQuery.isLoading}
                 onOpenSession={(sessionId) =>
-                  setLedgerSearch({ session_id: sessionId })
+                  setLedgerSearch({
+                    event_id: undefined,
+                    session_id: sessionId,
+                  })
                 }
               />
             </div>
@@ -586,45 +598,23 @@ function LedgerRow({
   )
 }
 
-/**
- * Index of the transcript line whose timestamp is closest to `at`, or -1.
- *
- * Best-effort anchor for a Fleet activity deep-link: transcript lines have no
- * stable id, and the activity timestamp (recorded at /discover) and the
- * transcript timestamp (recorded at /observe) come from different writes, so
- * this lands the reader near — not exactly on — the backing turn (TF-247).
- */
-function closestEventIndex(
+function eventIndex(
   events: LedgerTranscriptEvent[],
-  at: string | undefined,
+  eventId: string | undefined,
 ): number {
-  if (!at || events.length === 0) return -1
-  const target = new Date(at).getTime()
-  if (Number.isNaN(target)) return -1
-  let best = -1
-  let bestDelta = Number.POSITIVE_INFINITY
-  events.forEach((event, index) => {
-    if (!event.occurred_at) return
-    const stamp = new Date(event.occurred_at).getTime()
-    if (Number.isNaN(stamp)) return
-    const delta = Math.abs(stamp - target)
-    if (delta < bestDelta) {
-      bestDelta = delta
-      best = index
-    }
-  })
-  return best
+  if (!eventId) return -1
+  return events.findIndex((event) => event.id === eventId)
 }
 
 function LedgerDetail({
-  anchorAt,
+  anchorEventId,
   detail,
   demo,
   isError,
   isLoading,
   onBack,
 }: {
-  anchorAt?: string
+  anchorEventId?: string
   detail?: LedgerSessionDetail
   demo: boolean
   isError: boolean
@@ -632,8 +622,8 @@ function LedgerDetail({
   onBack: () => void
 }) {
   const anchorIndex = useMemo(
-    () => closestEventIndex(detail?.transcript_events ?? [], anchorAt),
-    [detail?.transcript_events, anchorAt],
+    () => eventIndex(detail?.transcript_events ?? [], anchorEventId),
+    [detail?.transcript_events, anchorEventId],
   )
   const anchorRef = useRef<HTMLDivElement | null>(null)
   useEffect(() => {
@@ -699,7 +689,7 @@ function LedgerDetail({
                 detail={detail}
                 event={event}
                 highlighted={index === anchorIndex}
-                key={`${event.kind}-${event.occurred_at ?? index}-${index}`}
+                key={event.id}
               />
             ))
           ) : (
@@ -819,6 +809,7 @@ function EventShell({
   return (
     <div
       className={cn(styles.ev, modifier, highlighted && styles.evHighlight)}
+      data-highlighted={highlighted ? "true" : undefined}
       ref={rootRef}
     >
       <div className={styles.evT}>{time}</div>
@@ -860,7 +851,7 @@ function SessionRail({
       anchor.remove()
       URL.revokeObjectURL(href)
     } catch {
-      setDownloadError("Could not download the raw transcript.")
+      setDownloadError("Could not download the transcript.")
     } finally {
       setIsDownloading(false)
     }
@@ -920,7 +911,7 @@ function SessionRail({
             onClick={() => void downloadRawTranscript()}
             type="button"
           >
-            {isDownloading ? "Preparing download…" : "Download raw transcript"}
+            {isDownloading ? "Preparing download…" : "Download transcript"}
           </button>
         ) : null}
         <button className={styles.btn} onClick={copyMarkdown} type="button">

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -7,6 +7,7 @@ import {
   readTaskforceSessionActivity,
   type TaskforceFleetAgent,
   type TaskforceFleetResponse,
+  type TaskforceSessionActivityEntry,
 } from "@/api/v2Taskforce"
 import { Button } from "@/components/ui/button"
 import styles from "@/components/V2/Fleet/FleetPage.module.css"
@@ -72,6 +73,28 @@ function metaRow(key: string, value: string, valueClass?: string) {
       </span>
     </div>
   )
+}
+
+function eventTitle(event: TaskforceSessionActivityEntry): string {
+  if (event.kind === "command") return `$ ${event.cmd ?? "command"}`
+  if (event.kind === "edit") return `Edited ${event.file ?? "file"}`
+  return event.text ?? event.note ?? event.kind
+}
+
+function eventDetail(event: TaskforceSessionActivityEntry): string | null {
+  if (event.kind === "command") {
+    const exit =
+      event.exit_code === null ? "" : `exit ${event.exit_code.toString()}`
+    return [event.output, exit].filter(Boolean).join(" · ") || null
+  }
+  if (event.kind === "edit") {
+    const stats =
+      event.added !== null || event.removed !== null
+        ? `+${event.added ?? 0} −${event.removed ?? 0}`
+        : ""
+    return [event.note, stats].filter(Boolean).join(" · ") || null
+  }
+  return event.note
 }
 
 function FleetAgentDetailRoute() {
@@ -146,11 +169,9 @@ function FleetAgentDetailRoute() {
     Boolean(bit),
   )
 
-  // Activity timeline — newest-first. The live "now" step sits on top; below it
-  // each captured turn (user prompt + a summary of the agent's response),
-  // deep-linking to the Ledger line that backs it (TF-247).
+  // The same canonical event stream shown by Ledger, newest-first here.
   const activityEntries = [...(activityQuery.data?.entries ?? [])].sort(
-    (a, b) => b.occurred_at.localeCompare(a.occurred_at),
+    (a, b) => (b.occurred_at ?? "").localeCompare(a.occurred_at ?? ""),
   )
 
   return (
@@ -279,30 +300,25 @@ function FleetAgentDetailRoute() {
                 </div>
               </div>
               {activityEntries.map((entry) => {
+                const detail = eventDetail(entry)
                 const body = (
                   <>
                     <span className={styles.tdot} />
                     <div className={styles.tt}>
                       {formatClockTime(entry.occurred_at)}
+                      <span className={styles.tkind}>{entry.kind}</span>
                     </div>
-                    <div className={styles.tx}>{entry.prompt}</div>
-                    {entry.response_summary && (
-                      <div className={styles.tsub}>
-                        {entry.response_summary}
-                      </div>
-                    )}
+                    <div className={styles.tx}>{eventTitle(entry)}</div>
+                    {detail && <div className={styles.tsub}>{detail}</div>}
                   </>
                 )
-                // The Ledger is org-only; ledger_href is null otherwise, so the
-                // row renders plain. When present we navigate to the session and
-                // anchor at this turn's timestamp (transcript lines have no id).
                 return entry.ledger_href ? (
                   <Link
                     key={entry.id}
                     to="/v2/ledger"
-                    search={{ session_id: sessionId, at: entry.occurred_at }}
+                    search={{ session_id: sessionId, event_id: entry.id }}
                     className={cn(styles.tev, styles.tevLink)}
-                    title="Open the backing Ledger line"
+                    title="Open this event in Ledger"
                   >
                     {body}
                   </Link>

--- a/src/routes/v2/ledger.tsx
+++ b/src/routes/v2/ledger.tsx
@@ -17,12 +17,9 @@ const searchSchema = z.object({
     }),
   q: z.string().optional(),
   session_id: z.string().optional(),
+  event_id: z.string().optional(),
   specialist: z.string().optional(),
   sort: z.enum(["newest", "oldest"]).optional(),
-  // Timestamp anchor (ISO) used to highlight the transcript line a Fleet
-  // activity entry deep-links to. Transcript lines have no stable id, so the
-  // detail view highlights the line whose occurred_at is closest (TF-247).
-  at: z.string().optional(),
 })
 
 export const Route = createFileRoute("/v2/ledger")({

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -162,18 +162,73 @@ async function mockFleet(
           session_id: "session-1",
           entries: [
             {
-              id: "act-2",
+              id: "event-command",
+              kind: "command",
               occurred_at: "2026-06-12T10:18:00Z",
-              prompt: "Add the automatic tax line item",
-              response_summary: "Wired automatic tax onto subscription create",
+              role: null,
+              who: null,
+              text: null,
+              cmd: "pytest tests/payments.spec.ts",
+              exit_code: 0,
+              output: "4 passed",
+              file: null,
+              added: null,
+              removed: null,
+              note: null,
+              repo: "EnderAI",
               ledger_href:
-                "/v2/ledger?session_id=session-1&at=2026-06-12T10:18:00Z",
+                "/v2/ledger?session_id=session-1&event_id=event-command",
             },
             {
-              id: "act-1",
+              id: "event-reply",
+              kind: "reply",
+              occurred_at: "2026-06-12T10:17:00Z",
+              role: "assistant",
+              who: "@agent",
+              text: "Wired automatic tax onto subscription create",
+              cmd: null,
+              exit_code: null,
+              output: null,
+              file: null,
+              added: null,
+              removed: null,
+              note: null,
+              repo: null,
+              ledger_href:
+                "/v2/ledger?session_id=session-1&event_id=event-reply",
+            },
+            {
+              id: "event-edit",
+              kind: "edit",
+              occurred_at: "2026-06-12T10:16:30Z",
+              role: null,
+              who: null,
+              text: null,
+              cmd: null,
+              exit_code: null,
+              output: null,
+              file: "src/payments.ts",
+              added: 12,
+              removed: 2,
+              note: "Enabled automatic tax",
+              repo: "EnderAI",
+              ledger_href: null,
+            },
+            {
+              id: "event-prompt",
+              kind: "prompt",
               occurred_at: "2026-06-12T10:02:00Z",
-              prompt: "Investigate the Stripe checkout flow",
-              response_summary: null,
+              role: "user",
+              who: "@user",
+              text: "Investigate the Stripe checkout flow",
+              cmd: null,
+              exit_code: null,
+              output: null,
+              file: null,
+              added: null,
+              removed: null,
+              note: null,
+              repo: null,
               ledger_href: null,
             },
           ],
@@ -227,7 +282,10 @@ test("clicking an agent row opens the session detail and back returns", async ({
   await mockFleet(page)
   await page.goto("/v2/fleet")
 
-  await page.getByText("Wiring automatic tax on Stripe checkout").first().click()
+  await page
+    .getByText("Wiring automatic tax on Stripe checkout")
+    .first()
+    .click()
 
   await expect(page).toHaveURL(/\/v2\/fleet\/session-1$/)
   await expect(
@@ -270,20 +328,21 @@ test("agent session can be renamed from the row menu", async ({ page }) => {
   await expect(page.getByText("Checkout tax rollout")).toBeVisible()
 })
 
-test("activity timeline shows per-turn entries newest-first and links to the Ledger", async ({
+test("activity timeline shows the full canonical event stream and exact Ledger links", async ({
   page,
 }) => {
   await mockFleet(page)
   await page.goto("/v2/fleet/session-1")
 
-  // Both captured turns render, with the agent's response summary as subtext.
-  const newest = page.getByText("Add the automatic tax line item")
+  const newest = page.getByText("$ pytest tests/payments.spec.ts")
   const oldest = page.getByText("Investigate the Stripe checkout flow")
   await expect(newest).toBeVisible()
   await expect(oldest).toBeVisible()
   await expect(
     page.getByText("Wired automatic tax onto subscription create"),
   ).toBeVisible()
+  await expect(page.getByText("Edited src/payments.ts")).toBeVisible()
+  await expect(page.getByText("4 passed · exit 0")).toBeVisible()
 
   // Newest-on-top ordering: the live "now" head sits above both turns, and the
   // newer turn precedes the older one in the DOM.
@@ -293,14 +352,14 @@ test("activity timeline shows per-turn entries newest-first and links to the Led
   const oldestBox = await oldest.boundingBox()
   expect(newestBox && oldestBox && newestBox.y < oldestBox.y).toBe(true)
 
-  // The org-available turn deep-links to the Ledger, anchored at its timestamp.
+  // The org-available event deep-links to the exact canonical Ledger event.
   const ledgerLink = page.getByRole("link", {
-    name: "Add the automatic tax line item",
+    name: /pytest tests\/payments\.spec\.ts/,
   })
   const href = await ledgerLink.getAttribute("href")
   expect(href).toContain("/v2/ledger?")
   expect(href).toContain("session_id=session-1")
-  expect(href).toContain("at=")
+  expect(href).toContain("event_id=event-command")
 })
 
 test("dragging an agent moves it to another fleet", async ({ page }) => {

--- a/tests/ledger.spec.ts
+++ b/tests/ledger.spec.ts
@@ -86,6 +86,7 @@ function ledgerDetail(rawTranscriptAvailable: boolean) {
     transcript_available: true,
     transcript_events: [
       {
+        id: "event-prompt",
         kind: "prompt",
         occurred_at: "2026-06-12T20:00:00Z",
         role: "user",
@@ -165,7 +166,7 @@ test("solo users see the team Ledger state without calling Ledger APIs", async (
   expect(ledgerRequests).toBe(0)
 })
 
-test("organization users can download an available raw transcript", async ({
+test("organization users can download an available transcript", async ({
   page,
 }) => {
   await mockTaskforceAuth(page, "org-1")
@@ -175,7 +176,7 @@ test("organization users can download an available raw transcript", async ({
 
   await expect(page.getByRole("link", { name: "Ledger" })).toBeVisible()
   const downloadPromise = page.waitForEvent("download")
-  await page.getByRole("button", { name: "Download raw transcript" }).click()
+  await page.getByRole("button", { name: "Download transcript" }).click()
   const download = await downloadPromise
 
   expect(download.suggestedFilename()).toBe("session-raw-transcript.json")
@@ -190,7 +191,20 @@ test("organization users can download an available raw transcript", async ({
   ])
 })
 
-test("sessions without a raw archive show no transcript download control", async ({
+test("event deep links highlight the exact canonical Ledger event", async ({
+  page,
+}) => {
+  await mockTaskforceAuth(page, "org-1")
+  await mockLedger(page, { rawTranscriptAvailable: true })
+
+  await page.goto("/v2/ledger?session_id=session-raw&event_id=event-prompt")
+
+  await expect(page.locator('[data-highlighted="true"]')).toContainText(
+    "Polish the Ledger.",
+  )
+})
+
+test("sessions without canonical events show no transcript download control", async ({
   page,
 }) => {
   await mockTaskforceAuth(page, "org-1")
@@ -200,6 +214,6 @@ test("sessions without a raw archive show no transcript download control", async
 
   await expect(page.getByText("Ledger transcript polish")).toBeVisible()
   await expect(
-    page.getByRole("button", { name: /raw transcript/i }),
+    page.getByRole("button", { name: /download transcript/i }),
   ).toHaveCount(0)
 })


### PR DESCRIPTION
## Summary
- render the complete canonical session timeline in the Fleet session detail, including prompts, replies, commands, edits, and notes
- use the same event IDs and event payloads as Ledger
- deep-link Fleet entries to the exact Ledger event and highlight that event on arrival
- rename the reconstructed export control from “raw transcript” to “transcript”

## Backend dependency
- https://github.com/al-exe/EnderAI/pull/152

## Validation
- production TypeScript/Vite build passed
- Biome passed on all changed frontend files
- canonical Fleet timeline Playwright test passed
- all four Ledger Playwright tests passed, including exact event highlighting and transcript download
- `git diff --check` passed

## Existing test note
A broader Fleet + Ledger run also passed the new timeline coverage and Ledger suite. Three unrelated pre-existing Fleet tests remain unstable: drag timeout and two 360px responsive column-count assertions.