### PR TITLE
Library: tighten recent reel spacing and rename to Recently viewed

### DIFF
--- a/src/components/V2/Library/LibraryRecentReel.tsx
+++ b/src/components/V2/Library/LibraryRecentReel.tsx
@@ -125,7 +125,7 @@ function RecentCard({
 }
 
 /**
- * Expressive "Recently accessed" reel — the top half of the hybrid Library. Shows
+ * Expressive "Recently viewed" reel — the top half of the hybrid Library. Shows
  * the most recently updated documents as cards above the folder/file list.
  */
 export function LibraryRecentReel({
@@ -146,10 +146,10 @@ export function LibraryRecentReel({
   if (recent.length === 0) return null
 
   return (
-    <section aria-label="Recently accessed" className="shrink-0">
-      <div className="mb-3">
+    <section aria-label="Recently viewed" className="shrink-0">
+      <div className="mb-2">
         <span className="font-mono text-[10px] tracking-[0.01em] text-foreground">
-          Recently accessed
+          Recently viewed
         </span>
       </div>
       <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">

--- a/src/routes/v2/library.tsx
+++ b/src/routes/v2/library.tsx
@@ -721,7 +721,7 @@ function TaskforceLibrary() {
           "-mb-6 bg-background font-sans text-foreground md:-mb-8",
         )}
       >
-        <div className={V2_PAGE_BODY}>
+        <div className={cn(V2_PAGE_BODY, "gap-3")}>
           <div className={V2_TAB_HEADER_STACK_CLASS}>
             <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
               <div>
@@ -815,7 +815,7 @@ function TaskforceLibrary() {
             onConfirm={(document) => deleteDocumentMutation.mutate(document.id)}
           />
 
-          <div className={V2_TAB_CONTENT_CLASS}>
+          <div className={cn(V2_TAB_CONTENT_CLASS, "gap-3 pt-2")}>
           {hasInitialLoadError ? (
             <QueryErrorState
               title="Could not load the library"


### PR DESCRIPTION
## Summary
- Rename the Library recent-documents section from **Recently accessed** to **Recently viewed**
- Reduce vertical gap above that section: tighter page-body gap (`gap-3`), content stack padding (`pt-2`), and section heading margin

## Test plan
- [ ] Open `/v2/library` with documents present
- [ ] Confirm scope filter tabs sit closer to the **Recently viewed** heading
- [ ] Confirm label reads **Recently viewed** (not "Recently accessed")
- [ ] Confirm folder grid spacing below the reel still looks balanced


Made with [Cursor](https://cursor.com)