### PR TITLE
Fleet: align collapsed session header height and contents

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -169,7 +169,7 @@
   display: grid;
   grid-template-columns: 26px minmax(200px, min(360px, 34vw)) minmax(0, 1fr) auto 64px;
   gap: 18px;
-  align-items: start;
+  align-items: center;
   width: 100%;
   padding: 16px 18px;
   border-bottom: 1px solid var(--fl-hair);
@@ -189,7 +189,6 @@
 }
 
 .arowMenu {
-  align-self: center;
   color: var(--fl-faint);
 }
 
@@ -221,7 +220,6 @@
 .dragCell {
   display: flex;
   align-items: center;
-  align-self: center;
   gap: 3px;
   width: 26px;
 }
@@ -323,6 +321,7 @@
 /* work */
 .work {
   min-width: 0;
+  align-self: center;
 }
 
 .workSummary {
@@ -373,10 +372,12 @@
 
 /* age */
 .age {
+  align-self: center;
   color: var(--fl-faint);
   font-family: var(--font-mono);
   font-size: calc(11px * var(--v2-scale, 1));
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
   text-align: right;
 }
 
@@ -1017,25 +1018,24 @@
   .arow {
     grid-template-columns: 26px minmax(0, 1fr) auto auto;
     gap: 12px;
-    align-items: start;
+    align-items: center;
   }
 
   .arow .work {
     grid-row: 2;
     grid-column: 2 / 4;
+    align-self: start;
     text-align: left;
   }
 
   .arow .age {
     grid-row: 1;
     grid-column: 3;
-    margin-top: 0;
   }
 
   .arowMenu {
     grid-row: 1;
     grid-column: 4;
-    margin-top: 0;
   }
 
   .dmain,

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -380,39 +380,6 @@
   text-align: right;
 }
 
-/* new-agent (card footer) */
-.newagent {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 11px 18px;
-  border-top: 1px solid var(--fl-hair);
-  color: var(--fl-faint);
-  font-family: var(--font-mono);
-  font-size: calc(11.5px * var(--v2-scale, 1));
-  letter-spacing: 0.02em;
-  white-space: nowrap;
-  cursor: pointer;
-}
-
-.newagent svg {
-  width: 13px;
-  height: 13px;
-  flex-shrink: 0;
-}
-
-.newagent span {
-  overflow: hidden;
-  min-width: 0;
-  text-overflow: ellipsis;
-}
-
-.newagent:hover {
-  background: var(--fl-hair);
-  color: var(--muted-foreground);
-}
-
 .emptyRows {
   padding: 18px;
   color: var(--fl-faint);

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -61,7 +61,8 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  min-height: 48px;
+  box-sizing: border-box;
+  height: 48px;
   padding: 10px 18px;
   border-bottom: 1px solid var(--fl-hair);
 }
@@ -989,6 +990,8 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 7px 10px;
+    height: auto;
+    min-height: 48px;
   }
 
   .fheadToggle {

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -59,9 +59,10 @@
 
 .fhead {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 12px;
-  padding: 14px 18px;
+  min-height: 48px;
+  padding: 10px 18px;
   border-bottom: 1px solid var(--fl-hair);
 }
 
@@ -71,7 +72,7 @@
 
 .fheadToggle {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 12px;
   min-width: 0;
   flex: 1;
@@ -134,13 +135,20 @@
   display: inline-flex;
   flex-shrink: 0;
   align-items: center;
-  margin-left: auto;
   gap: 6px;
   color: var(--fl-faint);
   font-family: var(--font-mono);
   font-size: calc(11px * var(--v2-scale, 1));
   letter-spacing: 0.01em;
   white-space: nowrap;
+}
+
+.fheadMeta {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
 }
 
 .pin {
@@ -152,7 +160,7 @@
 }
 
 .fmenu {
-  margin-left: 4px;
+  flex-shrink: 0;
   color: var(--fl-faint);
 }
 
@@ -1017,7 +1025,7 @@
 
   .fheadToggle {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
     gap: 7px 10px;
     width: 100%;
@@ -1026,6 +1034,12 @@
   .fheadToggle .frepo {
     grid-row: 2;
     grid-column: 2 / -1;
+  }
+
+  .fheadMeta {
+    width: 100%;
+    justify-content: flex-end;
+    margin-left: 0;
   }
 
   .fcount,

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -503,15 +503,6 @@ function FleetCard({
               ))
             )}
           </div>
-
-          <Link
-            to="/v2/settings"
-            search={{ tab: "connect-agent" }}
-            className={styles.newagent}
-          >
-            <Plus />
-            <span>New agent in {fleetTitle(fleet)}</span>
-          </Link>
         </>
       )}
     </section>

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -62,6 +62,7 @@ import {
   type FleetStatus,
   fleetRepo,
   fleetTitle,
+  rosterWorkSummary,
   runningCount,
   STATE_LABEL,
   waitingCount,
@@ -216,7 +217,7 @@ function AgentRow({
         </div>
         <div className={styles.work}>
           <div className={styles.workSummary}>
-            {agent.summary_markdown || "No current work captured yet"}
+            {rosterWorkSummary(agent)}
           </div>
           {docTitle && (
             <div className={styles.detailLine}>

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -425,6 +425,11 @@ function FleetCard({
               ) : (
                 <span className={styles.frepo}>no repo bound</span>
               ))}
+          </button>
+        )}
+
+        {!renaming && (
+          <div className={styles.fheadMeta}>
             <span className={styles.fcount}>
               {running > 0 ? (
                 <>
@@ -435,42 +440,41 @@ function FleetCard({
                 `${total} ${total === 1 ? "agent" : "agents"}`
               )}
             </span>
-          </button>
-        )}
-
-        {!renaming && !isHistory && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label={`${fleetTitle(fleet)} actions`}
-                className={styles.fmenu}
-                onClick={(event) => event.stopPropagation()}
-              >
-                <MoreHorizontal />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                onSelect={() => {
-                  setName(fleet.name ?? "")
-                  setRenaming(true)
-                }}
-              >
-                <Pencil />
-                Rename
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                variant="destructive"
-                onSelect={() => onDelete(fleet)}
-              >
-                <Trash2 />
-                Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+            {!isHistory && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={`${fleetTitle(fleet)} actions`}
+                    className={styles.fmenu}
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    <MoreHorizontal />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      setName(fleet.name ?? "")
+                      setRenaming(true)
+                    }}
+                  >
+                    <Pencil />
+                    Rename
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onSelect={() => onDelete(fleet)}
+                  >
+                    <Trash2 />
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
         )}
       </div>
 

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -143,7 +143,7 @@ export function liveActivityLabel(
   const summary = agent.summary_markdown?.trim()
 
   if (status === "run") {
-    return summary || "Actively working on this session"
+    return summary || "Running in this terminal"
   }
   if (status === "waiting") {
     return "Waiting for your input"

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -157,6 +157,35 @@ export function liveActivityLabel(
   return "Connected but not actively running"
 }
 
+/** Roster work column — prefer captured summary, else status-aware fallback. */
+export function rosterWorkSummary(agent: TaskforceFleetAgent): string {
+  const summary = agent.summary_markdown?.trim()
+  if (summary) return summary
+
+  const status = agentStatus(agent)
+  if (status === "run") return "Running in this terminal"
+  if (status === "waiting") return "Waiting for your input"
+  if (status === "paused" || agentCapturePaused(agent)) {
+    return "Activity capture is paused"
+  }
+  return "No current work captured yet"
+}
+
+/** Session detail "Working on" body when no summary is stored yet. */
+export function sessionWorkSummary(agent: TaskforceFleetAgent): string {
+  const summary = agent.summary_markdown?.trim()
+  if (summary) return summary
+
+  const status = agentStatus(agent)
+  if (status === "run") {
+    return "Running in this terminal. A summary appears after Taskforce capture records work."
+  }
+  if (status === "paused" || agentCapturePaused(agent)) {
+    return "Activity capture is paused, so no summary is being updated."
+  }
+  return "No summary has been captured for this session yet."
+}
+
 /** Locale-aware date and time in the browser's local timezone. */
 export function formatLocalDateTime(iso: string): string {
   const date = new Date(iso)

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -32,6 +32,7 @@ import {
   liveActivityTime,
   modelLabel,
   presenceLabel,
+  sessionWorkSummary,
   STATE_LABEL,
 } from "@/components/V2/Fleet/fleetStatus"
 import { cn } from "@/lib/utils"
@@ -272,10 +273,7 @@ function FleetAgentDetailRoute() {
           ) : (
             <div className={styles.section}>
               <div className={styles.seclabel}>Working on</div>
-              <div className={styles.nowtask}>
-                {agent.summary_markdown ||
-                  "No summary has been captured for this session yet."}
-              </div>
+              <div className={styles.nowtask}>{sessionWorkSummary(agent)}</div>
             </div>
           )}
 

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -481,6 +481,66 @@ test("activity timeline live head shows running without summary", async ({
 
   await expect(page.getByText("now", { exact: true })).toBeVisible()
   await expect(page.getByText("Running in this terminal")).toBeVisible()
+  await expect(
+    page.getByText(
+      "Running in this terminal. A summary appears after Taskforce capture records work.",
+    ),
+  ).toBeVisible()
+})
+
+test("roster shows running placeholder when summary is empty", async ({
+  page,
+}) => {
+  await mockFleet(page, {
+    agentOverrides: {
+      status: "running",
+      summary_markdown: "",
+      minutes_ago: 0,
+    },
+  })
+  await page.goto("/v2/fleet")
+
+  const row = page.getByTestId("fleet-agent-row")
+  await expect(row.getByText("Running in this terminal")).toBeVisible()
+  await expect(row.getByText("No current work captured yet")).toHaveCount(0)
+
+  const [dotBox, ageBox, menuBox] = await Promise.all([
+    row.getByTestId("fleet-status-dot").boundingBox(),
+    row.getByText("now", { exact: true }).boundingBox(),
+    row
+      .getByRole("button", {
+        name: "Wiring automatic tax on Stripe checkout actions",
+      })
+      .boundingBox(),
+  ])
+  const midY = (box: { y: number; height: number } | null) =>
+    box ? box.y + box.height / 2 : 0
+  expect(Math.abs(midY(dotBox) - midY(ageBox))).toBeLessThan(6)
+  expect(Math.abs(midY(dotBox) - midY(menuBox))).toBeLessThan(6)
+})
+
+test("collapsed fleet cards share header height", async ({ page }) => {
+  await mockFleet(page)
+  await page.goto("/v2/fleet")
+
+  await page.getByTestId("fleet-header-toggle-fleet-1").click()
+  await expect(page.getByTestId("fleet-card-fleet-1")).toHaveAttribute(
+    "data-collapsed",
+    "true",
+  )
+
+  const headerHeight = (card: ReturnType<Page["getByTestId"]>) =>
+    card.locator(":scope > div").first().evaluate((el) => {
+      return el.getBoundingClientRect().height
+    })
+
+  const historyCard = page.getByTestId("fleet-card-fleet-history")
+  const workCard = page.getByTestId("fleet-card-fleet-1")
+  const [historyHeight, workHeight] = await Promise.all([
+    headerHeight(historyCard),
+    headerHeight(workCard),
+  ])
+  expect(Math.abs(historyHeight - workHeight)).toBeLessThan(2)
 })
 
 test("activity timeline live head shows waiting state", async ({ page }) => {

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -480,7 +480,9 @@ test("activity timeline live head shows running without summary", async ({
   await page.goto("/v2/fleet/session-1")
 
   await expect(page.getByText("now", { exact: true })).toBeVisible()
-  await expect(page.getByText("Running in this terminal")).toBeVisible()
+  await expect(
+    page.getByText("Running in this terminal", { exact: true }),
+  ).toBeVisible()
   await expect(
     page.getByText(
       "Running in this terminal. A summary appears after Taskforce capture records work.",
@@ -589,7 +591,9 @@ test("activity timeline live head shows paused capture state", async ({
   await page.goto("/v2/fleet/session-1")
 
   await expect(page.getByText("1m", { exact: true })).toBeVisible()
-  await expect(page.getByText("Activity capture is paused")).toBeVisible()
+  await expect(
+    page.getByText("Activity capture is paused", { exact: true }),
+  ).toBeVisible()
 })
 
 test("Fleet session collapse defaults and persists", async ({ page }) => {

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -467,6 +467,22 @@ test("activity timeline shows the full canonical event stream and exact Ledger l
   expect(href).toContain("event_id=event-command")
 })
 
+test("activity timeline live head shows running without summary", async ({
+  page,
+}) => {
+  await mockFleet(page, {
+    agentOverrides: {
+      status: "running",
+      summary_markdown: "",
+      minutes_ago: 0,
+    },
+  })
+  await page.goto("/v2/fleet/session-1")
+
+  await expect(page.getByText("now", { exact: true })).toBeVisible()
+  await expect(page.getByText("Running in this terminal")).toBeVisible()
+})
+
 test("activity timeline live head shows waiting state", async ({ page }) => {
   await mockFleet(page, {
     agentOverrides: {


### PR DESCRIPTION
## Summary
- Collapsed work and History fleet cards now share the same header `min-height` and vertical centering
- Agent count and fleet actions menu sit in a shared right-side meta cluster instead of splitting across the toggle button and a sibling control
- Fixes misaligned ellipsis menu and uneven collapsed row heights between Session and History

## Test plan
- [ ] Collapse a work fleet and History — headers should be the same height
- [ ] Session name, repo line, agent count, and ⋯ menu vertically centered on one row
- [ ] Mobile breakpoint: meta cluster still aligns to the right when header wraps


Made with [Cursor](https://cursor.com)