### PR TITLE
Polish Fleet roster status styling and eyebrow copy

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -152,14 +152,6 @@
   margin-left: auto;
 }
 
-.pin {
-  width: 5px;
-  height: 5px;
-  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten status indicators. */
-  border-radius: 999px !important;
-  background: var(--primary);
-}
-
 .fmenu {
   flex-shrink: 0;
   color: var(--fl-faint);
@@ -168,7 +160,7 @@
 /* rows */
 .arow {
   display: grid;
-  grid-template-columns: 26px minmax(0, 1fr) minmax(0, 1fr) auto 64px;
+  grid-template-columns: 26px minmax(0, 1fr) 9.5rem 2.75rem 40px;
   gap: 18px;
   align-items: center;
   width: 100%;
@@ -309,6 +301,10 @@
   white-space: nowrap;
 }
 
+.stateRunning {
+  color: var(--primary);
+}
+
 .stateWaiting {
   color: var(--fl-attention);
 }
@@ -320,7 +316,8 @@
 
 /* age */
 .age {
-  align-self: center;
+  justify-self: end;
+  width: 100%;
   color: var(--fl-faint);
   font-family: var(--font-mono);
   font-size: calc(11px * var(--v2-scale, 1));
@@ -966,7 +963,7 @@
   }
 
   .arow {
-    grid-template-columns: 26px minmax(0, 1fr) minmax(0, 1fr) 40px;
+    grid-template-columns: 26px minmax(0, 1fr) 7.5rem 40px;
     gap: 10px;
     align-items: center;
   }

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -612,8 +612,12 @@ export function FleetPage() {
   const running = runningCount(activeAgents)
   const waiting = waitingCount(activeAgents)
 
-  const summaryBits = [`${running} running`]
-  if (waiting) summaryBits.push(`${waiting} awaiting prompt`)
+  const eyebrowParts = [
+    `${workFleets.length} ${workFleets.length === 1 ? "fleet" : "fleets"}`,
+    `${activeAgents.length} ${activeAgents.length === 1 ? "agent" : "agents"}`,
+    `${running} running`,
+  ]
+  if (waiting) eyebrowParts.push(`${waiting} awaiting prompt`)
 
   const openAgent = (agent: TaskforceFleetAgent) =>
     navigate({
@@ -682,10 +686,7 @@ export function FleetPage() {
           <header className="flex items-start justify-between gap-4">
             <div>
               <div className={V2_TAB_EYEBROW_CLASS}>
-                {activeAgents.length}{" "}
-                {activeAgents.length === 1 ? "agent" : "agents"} ·{" "}
-                {summaryBits.join(" · ")} · {workFleets.length}{" "}
-                {workFleets.length === 1 ? "fleet" : "fleets"}
+                {eyebrowParts.join(" ")}
               </div>
               <h1 className="mt-1 text-2xl font-semibold tracking-tight">
                 Fleet

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -99,8 +99,8 @@ function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Something went wrong."
 }
 
-const STATE_CLASS: Record<FleetStatus, string | undefined> = {
-  run: undefined,
+const STATE_CLASS: Record<FleetStatus, string> = {
+  run: styles.stateRunning,
   waiting: styles.stateWaiting,
   paused: styles.statePaused,
   idle: styles.stateIdle,
@@ -417,14 +417,9 @@ function FleetCard({
         {!renaming && (
           <div className={styles.fheadMeta}>
             <span className={styles.fcount}>
-              {running > 0 ? (
-                <>
-                  <span className={styles.pin} />
-                  {running} active · {total}
-                </>
-              ) : (
-                `${total} ${total === 1 ? "agent" : "agents"}`
-              )}
+              {running > 0
+                ? `${running} active ${total} total`
+                : `${total} ${total === 1 ? "agent" : "agents"}`}
             </span>
             {!isHistory && (
               <DropdownMenu>

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -335,8 +335,8 @@ test("Fleet renders the calm roster from live API data", async ({ page }) => {
     "Agent responding",
   )
   await expect(page.getByText("10m")).toBeVisible()
-  // Calm summary line — agents · running · fleets, no spend/token metrics.
-  await expect(page.getByText("1 agent · 1 running · 1 fleet")).toBeVisible()
+  // Calm summary line — fleets, agents, running; no spend/token metrics.
+  await expect(page.getByText("1 fleet 1 agent 1 running")).toBeVisible()
 
   // The rejected metrics direction must not reappear.
   await expect(page.getByText(/tokens/i)).toHaveCount(0)


### PR DESCRIPTION
## Summary
- Show "Agent responding" in purple to match the running status dot
- Remove the purple pulse dot from the fleet card active count
- Update fleet card count copy to `1 active 2 total`
- Right-align status and age columns with fixed widths for consistent row layout
- Reorder page eyebrow to space-separated, fleets-first: `2 fleets 2 agents 1 running 1 awaiting prompt`

## Test plan
- [x] Typecheck passes
- [ ] Fleet Playwright tests (`tests/fleet.spec.ts`)
- [ ] Manual: status/age columns align right across rows
- [ ] Manual: eyebrow and fleet header counts read correctly


Made with [Cursor](https://cursor.com)