### PR TITLE
Refine landing hero layout

### DIFF
--- a/src/components/V2/Landing/ClosingCta.tsx
+++ b/src/components/V2/Landing/ClosingCta.tsx
@@ -10,7 +10,8 @@ export function ClosingCta() {
     <section className={styles.ctaBand}>
       <div className={styles.ctaInner}>
         <h2>
-          Stop starting from <em>scratch</em>. Start using Taskforce.
+          Stop starting from <em>scratch</em>. Start using{" "}
+          <em>Taskforce</em>.
         </h2>
         <div className={styles.heroCtas}>
           <Button asChild className={styles.solidButton}>

--- a/src/components/V2/Landing/ClosingCta.tsx
+++ b/src/components/V2/Landing/ClosingCta.tsx
@@ -10,8 +10,7 @@ export function ClosingCta() {
     <section className={styles.ctaBand}>
       <div className={styles.ctaInner}>
         <h2>
-          Stop starting from <em>scratch</em>. Start using{" "}
-          <em>Taskforce</em>.
+          Stop starting from <em>scratch</em>. Start using <em>Taskforce</em>.
         </h2>
         <div className={styles.heroCtas}>
           <Button asChild className={styles.solidButton}>

--- a/src/components/V2/Landing/Hero.tsx
+++ b/src/components/V2/Landing/Hero.tsx
@@ -242,7 +242,7 @@ function HeroTerminal({ sceneIndex }: { sceneIndex: number }) {
     <div className={styles.term}>
       <div className={styles.termHead}>
         <span className={styles.termDot} />
-        <span className={styles.termName}>taskforce - live</span>
+        <span className={styles.termName}>taskforce</span>
         <span className={styles.liveStatus}>
           <span />
           connected

--- a/src/components/V2/Landing/Hero.tsx
+++ b/src/components/V2/Landing/Hero.tsx
@@ -36,6 +36,9 @@ const SCENES = [
   },
 ] as const
 
+const HERO_ROTATION_MS = 4400
+const HERO_CLICK_PAUSE_MS = 10_000
+
 function usePrefersReducedMotion() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
 
@@ -91,6 +94,7 @@ export function LandingHero() {
   const copyReveal = useRevealClass()
   const termReveal = useRevealClass()
   const swapTimer = useRef<number | null>(null)
+  const pauseUntilRef = useRef(0)
   const scene = SCENES[sceneIndex]
 
   const selectScene = useCallback(
@@ -119,11 +123,17 @@ export function LandingHero() {
   useEffect(() => {
     if (reducedMotion) return
     const interval = window.setInterval(() => {
+      if (Date.now() < pauseUntilRef.current) return
       selectScene((sceneIndex + 1) % SCENES.length)
-    }, 4400)
+    }, HERO_ROTATION_MS)
 
     return () => window.clearInterval(interval)
   }, [reducedMotion, sceneIndex, selectScene])
+
+  const selectSceneFromDot = (nextIndex: number) => {
+    pauseUntilRef.current = Date.now() + HERO_CLICK_PAUSE_MS
+    selectScene(nextIndex)
+  }
 
   useEffect(() => {
     return () => {
@@ -153,9 +163,6 @@ export function LandingHero() {
               className={cn(styles.heroCopy, copyReveal.className)}
               ref={copyReveal.ref}
             >
-              <span className={styles.eyebrow}>
-                AI work memory for engineering teams
-              </span>
               <h1 className={cn(isSwapping && styles.swapping)}>
                 <span className={styles.lead}>Stop </span>
                 <span className={styles.phrase}>{phrase}</span>
@@ -178,7 +185,7 @@ export function LandingHero() {
                     aria-selected={sceneIndex === index}
                     className={cn(sceneIndex === index && styles.activeDot)}
                     key={item.key}
-                    onClick={() => selectScene(index)}
+                    onClick={() => selectSceneFromDot(index)}
                     role="tab"
                     type="button"
                   />

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -1171,6 +1171,10 @@
   border-top: 1px solid var(--landing-hairline);
 }
 
+.features .proofRow:first-child {
+  border-top: 1px solid var(--landing-hairline);
+}
+
 .proofRow h2 {
   font-size: clamp(22px, 2.4vw, 27px);
 }

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -319,11 +319,12 @@
   display: flex;
   gap: 8px;
   margin-bottom: 26px;
+  width: 100%;
 }
 
 .heroDots button {
-  width: 26px;
-  height: 4px;
+  flex: 1 1 0;
+  height: 4.4px;
   padding: 0;
   border: 0;
   background: var(--landing-border);

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -1309,28 +1309,33 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 16px;
+  gap: 35px;
 }
 
 .footerBrand {
-  font-size: 14px;
+  gap: 11px;
+  font-size: 20px;
 }
 
 .footerMark {
-  width: 18px;
-  height: 18px;
+  width: 25px;
+  height: 25px;
 }
 
 .footerLinks {
   display: flex;
-  gap: 18px;
+  gap: 27.5px;
+}
+
+.footerLinks a {
+  font-size: 14.375px;
 }
 
 .copyright {
   margin-left: auto;
   color: var(--landing-faint);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: 14.375px;
 }
 
 .reveal {

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -484,10 +484,12 @@
 
 .greenDot {
   background: var(--landing-positive);
+  color: var(--landing-positive);
 }
 
 .amberDot {
   background: oklch(0.74 0.15 70);
+  color: oklch(0.74 0.15 70);
 }
 
 .purpleDot {

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -45,7 +45,7 @@
     0 1px 2px oklch(0.7 0 0 / 0.06), 0 12px 32px -20px oklch(0.4 0 0 / 0.22);
 
   min-height: 100svh;
-  overflow-x: hidden;
+  overflow-x: clip;
   background: var(--landing-bg);
   color: var(--landing-fg);
   font-family: var(--font-sans);
@@ -243,7 +243,7 @@
 
 .heroCopy {
   align-self: start;
-  max-width: 540px;
+  width: 100%;
   margin-top: 7vh;
 }
 

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -20,7 +20,7 @@ test("/landing renders the redesigned Taskforce landing page", async ({
       name: /stop losing track.*of your agents/i,
     }),
   ).toBeVisible()
-  await expect(page.getByText("taskforce")).toBeVisible()
+  await expect(page.getByText("taskforce", { exact: true })).toBeVisible()
 
   for (const heading of [
     "Orchestration",

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -20,7 +20,7 @@ test("/landing renders the redesigned Taskforce landing page", async ({
       name: /stop losing track.*of your agents/i,
     }),
   ).toBeVisible()
-  await expect(page.getByText("taskforce - live")).toBeVisible()
+  await expect(page.getByText("taskforce")).toBeVisible()
 
   for (const heading of [
     "Orchestration",


### PR DESCRIPTION
## Summary
- Make the landing top bar stick on scroll by avoiding an overflow ancestor that interferes with `position: sticky`.
- Remove `- live` from the hero terminal title so it reads `taskforce`.
- Let the hero copy column use the full 50% grid width instead of being capped at 540px.

## Validation
- `./node_modules/.bin/biome check --write --unsafe --files-ignore-unknown=true src/components/V2/Landing src/routes/landing.tsx tests/landing.spec.ts`

Full build/browser validation intentionally deferred until merge request, per workflow preference.