### PR TITLE
Fleet: relabel waiting state as "Awaiting user prompt"

### DIFF
--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -633,7 +633,7 @@ export function FleetPage() {
   const waiting = waitingCount(activeAgents)
 
   const summaryBits = [`${running} running`]
-  if (waiting) summaryBits.push(`${waiting} waiting for input`)
+  if (waiting) summaryBits.push(`${waiting} awaiting prompt`)
 
   const openAgent = (agent: TaskforceFleetAgent) =>
     navigate({

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -13,7 +13,7 @@ export type FleetStatus = "run" | "waiting" | "paused" | "idle"
 /** Quiet word shown next to a non-running status dot. */
 export const STATE_LABEL: Record<FleetStatus, string> = {
   run: "running",
-  waiting: "waiting for input",
+  waiting: "awaiting prompt",
   paused: "capture paused",
   idle: "idle",
 }
@@ -146,7 +146,7 @@ export function liveActivityLabel(
     return summary || "Running in this terminal"
   }
   if (status === "waiting") {
-    return "Waiting for your input"
+    return "Awaiting user prompt"
   }
   if (status === "paused" || options.capturePaused) {
     const reason = options.pauseReason?.trim()
@@ -164,7 +164,7 @@ export function rosterWorkSummary(agent: TaskforceFleetAgent): string {
 
   const status = agentStatus(agent)
   if (status === "run") return "Running in this terminal"
-  if (status === "waiting") return "Waiting for your input"
+  if (status === "waiting") return "Awaiting user prompt"
   if (status === "paused" || agentCapturePaused(agent)) {
     return "Activity capture is paused"
   }

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -556,7 +556,7 @@ test("activity timeline live head shows waiting state", async ({ page }) => {
   await page.goto("/v2/fleet/session-1")
 
   await expect(page.getByText("now", { exact: true })).toBeVisible()
-  await expect(page.getByText("Waiting for your input")).toBeVisible()
+  await expect(page.getByText("Awaiting user prompt")).toBeVisible()
   await expect(
     page.getByText("Stale summary from earlier work"),
   ).toHaveCount(0)


### PR DESCRIPTION
## Why

In the Fleet tab, a finished-but-idle agent session read "Running in this terminal." The backend now emits a distinct `waiting` status when an agent has completed its turn and is awaiting the next user prompt (see EnderAI #154). This updates the frontend copy to reflect that state.

## What

In `fleetStatus.ts`:
- `liveActivityLabel` and `rosterWorkSummary` `waiting` copy → **"Awaiting user prompt"**
- short `STATE_LABEL.waiting` dot label → **"awaiting prompt"**

In `FleetPage.tsx`:
- roster count summary → **"N awaiting prompt"**

`running` / `paused` / `idle` copy unchanged.

## Testing

- `tsc -p tsconfig.build.json` clean.
- `playwright test --config=playwright.mocked.config.ts tests/fleet.spec.ts` → **19 passed** (incl. the waiting-state live-head test now asserting "Awaiting user prompt").

> Pairs with backend EnderAI #154 — that PR emits the `waiting` status this copy renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)