### PR TITLE
Refine landing page presentation

### DIFF
--- a/src/components/V2/Landing/ClosingCta.tsx
+++ b/src/components/V2/Landing/ClosingCta.tsx
@@ -10,7 +10,7 @@ export function ClosingCta() {
     <section className={styles.ctaBand}>
       <div className={styles.ctaInner}>
         <h2>
-          Stop starting from <em>scratch</em>.
+          Stop starting from <em>scratch</em>. Start using Taskforce.
         </h2>
         <div className={styles.heroCtas}>
           <Button asChild className={styles.solidButton}>

--- a/src/components/V2/Landing/ClosingCta.tsx
+++ b/src/components/V2/Landing/ClosingCta.tsx
@@ -12,7 +12,6 @@ export function ClosingCta() {
         <h2>
           Stop starting from <em>scratch</em>.
         </h2>
-        <p>Works with Claude Code, Codex, and Cursor.</p>
         <div className={styles.heroCtas}>
           <Button asChild className={styles.solidButton}>
             <Link to="/signup">

--- a/src/components/V2/Landing/FeatureSection.tsx
+++ b/src/components/V2/Landing/FeatureSection.tsx
@@ -78,7 +78,9 @@ function FeatureRow({
           <span>{label}</span>
         </div>
         <h2>{title}</h2>
-        <p>{body}</p>
+        <p className={cn(id === "profiles" && styles.profileFeatureBody)}>
+          {body}
+        </p>
       </div>
       <div className={styles.visual}>{visual}</div>
     </div>
@@ -201,9 +203,6 @@ function ProfilePanel() {
     <Panel chip="active" label="Profile">
       <div className={styles.profileBody}>
         <div className={styles.profileHead}>
-          <div className={styles.avatar}>
-            <Bot />
-          </div>
           <div>
             <div className={styles.profileName}>Payments Specialist</div>
             <div className={styles.profileRole}>role - billing & checkout</div>
@@ -275,6 +274,12 @@ function LibraryPanel() {
           reused="Reused 2x"
           signal="Updated 5d ago"
           title="PG16 migration notes"
+        />
+        <DocumentRow
+          path="/agents/profile-routing.md"
+          reused="Reused 7x"
+          signal="Updated 1w ago"
+          title="Profile routing rules"
         />
       </div>
     </Panel>

--- a/src/components/V2/Landing/FeatureSection.tsx
+++ b/src/components/V2/Landing/FeatureSection.tsx
@@ -175,14 +175,16 @@ function FleetGroup({
           <div className={styles.agentCard} key={agent.name}>
             <div className={styles.agentTop}>
               <span>{agent.name}</span>
+            </div>
+            <div className={styles.agentTask}>
               <span
                 className={cn(
-                  styles.statusDot,
+                  styles.actionStatus,
                   agent.accent === "amber" ? styles.amberDot : styles.greenDot,
                 )}
               />
+              <span className={styles.agentTaskText}>{agent.task}</span>
             </div>
-            <div className={styles.agentTask}>{agent.task}</div>
             <div className={styles.agentMeta}>
               <span>{agent.tool}</span>
               <span>{agent.host}</span>

--- a/src/components/V2/Landing/Hero.tsx
+++ b/src/components/V2/Landing/Hero.tsx
@@ -164,7 +164,7 @@ export function LandingHero() {
                 className={cn(styles.heroCap, isSwapping && styles.swapping)}
               >
                 <span className={styles.capKey}>{scene.key}</span>
-                <span className={styles.capSep}>.</span>
+                <span className={styles.capSep}>·</span>
                 <span>{scene.name}</span>
               </div>
               <div
@@ -185,7 +185,6 @@ export function LandingHero() {
                 ))}
               </div>
               <div className={styles.works}>
-                <span className={styles.workDot} />
                 Works with Claude Code, Codex, and Cursor.
               </div>
               <div className={styles.heroCtas}>

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -730,6 +730,10 @@
   text-wrap: pretty;
 }
 
+.featureCopy .profileFeatureBody {
+  font-size: 18.4px;
+}
+
 .featureLabel {
   display: flex;
   align-items: center;
@@ -1021,7 +1025,7 @@
   grid-template-columns: 18px 1fr auto;
   align-items: center;
   gap: 11px;
-  padding: 11px 12px;
+  padding: 9px 12px;
   border: 1px solid transparent;
 }
 

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -71,8 +71,8 @@
   align-items: center;
   max-width: var(--landing-max);
   margin: 0 auto;
-  padding: 14px 32px;
-  gap: 28px;
+  padding: 17.5px 32px;
+  gap: 35px;
 }
 
 .brand,
@@ -92,10 +92,20 @@
   height: 20px;
 }
 
+.brand {
+  gap: 11px;
+  font-size: 20px;
+}
+
+.brand .brandMark {
+  width: 25px;
+  height: 25px;
+}
+
 .navLinks {
   display: flex;
-  gap: 22px;
-  margin-left: 8px;
+  gap: 27.5px;
+  margin-left: 10px;
 }
 
 .navLinks a,
@@ -108,6 +118,10 @@
   transition: color 150ms ease;
 }
 
+.navLinks a {
+  font-size: 14.375px;
+}
+
 .navLinks a:hover,
 .footerLinks a:hover {
   color: var(--landing-fg);
@@ -116,19 +130,19 @@
 .navRight {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 15px;
   margin-left: auto;
 }
 
 .navCta {
   display: flex;
-  gap: 8px;
+  gap: 10px;
 }
 
 .themeToggle {
   position: relative;
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   padding: 0;
   border-color: var(--landing-border);
   background: var(--landing-bg);
@@ -141,17 +155,17 @@
 }
 
 .themeToggle svg {
-  width: 15px;
-  height: 15px;
+  width: 18.75px;
+  height: 18.75px;
 }
 
 .solidButton,
 .outlineButton {
   height: auto;
   border-radius: 0;
-  padding: 9px 15px;
+  padding: 11.25px 18.75px;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 15px;
   font-weight: 500;
   letter-spacing: 0.02em;
 }
@@ -180,7 +194,7 @@
 }
 
 .hero {
-  --nav-h: 61px;
+  --nav-h: 77px;
   position: relative;
   display: flex;
   overflow: hidden;
@@ -222,7 +236,7 @@
   z-index: 1;
   display: grid;
   flex: 1 1 auto;
-  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.1fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   align-items: stretch;
   gap: 46px;
 }
@@ -282,7 +296,7 @@
   margin-bottom: 22px;
   color: var(--landing-muted);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 15px;
   letter-spacing: 0.04em;
   transition: opacity 260ms ease;
 }
@@ -335,13 +349,6 @@
   font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 0.04em;
-}
-
-.workDot {
-  width: 5px;
-  height: 5px;
-  border-radius: 999px;
-  background: var(--landing-positive);
 }
 
 .heroCtas {
@@ -730,7 +737,7 @@
   margin-bottom: 18px;
   color: var(--landing-primary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 13.75px;
   font-weight: 500;
   letter-spacing: 0.02em;
 }
@@ -739,16 +746,16 @@
   display: grid;
   flex-shrink: 0;
   place-items: center;
-  width: 34px;
-  height: 34px;
+  width: 42.5px;
+  height: 42.5px;
   border: 1px solid var(--landing-primary-line);
   background: var(--landing-primary-soft);
   color: var(--landing-primary);
 }
 
 .featureIcon svg {
-  width: 18px;
-  height: 18px;
+  width: 22.5px;
+  height: 22.5px;
 }
 
 .visual {
@@ -857,14 +864,26 @@
   white-space: nowrap;
 }
 
-.agentTop .statusDot {
-  margin-left: auto;
-}
-
 .agentTask {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
   color: var(--landing-muted);
   font-size: 11px;
   line-height: 1.4;
+}
+
+.actionStatus {
+  width: 7px;
+  height: 7px;
+  flex-shrink: 0;
+  margin-top: 4px;
+  animation: actionGlow 1800ms ease-in-out infinite;
+}
+
+.agentTaskText {
+  color: var(--landing-muted);
+  animation: actionTextGlow 1800ms ease-in-out infinite;
 }
 
 .agentMeta {
@@ -1260,7 +1279,7 @@
 }
 
 .ctaInner h2 {
-  margin: 0 0 16px;
+  margin: 0 0 28px;
   font-size: clamp(30px, 4vw, 44px);
   font-weight: 600;
   line-height: 1.05;
@@ -1271,14 +1290,6 @@
 .ctaInner h2 em {
   color: var(--landing-primary);
   font-style: normal;
-}
-
-.ctaInner p {
-  margin: 0 0 28px;
-  color: var(--landing-faint);
-  font-family: var(--font-mono);
-  font-size: 12px;
-  letter-spacing: 0.04em;
 }
 
 .footer {
@@ -1414,6 +1425,30 @@
   }
   50% {
     transform: translateY(5px);
+  }
+}
+
+@keyframes actionGlow {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 0%, transparent);
+    opacity: 1;
+  }
+  50% {
+    box-shadow: 0 0 10px 2px currentColor;
+    opacity: 0.58;
+  }
+}
+
+@keyframes actionTextGlow {
+  0%,
+  100% {
+    opacity: 1;
+    text-shadow: none;
+  }
+  50% {
+    opacity: 0.72;
+    text-shadow: 0 0 8px color-mix(in srgb, currentColor 35%, transparent);
   }
 }
 

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -1176,17 +1176,6 @@
   font-size: 15px;
 }
 
-.proofTag {
-  display: inline-block;
-  margin-bottom: 10.5px;
-  padding: 3px 8px;
-  border: 1px solid var(--landing-border);
-  color: var(--landing-faint);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.12em;
-}
-
 .metricsCard {
   justify-content: center;
   padding: 18px;

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -699,13 +699,13 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   align-items: center;
-  gap: 64px;
-  padding: 64px 0;
+  gap: 48px;
+  padding: 48px 0;
   border-top: 1px solid var(--landing-hairline);
 }
 
 .features .featureRow:first-child {
-  padding-top: 32px;
+  padding-top: 24px;
   border-top: 0;
 }
 
@@ -738,7 +738,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 18px;
+  margin-bottom: 13.5px;
   color: var(--landing-primary);
   font-family: var(--font-mono);
   font-size: 13.75px;
@@ -1164,7 +1164,8 @@
 }
 
 .proofRow {
-  padding: 56px 0 64px;
+  padding: 42px 0 48px;
+  border-top: 1px solid var(--landing-hairline);
 }
 
 .proofRow h2 {
@@ -1177,7 +1178,7 @@
 
 .proofTag {
   display: inline-block;
-  margin-bottom: 14px;
+  margin-bottom: 10.5px;
   padding: 3px 8px;
   border: 1px solid var(--landing-border);
   color: var(--landing-faint);
@@ -1495,8 +1496,8 @@
   .featureRow,
   .proofRow {
     grid-template-columns: 1fr;
-    gap: 28px;
-    padding: 48px 0;
+    gap: 21px;
+    padding: 36px 0;
   }
 
   .featureCopy {

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -1212,7 +1212,7 @@
 
 .chart {
   margin-bottom: 14px;
-  padding: 12px;
+  padding: 12px 14px 10px;
   border: 1px solid var(--landing-hairline);
   background: var(--landing-bg);
 }
@@ -1220,28 +1220,41 @@
 .chart svg {
   display: block;
   width: 100%;
-  height: 64px;
+  height: 132px;
 }
 
-.metricsMethod {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 12px;
-  color: var(--landing-muted);
+.chartGrid line {
+  stroke: var(--landing-hairline);
+  stroke-width: 1;
+}
+
+.chartAxis line {
+  stroke: color-mix(in srgb, var(--landing-faint) 72%, var(--landing-border));
+  stroke-width: 1.2;
+}
+
+.chartLabels text {
+  fill: var(--landing-faint);
   font-family: var(--font-mono);
   font-size: 10px;
 }
 
-.metricsMethod svg {
-  width: 12px;
-  height: 12px;
+.chartArea {
+  fill: url("#rediscovery-gradient");
 }
 
-.metricsMethod a {
-  color: var(--landing-primary);
-  text-decoration: underline;
-  text-underline-offset: 2px;
+.chartLine {
+  fill: none;
+  stroke: var(--landing-primary);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2.4;
+}
+
+.chartPoints circle {
+  fill: var(--landing-bg);
+  stroke: var(--landing-primary);
+  stroke-width: 2;
 }
 
 .ctaBand {

--- a/src/components/V2/Landing/ProvenRoi.tsx
+++ b/src/components/V2/Landing/ProvenRoi.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Info } from "lucide-react"
+import { BarChart3 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -37,22 +37,76 @@ export function ProvenRoi() {
               <div className={styles.chart}>
                 <svg
                   aria-hidden="true"
-                  preserveAspectRatio="none"
-                  viewBox="0 0 280 64"
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 320 132"
                 >
-                  <polyline
-                    fill="none"
-                    points="0,52 28,49 56,44 84,46 112,38 140,33 168,30 196,22 224,18 252,12 280,8"
-                    stroke="var(--landing-primary)"
-                    strokeWidth="1.6"
+                  <defs>
+                    <linearGradient
+                      id="rediscovery-gradient"
+                      x1="0"
+                      x2="0"
+                      y1="0"
+                      y2="1"
+                    >
+                      <stop
+                        offset="0%"
+                        stopColor="var(--landing-primary)"
+                        stopOpacity="0.22"
+                      />
+                      <stop
+                        offset="100%"
+                        stopColor="var(--landing-primary)"
+                        stopOpacity="0"
+                      />
+                    </linearGradient>
+                  </defs>
+                  <g className={styles.chartGrid}>
+                    <line x1="44" x2="304" y1="20" y2="20" />
+                    <line x1="44" x2="304" y1="52" y2="52" />
+                    <line x1="44" x2="304" y1="84" y2="84" />
+                  </g>
+                  <g className={styles.chartAxis}>
+                    <line x1="44" x2="44" y1="12" y2="100" />
+                    <line x1="44" x2="304" y1="100" y2="100" />
+                  </g>
+                  <g className={styles.chartLabels}>
+                    <text x="10" y="24">
+                      80%
+                    </text>
+                    <text x="10" y="56">
+                      60%
+                    </text>
+                    <text x="10" y="88">
+                      40%
+                    </text>
+                    <text x="44" y="122">
+                      W1
+                    </text>
+                    <text x="124" y="122">
+                      W2
+                    </text>
+                    <text x="204" y="122">
+                      W3
+                    </text>
+                    <text x="284" y="122">
+                      W4
+                    </text>
+                  </g>
+                  <path
+                    className={styles.chartArea}
+                    d="M44 88 L76 84 L108 77 L140 72 L172 61 L204 54 L236 43 L268 34 L304 24 L304 100 L44 100 Z"
                   />
-                  <polyline
-                    fill="none"
-                    points="0,52 280,48"
-                    stroke="var(--landing-faint)"
-                    strokeDasharray="3 3"
-                    strokeWidth="1"
+                  <path
+                    className={styles.chartLine}
+                    d="M44 88 L76 84 L108 77 L140 72 L172 61 L204 54 L236 43 L268 34 L304 24"
                   />
+                  <g className={styles.chartPoints}>
+                    <circle cx="44" cy="88" r="3" />
+                    <circle cx="108" cy="77" r="3" />
+                    <circle cx="172" cy="61" r="3" />
+                    <circle cx="236" cy="43" r="3" />
+                    <circle cx="304" cy="24" r="3.5" />
+                  </g>
                 </svg>
               </div>
               <div className={styles.metricsTiles}>
@@ -64,11 +118,6 @@ export function ProvenRoi() {
                   <div>31 hrs</div>
                   <span>Eng time / wk</span>
                 </div>
-              </div>
-              <div className={styles.metricsMethod}>
-                <Info />
-                Measured against cold-start baselines -{" "}
-                <a href="#metrics">methodology</a>
               </div>
             </div>
           </div>

--- a/src/components/V2/Landing/ProvenRoi.tsx
+++ b/src/components/V2/Landing/ProvenRoi.tsx
@@ -12,7 +12,6 @@ export function ProvenRoi() {
           className={cn(styles.featureRow, styles.proofRow, styles.visualLeft)}
         >
           <div className={styles.featureCopy}>
-            <span className={styles.proofTag}>ROI - supporting proof</span>
             <div className={styles.featureLabel}>
               <span className={styles.featureIcon}>
                 <BarChart3 />
@@ -21,8 +20,9 @@ export function ProvenRoi() {
             </div>
             <h2>Proven ROI</h2>
             <p>
-              Quantify it: tokens and engineering time saved, with a transparent
-              methodology.
+              Measure the tokens and engineering time your agents save. Use a
+              transparent methodology to understand what Taskforce returns
+              across your work.
             </p>
           </div>
           <div className={styles.visual}>

--- a/src/components/V2/Landing/ProvenRoi.tsx
+++ b/src/components/V2/Landing/ProvenRoi.tsx
@@ -20,9 +20,9 @@ export function ProvenRoi() {
             </div>
             <h2>Proven ROI</h2>
             <p>
-              Measure the tokens and engineering time your agents save. Use a
-              transparent methodology to understand what Taskforce returns
-              across your work.
+              Measure the tokens and engineering time your agents save with
+              Taskforce-powered shared context and knowledge. Use a transparent
+              methodology to understand what Taskforce returns across your work.
             </p>
           </div>
           <div className={styles.visual}>


### PR DESCRIPTION
## Summary
- Remove the green status dot from the hero "Works with Claude Code, Codex, and Cursor." line.
- Remove the repeated "Works with Claude Code, Codex, and Cursor." copy from the closing CTA.
- Replace the hero capability separator with a centered middle dot and enlarge the capability text by 25%.
- Enlarge the top nav brand, links, controls, and CTA buttons by roughly 25%.
- Make the hero copy/terminal split equal 50/50 on desktop.
- Enlarge feature capability labels and icons by 25%.
- Move orchestration panel status blocks next to the action text and add subtle glow pulses to the blocks and gray action text.

## Validation
- `./node_modules/.bin/biome check --files-ignore-unknown=true src/components/V2/Landing src/routes/landing.tsx tests/landing.spec.ts`
- `bun run build` (passes; Vite still reports the existing large chunk warning)
- Playwright render sanity checks against `http://127.0.0.1:5180/landing` for desktop and mobile: no horizontal overflow, only one Works line remains, no child dot on that line, desktop hero columns are equal, action block/text animations are applied, and feature label/icon sizing is scaled.