### PR TITLE
Simplify Fleet agent rows and tighten header spacing

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -168,11 +168,11 @@
 /* rows */
 .arow {
   display: grid;
-  grid-template-columns: 26px minmax(200px, min(360px, 34vw)) minmax(0, 1fr) auto 64px;
+  grid-template-columns: 26px minmax(0, 1fr) minmax(0, 1fr) auto 64px;
   gap: 18px;
   align-items: center;
   width: 100%;
-  padding: 16px 18px;
+  padding: 12px 18px;
   border-bottom: 1px solid var(--fl-hair);
   text-align: left;
 }
@@ -286,28 +286,27 @@
 }
 
 .nm {
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  color: var(--foreground);
   font-size: calc(14px * var(--v2-scale, 1));
   font-weight: 500;
   line-height: 1.35;
   letter-spacing: -0.005em;
+  text-overflow: ellipsis;
   text-transform: none;
+  white-space: nowrap;
 }
 
-.meta {
-  margin-top: 4px;
-  color: var(--fl-faint);
-  font-family: var(--font-mono);
-  font-size: calc(10.5px * var(--v2-scale, 1));
-  letter-spacing: 0.01em;
-}
-
-.state {
-  margin-top: 7px;
+/* roster status */
+.status {
+  min-width: 0;
+  overflow: hidden;
   color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: calc(10.5px * var(--v2-scale, 1));
-  letter-spacing: 0.02em;
+  font-size: calc(13px * var(--v2-scale, 1));
+  line-height: 1.35;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .stateWaiting {
@@ -317,58 +316,6 @@
 .statePaused,
 .stateIdle {
   color: var(--fl-faint);
-}
-
-/* work */
-.work {
-  min-width: 0;
-  align-self: center;
-}
-
-.workSummary {
-  display: -webkit-box;
-  overflow: hidden;
-  color: var(--muted-foreground);
-  font-size: calc(13px * var(--v2-scale, 1));
-  line-height: 1.5;
-  text-overflow: ellipsis;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
-}
-
-.detailLine {
-  display: flex;
-  align-items: center;
-  margin-top: 6px;
-  gap: 8px;
-  flex-wrap: wrap;
-  color: var(--fl-faint);
-  font-family: var(--font-mono);
-  font-size: calc(11px * var(--v2-scale, 1));
-}
-
-.file {
-  color: var(--muted-foreground);
-}
-
-.more {
-  color: var(--fl-faint);
-}
-
-.docInline {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--fl-faint);
-}
-
-.docInline::before {
-  width: 3px;
-  height: 3px;
-  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten dot separators. */
-  border-radius: 999px !important;
-  background: var(--fl-faint);
-  content: "";
 }
 
 /* age */
@@ -1019,26 +966,13 @@
   }
 
   .arow {
-    grid-template-columns: 26px minmax(0, 1fr) auto auto;
-    gap: 12px;
+    grid-template-columns: 26px minmax(0, 1fr) minmax(0, 1fr) 40px;
+    gap: 10px;
     align-items: center;
   }
 
-  .arow .work {
-    grid-row: 2;
-    grid-column: 2 / 4;
-    align-self: start;
-    text-align: left;
-  }
-
   .arow .age {
-    grid-row: 1;
-    grid-column: 3;
-  }
-
-  .arowMenu {
-    grid-row: 1;
-    grid-column: 4;
+    display: none;
   }
 
   .dmain,

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -56,15 +56,13 @@ import { cn } from "@/lib/utils"
 import styles from "./FleetPage.module.css"
 import {
   agentDisplayName,
-  agentMeta,
   agentStatus,
   compactPresence,
   type FleetStatus,
   fleetRepo,
   fleetTitle,
-  rosterWorkSummary,
+  rosterStatusLabel,
   runningCount,
-  STATE_LABEL,
   waitingCount,
 } from "./fleetStatus"
 
@@ -148,8 +146,6 @@ function AgentRow({
   const [renameValue, setRenameValue] = useState(agent.display_name ?? "")
   const status = agentStatus(agent)
   const age = compactPresence(agent)
-  const showAgeInState = status === "waiting" || status === "idle"
-  const docTitle = agent.active_document_id ? agent.title : null
   const sessionLabel = agentDisplayName(agent)
 
   const submitRename = (event: FormEvent) => {
@@ -207,27 +203,16 @@ function AgentRow({
           <div className={styles.nm} data-testid="fleet-agent-name">
             {sessionLabel}
           </div>
-          <div className={styles.meta}>{agentMeta(agent)}</div>
-          {status !== "run" && (
-            <div className={cn(styles.state, STATE_CLASS[status])}>
-              {STATE_LABEL[status]}
-              {showAgeInState ? ` · ${age}` : ""}
-            </div>
-          )}
         </div>
-        <div className={styles.work}>
-          <div className={styles.workSummary}>
-            {rosterWorkSummary(agent)}
-          </div>
-          {docTitle && (
-            <div className={styles.detailLine}>
-              <span className={styles.docInline}>{docTitle}</span>
-            </div>
-          )}
+        <div
+          className={cn(styles.status, STATE_CLASS[status])}
+          data-testid="fleet-agent-status"
+        >
+          {rosterStatusLabel(agent)}
         </div>
       </button>
 
-      <div className={styles.age}>{status === "run" ? age : ""}</div>
+      <div className={styles.age}>{age}</div>
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -681,7 +681,7 @@ export function FleetPage() {
         <div
           className={cn(
             V2_STICKY_HEADER_CLASS,
-            "flex flex-col gap-1 border-b-0 pb-4",
+            "flex flex-col gap-1 border-b-0 pb-2",
           )}
         >
           <header className="flex items-start justify-between gap-4">
@@ -711,7 +711,7 @@ export function FleetPage() {
           </header>
         </div>
 
-        <div className={V2_TAB_CONTENT_CLASS}>
+        <div className={cn(V2_TAB_CONTENT_CLASS, "pt-2")}>
           {Boolean(mutationError) && (
             <div className="mb-4 border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
               {errorMessage(mutationError)}

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -18,6 +18,18 @@ export const STATE_LABEL: Record<FleetStatus, string> = {
   idle: "idle",
 }
 
+/** One-line roster status in the agent row's second column. */
+export const ROSTER_STATUS_LABEL: Record<FleetStatus, string> = {
+  run: "Agent responding",
+  waiting: "Agent waiting",
+  paused: "Capture paused",
+  idle: "Agent idle",
+}
+
+export function rosterStatusLabel(agent: TaskforceFleetAgent): string {
+  return ROSTER_STATUS_LABEL[agentStatus(agent)]
+}
+
 // Ingestion does not capture these fields yet. Keep the accessors defensive so
 // the detail route can adopt them without fabricating data in the API.
 type FutureAgentFields = TaskforceFleetAgent & {
@@ -155,20 +167,6 @@ export function liveActivityLabel(
       : "Activity capture is paused"
   }
   return "Connected but not actively running"
-}
-
-/** Roster work column — prefer captured summary, else status-aware fallback. */
-export function rosterWorkSummary(agent: TaskforceFleetAgent): string {
-  const summary = agent.summary_markdown?.trim()
-  if (summary) return summary
-
-  const status = agentStatus(agent)
-  if (status === "run") return "Running in this terminal"
-  if (status === "waiting") return "Awaiting user prompt"
-  if (status === "paused" || agentCapturePaused(agent)) {
-    return "Activity capture is paused"
-  }
-  return "No current work captured yet"
 }
 
 /** Session detail "Working on" body when no summary is stored yet. */

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -293,9 +293,7 @@ test("hard refresh on /v2/fleet keeps Fleet selected and renders content", async
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
 })
 
-test("agent session display name wraps instead of ellipsing", async ({
-  page,
-}) => {
+test("agent session display name truncates on one line", async ({ page }) => {
   const longName =
     "Wiring automatic tax on Stripe checkout for international customers with VAT compliance"
   await mockFleet(page, { agentOverrides: { display_name: longName } })
@@ -310,13 +308,11 @@ test("agent session display name wraps instead of ellipsing", async ({
       textOverflow: style.textOverflow,
       whiteSpace: style.whiteSpace,
       textTransform: style.textTransform,
-      fits: element.scrollWidth <= element.clientWidth + 1,
     }
   })
-  expect(typography.textOverflow).not.toBe("ellipsis")
-  expect(typography.whiteSpace).not.toBe("nowrap")
+  expect(typography.textOverflow).toBe("ellipsis")
+  expect(typography.whiteSpace).toBe("nowrap")
   expect(typography.textTransform).toBe("none")
-  expect(typography.fits).toBe(true)
 })
 
 test("agent session display name preserves stored casing", async ({ page }) => {
@@ -335,11 +331,10 @@ test("Fleet renders the calm roster from live API data", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Fleet" })).toBeVisible()
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
-  await expect(page.getByText("Opus 4.8")).toBeVisible()
+  await expect(page.getByTestId("fleet-agent-status")).toHaveText(
+    "Agent responding",
+  )
   await expect(page.getByText("10m")).toBeVisible()
-  await expect(
-    page.getByText("Wiring automatic tax onto the subscription create path"),
-  ).toBeVisible()
   // Calm summary line — agents · running · fleets, no spend/token metrics.
   await expect(page.getByText("1 agent · 1 running · 1 fleet")).toBeVisible()
 
@@ -490,9 +485,7 @@ test("activity timeline live head shows running without summary", async ({
   ).toBeVisible()
 })
 
-test("roster shows running placeholder when summary is empty", async ({
-  page,
-}) => {
+test("roster shows agent status when summary is empty", async ({ page }) => {
   await mockFleet(page, {
     agentOverrides: {
       status: "running",
@@ -503,7 +496,9 @@ test("roster shows running placeholder when summary is empty", async ({
   await page.goto("/v2/fleet")
 
   const row = page.getByTestId("fleet-agent-row")
-  await expect(row.getByText("Running in this terminal")).toBeVisible()
+  await expect(row.getByTestId("fleet-agent-status")).toHaveText(
+    "Agent responding",
+  )
   await expect(row.getByText("No current work captured yet")).toHaveCount(0)
 
   const [dotBox, ageBox, menuBox] = await Promise.all([


### PR DESCRIPTION
## Summary
- Replace multi-line Fleet agent rows with a single-line layout: session name on the left, conversation status (`Agent responding`, `Agent waiting`, etc.) on the right
- Remove work-summary blob, model subtitle, and doc title from roster rows
- Tighten spacing between the Fleet page header and the first session card

## Test plan
- [x] Typecheck passes
- [ ] Fleet Playwright tests (`tests/fleet.spec.ts`)
- [ ] Manual: confirm agent rows are one line with status on the right
- [ ] Manual: confirm header-to-first-session gap looks right


Made with [Cursor](https://cursor.com)