### PR TITLE
Fix v2 tab routing after hard refresh

### DIFF
--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -148,14 +148,21 @@ function TaskforceNav({ currentUser }: TaskforceShellProps) {
     }
   }
 
+  const normalizedPath = currentPath.replace(/\/+$/, "") || "/"
+
   return (
     <SidebarMenu className="px-2">
       {items.map((item) => {
         const isActive =
-          currentPath === item.path ||
+          normalizedPath === item.path ||
           (item.path === "/v2/library" &&
-            currentPath.startsWith("/v2/library/")) ||
-          (item.path === "/v2/agents" && currentPath.startsWith("/v2/agents/"))
+            normalizedPath.startsWith("/v2/library/")) ||
+          (item.path === "/v2/agents" &&
+            normalizedPath.startsWith("/v2/agents/")) ||
+          (item.path === "/v2/fleet" &&
+            normalizedPath.startsWith("/v2/fleet/")) ||
+          (item.path === "/v2/metrics" &&
+            normalizedPath.startsWith("/v2/metrics/"))
 
         return (
           <SidebarMenuItem key={item.title}>

--- a/src/routes/v2/fleet.tsx
+++ b/src/routes/v2/fleet.tsx
@@ -14,9 +14,18 @@ export const Route = createFileRoute("/v2/fleet")({
 })
 
 function FleetRoute() {
-  const isDetailRoute = useRouterState({
-    select: (state) => state.location.pathname !== "/v2/fleet",
-  })
+  const router = useRouterState()
+  const pathname = router.location.pathname
 
-  return isDetailRoute ? <Outlet /> : <FleetPage />
+  // Child route /v2/fleet/$sessionId renders via Outlet (same pattern as library).
+  // A bare /v2/fleet/ (trailing slash, no session id) must still render FleetPage —
+  // otherwise a hard refresh paints a blank screen and the Fleet tab stays unselected.
+  if (
+    pathname.startsWith("/v2/fleet/") &&
+    pathname.replace(/\/+$/, "") !== "/v2/fleet"
+  ) {
+    return <Outlet />
+  }
+
+  return <FleetPage />
 }

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -174,6 +174,23 @@ test("direct specialist URL renders detail instead of the agents grid", async ({
   ).toHaveCount(0)
 })
 
+test("hard refresh on /v2/agents/ keeps Profiles selected and renders content", async ({
+  page,
+}) => {
+  await mockAgentsShell(page)
+
+  await page.goto("/v2/agents/")
+  await page.reload()
+
+  await expect(page.getByRole("link", { name: "Profiles" })).toHaveAttribute(
+    "data-active",
+    "true",
+  )
+  await expect(
+    page.getByRole("heading", { name: "Profiles", level: 1 }),
+  ).toBeVisible()
+})
+
 test("agent detail navigation does not flash no-access or not-found", async ({
   page,
 }) => {

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -248,6 +248,21 @@ async function mockFleet(
   })
 }
 
+test("hard refresh on /v2/fleet/ keeps Fleet selected and renders content", async ({
+  page,
+}) => {
+  await mockFleet(page)
+  await page.goto("/v2/fleet/")
+  await page.reload()
+
+  await expect(page.getByRole("link", { name: "Fleet" })).toHaveAttribute(
+    "data-active",
+    "true",
+  )
+  await expect(page.getByRole("heading", { name: "Fleet" })).toBeVisible()
+  await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
+})
+
 test("Fleet renders the calm roster from live API data", async ({ page }) => {
   await mockFleet(page)
   await page.goto("/v2/fleet")

--- a/tests/taskforce-routing.spec.ts
+++ b/tests/taskforce-routing.spec.ts
@@ -101,3 +101,18 @@ test("legacy settings route redirects into the Taskforce shell", async ({
     page.getByRole("tab", { name: "Connect agent" }),
   ).toHaveAttribute("aria-selected", "true")
 })
+
+test("hard refresh on /v2/library/ keeps Library selected and renders content", async ({
+  page,
+}) => {
+  await mockAuth(page)
+
+  await page.goto("/v2/library/")
+  await page.reload()
+
+  await expect(page.getByRole("link", { name: "Library" })).toHaveAttribute(
+    "data-active",
+    "true",
+  )
+  await expect(page.getByRole("heading", { name: "Library" })).toBeVisible()
+})


### PR DESCRIPTION
## Summary
- Fix Fleet route to use the same child-route Outlet handoff as Library/Agents, so `/v2/fleet/` (trailing slash from static Pages entrypoints) renders `FleetPage` instead of a blank Outlet.
- Normalize sidebar tab active-state matching (strip trailing slashes; highlight Fleet and Metrics on child routes).

## Test plan
- [x] Added Playwright regression tests for hard refresh on `/v2/fleet/`, `/v2/library/`, and `/v2/agents/`
- [ ] CI Playwright suite


Made with [Cursor](https://cursor.com)