### PR TITLE
Align Ledger transcript timeline with Fleet

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -34,6 +34,7 @@
   --tf-card: color-mix(in srgb, var(--foreground) 4%, var(--background));
   --tf-card-2: color-mix(in srgb, var(--foreground) 7%, var(--background));
   --tf-primary: var(--primary);
+  --tf-primary-soft: color-mix(in srgb, var(--primary) 10%, transparent);
   --tf-positive: #15a34a;
   --tf-danger: var(--destructive);
   --tf-warn: #b45309;
@@ -429,172 +430,88 @@
   line-height: 1.3;
 }
 
-/* Transcript stream — a log */
-.ev {
-  display: grid;
-  grid-template-columns: 74px 1fr;
-  gap: 0;
-}
-.evT {
-  font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
-  color: var(--tf-faint-fg);
-  padding: 16px 14px 0 0;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-.evC {
-  border-left: 1px solid var(--tf-hairline);
-  padding: 0 0 18px 20px;
+/* Transcript timeline — mirrors Fleet agent detail activity formatting. */
+.transcriptTimeline {
   position: relative;
-  min-width: 0;
+  padding-left: 20px;
 }
-/* Highlighted target of a Fleet activity deep-link (?event_id=…). */
-.evHighlight .evC {
-  background: var(
-    --tf-primary-soft,
-    color-mix(in srgb, var(--tf-primary) 10%, transparent)
-  );
-  border-left-color: var(--tf-primary);
-  box-shadow: -2px 0 0 0 var(--tf-primary);
-}
-.evC::before {
-  content: "";
+.transcriptTimeline::before {
   position: absolute;
-  left: -4px;
-  top: 18px;
-  width: 8px;
-  height: 8px;
-  background: var(--tf-dot);
+  top: 6px;
+  bottom: 8px;
+  left: 3px;
+  width: 1px;
+  background: var(--tf-hairline);
+  content: "";
 }
-.evPrompt .evC::before {
+.ev {
+  position: relative;
+  padding: 0 0 18px;
+}
+.ev:last-child {
+  padding-bottom: 0;
+}
+.evDot {
+  position: absolute;
+  top: 5px;
+  left: -20px;
+  width: 7px;
+  height: 7px;
+  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten timeline dots. */
+  border-radius: 999px !important;
+  background: var(--tf-dot);
+  box-shadow: 0 0 0 3px var(--tf-bg);
+}
+.evPrompt .evDot,
+.evReply .evDot {
   background: var(--tf-primary);
 }
-.lab {
-  font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
-  letter-spacing: 0.06em;
-  text-transform: none;
+.evT {
   color: var(--tf-faint-fg);
-  padding-top: 14px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: calc(10.5px * var(--v2-scale, 1));
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
 }
-.lab b {
-  color: var(--tf-fg);
-  font-weight: 600;
-  text-transform: none;
-  letter-spacing: 0;
-  font-family: var(--font-sans);
-  font-size: calc(14px * var(--v2-scale, 1));
+.evKind {
+  margin-left: 8px;
+  color: var(--tf-muted-fg);
+  text-transform: uppercase;
 }
-.txt {
-  font-size: calc(16px * var(--v2-scale, 1));
-  line-height: 1.55;
-  color: var(--tf-fg);
-  margin-top: 7px;
-  max-width: 70ch;
+.evC {
+  min-width: 0;
+}
+.evTitle {
+  margin-top: 3px;
+  max-width: 72ch;
+  color: var(--tf-muted-fg);
+  font-size: calc(13px * var(--v2-scale, 1));
+  line-height: 1.45;
   text-wrap: pretty;
   white-space: pre-wrap;
 }
-.evReply .txt {
-  color: var(--tf-ink);
-}
-
-.cmd {
-  margin-top: 9px;
-  border: 1px solid var(--tf-border);
-  background: var(--tf-card);
-  font-family: var(--font-mono);
-  font-size: calc(14px * var(--v2-scale, 1));
-}
-.cmdLine {
-  padding: 8px 11px;
-  display: flex;
-  gap: 8px;
-  align-items: baseline;
-  border-bottom: 1px solid var(--tf-hairline);
-}
-.cmdPr {
-  color: var(--tf-primary);
-}
-.cmdC {
+.evPrompt .evTitle,
+.evReply .evTitle {
   color: var(--tf-fg);
-  white-space: pre-wrap;
-  word-break: break-all;
 }
-.cmdOut {
-  padding: 8px 11px 8px 26px;
-  color: var(--tf-muted-fg);
-  white-space: pre-wrap;
-  line-height: 1.5;
+.evTitleMono {
+  font-family: var(--font-mono);
+  word-break: break-word;
 }
-.cmdMeta {
-  padding: 7px 11px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  border-top: 1px solid var(--tf-hairline);
+.evSub {
+  margin-top: 4px;
+  max-width: 72ch;
   color: var(--tf-faint-fg);
   font-size: calc(12px * var(--v2-scale, 1));
-}
-.exit {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-}
-.exitD {
-  width: 7px;
-  height: 7px;
-  background: var(--tf-positive);
-}
-.exitFail .exitD {
-  background: var(--tf-danger);
-}
-
-.edit {
-  margin-top: 9px;
-  border: 1px solid var(--tf-border);
-  padding: 9px 11px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.editFile {
-  font-family: var(--font-mono);
-  font-size: calc(14px * var(--v2-scale, 1));
-  color: var(--tf-fg);
-  word-break: break-all;
-}
-.editStat {
-  font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
-  margin-left: auto;
-  white-space: nowrap;
-}
-.editAdd {
-  color: var(--tf-positive);
-}
-.editRem {
-  color: var(--tf-danger);
-}
-.editNote {
-  margin-top: 8px;
-  font-size: calc(14px * var(--v2-scale, 1));
-  color: var(--tf-muted-fg);
-  line-height: 1.55;
-  max-width: 70ch;
+  line-height: 1.45;
   white-space: pre-wrap;
 }
-.evNote .evC {
-  padding-bottom: 7px;
-}
-.noteTxt {
-  font-size: calc(14px * var(--v2-scale, 1));
-  color: var(--tf-muted-fg);
-  font-style: italic;
-  margin-top: 7px;
+/* Highlighted target of a Fleet activity deep-link (?event_id=…). */
+.evHighlight {
+  margin-left: -8px;
+  padding-left: 8px;
+  background: var(--tf-primary-soft);
+  box-shadow: -2px 0 0 0 var(--tf-primary);
 }
 
 /* Metadata rail */

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -601,6 +601,37 @@ function eventIndex(
   return events.findIndex((event) => event.id === eventId)
 }
 
+function transcriptEventTitle(event: LedgerTranscriptEvent): string {
+  if (event.kind === "prompt") return event.text ?? "Prompt"
+  if (event.kind === "reply") return event.text ?? "Reply"
+  if (event.kind === "command") return `$ ${event.cmd ?? "command"}`
+  if (event.kind === "edit") return `Edited ${event.file ?? "file"}`
+  return event.note ?? event.text ?? event.kind
+}
+
+function transcriptEventDetail(
+  event: LedgerTranscriptEvent,
+  detail: LedgerSessionDetail,
+): string | null {
+  if (event.kind === "prompt") return `${eventWho(event, detail)} asked`
+  if (event.kind === "reply") return `${agentLabel(detail)} replied`
+  if (event.kind === "command") {
+    const exit =
+      event.exit_code === null ? "" : `exit ${event.exit_code.toString()}`
+    return [event.output, exit, event.repo ?? detail.repo]
+      .filter(Boolean)
+      .join(" · ")
+  }
+  if (event.kind === "edit") {
+    const stats =
+      event.added !== null || event.removed !== null
+        ? `+${event.added ?? 0} −${event.removed ?? 0}`
+        : ""
+    return [event.note, stats].filter(Boolean).join(" · ") || null
+  }
+  return event.note
+}
+
 function LedgerDetail({
   anchorEventId,
   detail,
@@ -616,9 +647,16 @@ function LedgerDetail({
   isLoading: boolean
   onBack: () => void
 }) {
+  const transcriptEvents = useMemo(
+    () =>
+      [...(detail?.transcript_events ?? [])].sort((a, b) =>
+        (b.occurred_at ?? "").localeCompare(a.occurred_at ?? ""),
+      ),
+    [detail?.transcript_events],
+  )
   const anchorIndex = useMemo(
-    () => eventIndex(detail?.transcript_events ?? [], anchorEventId),
-    [detail?.transcript_events, anchorEventId],
+    () => eventIndex(transcriptEvents, anchorEventId),
+    [transcriptEvents, anchorEventId],
   )
   const anchorRef = useRef<HTMLDivElement | null>(null)
   useEffect(() => {
@@ -677,16 +715,18 @@ function LedgerDetail({
             </div>
             <h2>{sessionTitle(detail)}</h2>
           </div>
-          {detail.transcript_events.length > 0 ? (
-            detail.transcript_events.map((event, index) => (
-              <TranscriptEvent
-                anchorRef={index === anchorIndex ? anchorRef : undefined}
-                detail={detail}
-                event={event}
-                highlighted={index === anchorIndex}
-                key={event.id}
-              />
-            ))
+          {transcriptEvents.length > 0 ? (
+            <div className={styles.transcriptTimeline}>
+              {transcriptEvents.map((event, index) => (
+                <TranscriptEvent
+                  anchorRef={index === anchorIndex ? anchorRef : undefined}
+                  detail={detail}
+                  event={event}
+                  highlighted={index === anchorIndex}
+                  key={event.id}
+                />
+              ))}
+            </div>
           ) : (
             <div className={styles.empty}>
               Transcript archive is not available for this older session.
@@ -710,80 +750,66 @@ function TranscriptEvent({
   event: LedgerTranscriptEvent
   highlighted?: boolean
 }) {
-  const time = formatTimeOfDay(event.occurred_at)
+  const time = formatClock(event.occurred_at)
   const anchorProps = { highlighted, rootRef: anchorRef }
+  const title = transcriptEventTitle(event)
+  const eventDetail = transcriptEventDetail(event, detail)
 
   if (event.kind === "prompt") {
     return (
-      <EventShell modifier={styles.evPrompt} time={time} {...anchorProps}>
-        <div className={styles.lab}>
-          <b>{eventWho(event, detail)} asked</b>
-        </div>
-        {event.text ? <div className={styles.txt}>{event.text}</div> : null}
+      <EventShell
+        kind={event.kind}
+        modifier={styles.evPrompt}
+        time={time}
+        {...anchorProps}
+      >
+        <div className={styles.evTitle}>{title}</div>
+        {eventDetail ? <div className={styles.evSub}>{eventDetail}</div> : null}
       </EventShell>
     )
   }
 
   if (event.kind === "reply") {
     return (
-      <EventShell modifier={styles.evReply} time={time} {...anchorProps}>
-        <div className={styles.lab}>
-          <b>{agentLabel(detail)}</b> replied
-        </div>
-        {event.text ? <div className={styles.txt}>{event.text}</div> : null}
+      <EventShell
+        kind={event.kind}
+        modifier={styles.evReply}
+        time={time}
+        {...anchorProps}
+      >
+        <div className={styles.evTitle}>{title}</div>
+        {eventDetail ? <div className={styles.evSub}>{eventDetail}</div> : null}
       </EventShell>
     )
   }
 
   if (event.kind === "command") {
-    const failed = event.exit_code !== null && event.exit_code !== 0
-    const repo = event.repo ?? detail.repo
     return (
-      <EventShell time={time} {...anchorProps}>
-        <div className={styles.lab}>ran command</div>
-        <div className={styles.cmd}>
-          <div className={styles.cmdLine}>
-            <span className={styles.cmdPr}>$</span>
-            <span className={styles.cmdC}>{event.cmd}</span>
-          </div>
-          {event.output ? (
-            <div className={styles.cmdOut}>{event.output}</div>
-          ) : null}
-          <div className={styles.cmdMeta}>
-            {event.exit_code !== null ? (
-              <span className={cn(styles.exit, failed && styles.exitFail)}>
-                <span className={styles.exitD} />
-                exit {event.exit_code}
-              </span>
-            ) : null}
-            {repo ? <span>{repo}</span> : null}
-          </div>
-        </div>
+      <EventShell kind={event.kind} time={time} {...anchorProps}>
+        <div className={cn(styles.evTitle, styles.evTitleMono)}>{title}</div>
+        {eventDetail ? <div className={styles.evSub}>{eventDetail}</div> : null}
       </EventShell>
     )
   }
 
   if (event.kind === "edit") {
     return (
-      <EventShell time={time} {...anchorProps}>
-        <div className={styles.lab}>edited file</div>
-        <div className={styles.edit}>
-          <span className={styles.editFile}>{event.file}</span>
-          <span className={styles.editStat}>
-            <span className={styles.editAdd}>+{event.added ?? 0}</span>{" "}
-            <span className={styles.editRem}>−{event.removed ?? 0}</span>
-          </span>
-        </div>
-        {event.note ? (
-          <div className={styles.editNote}>{event.note}</div>
-        ) : null}
+      <EventShell kind={event.kind} time={time} {...anchorProps}>
+        <div className={styles.evTitle}>{title}</div>
+        {eventDetail ? <div className={styles.evSub}>{eventDetail}</div> : null}
       </EventShell>
     )
   }
 
   return (
-    <EventShell modifier={styles.evNote} time={time} {...anchorProps}>
-      <div className={styles.noteTxt}>● {event.note ?? event.text}</div>
+    <EventShell
+      kind={event.kind}
+      modifier={styles.evNote}
+      time={time}
+      {...anchorProps}
+    >
+      <div className={styles.evTitle}>{title}</div>
+      {eventDetail ? <div className={styles.evSub}>{eventDetail}</div> : null}
     </EventShell>
   )
 }
@@ -791,12 +817,14 @@ function TranscriptEvent({
 function EventShell({
   children,
   highlighted,
+  kind,
   modifier,
   rootRef,
   time,
 }: {
   children: ReactNode
   highlighted?: boolean
+  kind: string
   modifier?: string
   rootRef?: RefObject<HTMLDivElement | null>
   time: string
@@ -807,7 +835,11 @@ function EventShell({
       data-highlighted={highlighted ? "true" : undefined}
       ref={rootRef}
     >
-      <div className={styles.evT}>{time}</div>
+      <span className={styles.evDot} />
+      <div className={styles.evT}>
+        {time}
+        <span className={styles.evKind}>{kind}</span>
+      </div>
       <div className={styles.evC}>{children}</div>
     </div>
   )

--- a/tests/ledger.spec.ts
+++ b/tests/ledger.spec.ts
@@ -58,7 +58,7 @@ function ledgerDetail(rawTranscriptAvailable: boolean) {
     kinds: ["session.observed"],
     net_saved_tokens: 0,
     usd_amount: "0",
-    event_count: 1,
+    event_count: 4,
     cross_boundary: false,
     occurred_at_first: "2026-06-12T20:00:00Z",
     occurred_at_last: "2026-06-12T20:01:00Z",
@@ -75,9 +75,9 @@ function ledgerDetail(rawTranscriptAvailable: boolean) {
     ended_at: "2026-06-12T20:01:00Z",
     duration_ms: 60000,
     imported_at: "2026-06-12T20:01:00Z",
-    message_count: 1,
-    command_count: 0,
-    edit_count: 0,
+    message_count: 2,
+    command_count: 1,
+    edit_count: 1,
     input_tokens: 100,
     output_tokens: 20,
     cache_read_tokens: 0,
@@ -100,6 +100,54 @@ function ledgerDetail(rawTranscriptAvailable: boolean) {
         removed: null,
         note: null,
         repo: null,
+      },
+      {
+        id: "event-edit",
+        kind: "edit",
+        occurred_at: "2026-06-12T20:00:30Z",
+        role: null,
+        who: null,
+        text: null,
+        cmd: null,
+        exit_code: null,
+        output: null,
+        file: "tests/ledger.spec.ts",
+        added: 12,
+        removed: 2,
+        note: "Covered newest-first transcript ordering",
+        repo: "EnderAI",
+      },
+      {
+        id: "event-reply",
+        kind: "reply",
+        occurred_at: "2026-06-12T20:00:45Z",
+        role: "assistant",
+        who: "Codex",
+        text: "Ledger timeline now matches Fleet.",
+        cmd: null,
+        exit_code: null,
+        output: null,
+        file: null,
+        added: null,
+        removed: null,
+        note: null,
+        repo: null,
+      },
+      {
+        id: "event-command",
+        kind: "command",
+        occurred_at: "2026-06-12T20:01:00Z",
+        role: null,
+        who: null,
+        text: null,
+        cmd: "npm run test:mocked -- tests/ledger.spec.ts",
+        exit_code: 0,
+        output: "1 passed",
+        file: null,
+        added: null,
+        removed: null,
+        note: null,
+        repo: "EnderAI",
       },
     ],
     raw_transcript_available: rawTranscriptAvailable,
@@ -202,6 +250,30 @@ test("event deep links highlight the exact canonical Ledger event", async ({
   await expect(page.locator('[data-highlighted="true"]')).toContainText(
     "Polish the Ledger.",
   )
+})
+
+test("session transcript timeline matches Fleet formatting newest first", async ({
+  page,
+}) => {
+  await mockTaskforceAuth(page, "org-1")
+  await mockLedger(page, { rawTranscriptAvailable: true })
+
+  await page.goto("/v2/ledger?session_id=session-raw")
+
+  const newest = page.getByText("$ npm run test:mocked -- tests/ledger.spec.ts")
+  const oldest = page.getByText("Polish the Ledger.")
+  await expect(newest).toBeVisible()
+  await expect(oldest).toBeVisible()
+  await expect(page.getByText("command", { exact: true })).toBeVisible()
+  await expect(page.getByText("1 passed · exit 0 · EnderAI")).toBeVisible()
+  await expect(page.getByText("Edited tests/ledger.spec.ts")).toBeVisible()
+  await expect(
+    page.getByText("Covered newest-first transcript ordering · +12 −2"),
+  ).toBeVisible()
+
+  const newestBox = await newest.boundingBox()
+  const oldestBox = await oldest.boundingBox()
+  expect(newestBox && oldestBox && newestBox.y < oldestBox.y).toBe(true)
 })
 
 test("sessions without canonical events show no transcript download control", async ({


### PR DESCRIPTION
## Summary
- Reworked the Ledger session transcript detail to use the same compact timeline structure as the Fleet session-agent activity view.
- Display transcript events newest-first, with time, event kind, primary text, and secondary detail formatting.
- Preserved Fleet/Ledger event deep-link highlighting and added Ledger coverage for mixed prompt/reply/edit/command timeline ordering.

## Validation
- `./node_modules/.bin/biome check src/components/V2/Ledger/LedgerPage.tsx tests/ledger.spec.ts`
- `./node_modules/.bin/tsc -p tsconfig.build.json --noEmit`
- Attempted `npm run test:mocked -- tests/ledger.spec.ts`; local Playwright is blocked because this shell is Node 18.19.1 while Vite 7 requires Node 20.19+ or 22.12+.
