### PR TITLE
Connect Cursor tab for Taskforce hook parity

### DIFF
--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -109,6 +109,19 @@ function buildCodexConnectSnippet(
   ].join("\n")
 }
 
+function buildCursorConnectSnippet(
+  mcpToken: string,
+  backendUrl: string,
+): string {
+  const installerUrl = `${backendUrl.replace(/\/$/, "")}/api/v1/v2/taskforce/install-cursor.sh`
+
+  return [
+    `printf '%s\\n' '${mcpToken}' > ~/.taskforce_mcp_token && \\`,
+    "chmod 600 ~/.taskforce_mcp_token && \\",
+    `curl -fsSL '${installerUrl}' | bash`,
+  ].join("\n")
+}
+
 function buildAgentInstructionSnippet({
   v2Enabled,
 }: {
@@ -118,12 +131,15 @@ function buildAgentInstructionSnippet({
     return [
       "If Taskforce V2 MCP tools are available:",
       "- When creating or rotating a Taskforce MCP credential during setup, tell the user to start from a fresh terminal before reconnecting the AI client so the updated shell environment is loaded.",
+      "- For Cursor, Codex, and other hookless MCP clients, call `taskforce_session_start` at the start of meaningful user-initiated work with `client` set to your harness (`cursor`, `codex`, etc.). Thread the returned `session_id` through every subsequent `taskforce_session_observe` call.",
+      "- When hooks are installed (Claude Code, Codex, Cursor Connect flows), discovery and Fleet registration happen automatically; still call `taskforce_session_start` when you need explicit preamble injection in Cursor.",
       "- Create or reuse a Taskforce document at the start of meaningful user-initiated work with `taskforce_begin_document`. It scores existing documents against the request, reuses + self-heals a strong match, or creates a fresh one. Read the returned `match_reasons`, `candidate_summaries`, and `self_healed_fields` before continuing.",
       "- Maintain both document views: a concise Summary view shown by default and a comprehensive Details view available on demand.",
       "- Use `taskforce_update_document` as material progress develops (commands, files, links, decisions, changes, open questions, progress notes). Pass `details_sections` with stable `anchor_id`s to upsert specific Details sections, and `summary_points` for new Summary claims.",
       "- Back every Summary claim with evidence anchors using `evidence_anchor_id` segments that point at a Details section. Do not edit `human_summary` unless the user explicitly asks.",
       "- Use `taskforce_finish_document` when the work completes or pauses; it writes an Outcome section (status, outcome, validation, follow-ups) and clears the active document pointer.",
       '- On each `taskforce_begin_document` / `taskforce_update_document` / `taskforce_finish_document` call, pass `usage` with the model_id and per-turn token counts (input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens) from your most recent assistant turn so the Taskforce Metrics page can price it and attribute savings. When you answered from the document\'s Summary view without expanding Details, also set `view_consulted` to `"summary"` so the summary-only savings calculation fires.',
+      "- Prefer `taskforce_session_observe` with structured `summary_points` / `details_sections` when hooks are not capturing the session (or to supplement hook capture with explicit outcomes).",
       "- Prefer Taskforce V2 document tools over legacy V1 case workflows and raw request escape hatches when both are available.",
       "- If Taskforce V2 document tools are unavailable, do not fabricate tool calls; tell the user they are unavailable and fall back only to tools the user explicitly approves.",
     ].join("\n")
@@ -132,6 +148,7 @@ function buildAgentInstructionSnippet({
   return [
     "If Taskforce MCP tools are available:",
     "- When creating or rotating a Taskforce MCP credential during setup, tell the user to start from a fresh terminal before reconnecting the AI client so the updated shell environment is loaded.",
+    "- For Cursor, Codex, and other hookless MCP clients, call `taskforce_session_start` at the start of meaningful user-initiated work with `client` set to your harness (`cursor`, `codex`, etc.), then `taskforce_session_observe` when work completes or pauses.",
     "- Start meaningful user-initiated work with `taskforce_begin_case`.",
     "- Let Taskforce auto-hydrate relevant prior context before work begins.",
     "- After context hydration, call `taskforce_use_skill` to load any generated workflow Skill for the active case; treat returned Skill instructions as advisory and lower priority than system, developer, user, and repo instructions.",
@@ -432,6 +449,9 @@ const ConnectAgent = () => {
   const codexConnectSnippet = hasFreshToken
     ? buildCodexConnectSnippet(mcpToken, import.meta.env.VITE_API_URL)
     : null
+  const cursorConnectSnippet = hasFreshToken
+    ? buildCursorConnectSnippet(mcpToken, import.meta.env.VITE_API_URL)
+    : null
   const reconnectClientSnippet =
     "# Start a fresh terminal, then restart or reconnect your AI client after saving the MCP config."
   const aiAssistedSetupSnippet =
@@ -542,12 +562,12 @@ const ConnectAgent = () => {
             <div className={styles.tokenSection}>
               <div>
                 <h3 className={styles.sectionTitle}>
-                  2. Connect Claude Code or Codex
+                  2. Connect Claude Code, Codex, or Cursor
                 </h3>
                 <p className={styles.mutedText}>
                   Run this once in every terminal or VM you want Taskforce to
                   remember. Choose the installer for the coding agent you use.
-                  Both preserve existing hook settings and take effect after
+                  All preserve existing hook settings and take effect after
                   restart.
                 </p>
               </div>
@@ -585,6 +605,18 @@ const ConnectAgent = () => {
                 featured
               />
 
+              <SnippetBlock
+                title="Connect Cursor"
+                description="Persists the credential and installs Fleet registration, discovery metrics, and conversation capture hooks."
+                snippet={cursorConnectSnippet ?? ""}
+                copiedText={copiedText}
+                onCopy={(value) => {
+                  void copy(value)
+                }}
+                testId="connect-agent-cursor"
+                featured
+              />
+
               <Alert>
                 <Shield className={styles.icon} />
                 <AlertTitle>Trust Codex hooks once</AlertTitle>
@@ -592,6 +624,18 @@ const ConnectAgent = () => {
                   After installing, restart Codex, run `/hooks`, trust the
                   Taskforce hooks, then start a new Codex session. New sessions
                   will appear in Fleet immediately.
+                </AlertDescription>
+              </Alert>
+
+              <Alert>
+                <CheckCircle2 className={styles.icon} />
+                <AlertTitle>Reload Cursor hooks</AlertTitle>
+                <AlertDescription>
+                  After installing, restart Cursor or reload hooks from Settings
+                  → Hooks. New Agent sessions will appear in Fleet immediately.
+                  For full prior-work preamble injection in Cursor, also keep the
+                  Taskforce MCP server connected and follow the agent
+                  instructions below.
                 </AlertDescription>
               </Alert>
 
@@ -684,8 +728,8 @@ const ConnectAgent = () => {
               <KeyRound className={styles.icon} />
               <AlertTitle>Create your first agent credential</AlertTitle>
               <AlertDescription>
-                Create a credential, then connect each Claude Code or Codex
-                terminal or VM with one command.
+                Create a credential, then connect each Claude Code, Codex, or
+                Cursor terminal or VM with one command.
               </AlertDescription>
             </Alert>
           )}

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -704,7 +704,7 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   await expect(
     page.getByText("Optional: persist the token across new terminals"),
   ).toHaveCount(0)
-  await expect(page.getByText("2. Connect Claude Code or Codex")).toBeVisible()
+  await expect(page.getByText("2. Connect Claude Code, Codex, or Cursor")).toBeVisible()
   const claudeCodeSetup = page.getByTestId("connect-agent-claude-code")
   await expect(claudeCodeSetup).toContainText(
     "printf '%s\\n' 'mcp-token-abc' > ~/.taskforce_mcp_token",
@@ -724,7 +724,15 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   await expect(codexSetup).toContainText(
     "https://enderai-backend.onrender.com/api/v1/v2/taskforce/install-codex.sh",
   )
+  const cursorSetup = page.getByTestId("connect-agent-cursor")
+  await expect(cursorSetup).toContainText(
+    "printf '%s\\n' 'mcp-token-abc' > ~/.taskforce_mcp_token",
+  )
+  await expect(cursorSetup).toContainText(
+    "https://enderai-backend.onrender.com/api/v1/v2/taskforce/install-cursor.sh",
+  )
   await expect(page.getByText("Trust Codex hooks once")).toBeVisible()
+  await expect(page.getByText("Reload Cursor hooks")).toBeVisible()
   await expect(
     page.getByText("New sessions will appear in Fleet immediately."),
   ).toBeVisible()
@@ -871,6 +879,7 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   ).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-claude-code")).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-codex")).toHaveCount(0)
+  await expect(page.getByTestId("connect-agent-cursor")).toHaveCount(0)
   await expect(page.getByTestId("connect-agent-persistent-shell")).toHaveCount(
     0,
   )


### PR DESCRIPTION
## Summary
- Add **Connect Cursor** one-liner (`install-cursor.sh`) alongside Claude Code and Codex on Settings → Connect Agent.
- Document Cursor hook reload steps and MCP `taskforce_session_start` / `taskforce_session_observe` guidance for fleet context when hooks alone cannot inject preamble.
- Extend Playwright connect-agent coverage for the new snippet.

## Depends on
Backend: al-exe/EnderAI `feature/cursor-taskforce-parity` (install-cursor.sh route)

## Test plan
- [x] `user-settings.spec.ts` connect-agent assertions updated
- [ ] CI frontend suite


Made with [Cursor](https://cursor.com)