### PR TITLE
Polish fleet page UI

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -30,6 +30,8 @@
 }
 
 .fleet {
+  --fl-row-cols: 26px minmax(0, 1fr) 9.5rem 2.75rem 40px;
+  --fl-row-gap: 18px;
   border: 1px solid var(--border);
   background: var(--fl-surface);
   transition:
@@ -58,9 +60,10 @@
 }
 
 .fhead {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--fl-row-cols);
+  gap: var(--fl-row-gap);
   align-items: center;
-  gap: 12px;
   box-sizing: border-box;
   height: 48px;
   padding: 10px 18px;
@@ -72,11 +75,12 @@
 }
 
 .fheadToggle {
-  display: flex;
+  display: grid;
+  grid-column: 1 / 3;
+  grid-template-columns: 26px minmax(0, 1fr);
+  column-gap: var(--fl-row-gap);
   align-items: center;
-  gap: 12px;
   min-width: 0;
-  flex: 1;
   padding: 0;
   border: 0;
   background: transparent;
@@ -84,6 +88,18 @@
   font: inherit;
   text-align: left;
   cursor: pointer;
+}
+
+.fheadIdentity {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.fheadRename {
+  grid-column: 1 / -1;
 }
 
 .fheadToggle:hover {
@@ -134,6 +150,8 @@
 
 .fcount {
   display: inline-flex;
+  grid-column: 3;
+  justify-self: end;
   flex-shrink: 0;
   align-items: center;
   gap: 6px;
@@ -145,14 +163,12 @@
 }
 
 .fheadMeta {
-  display: inline-flex;
-  flex-shrink: 0;
-  align-items: center;
-  gap: 4px;
-  margin-left: auto;
+  display: contents;
 }
 
 .fmenu {
+  grid-column: 5;
+  justify-self: end;
   flex-shrink: 0;
   color: var(--fl-faint);
 }
@@ -160,8 +176,8 @@
 /* rows */
 .arow {
   display: grid;
-  grid-template-columns: 26px minmax(0, 1fr) 9.5rem 2.75rem 40px;
-  gap: 18px;
+  grid-template-columns: var(--fl-row-cols);
+  gap: var(--fl-row-gap);
   align-items: center;
   width: 100%;
   padding: 12px 18px;
@@ -182,6 +198,8 @@
 }
 
 .arowMenu {
+  grid-column: 5;
+  justify-self: end;
   color: var(--fl-faint);
 }
 
@@ -929,42 +947,38 @@
 }
 
 @media (max-width: 760px) {
+  .fleet {
+    --fl-row-cols: 26px minmax(0, 1fr) 7.5rem 40px;
+    --fl-row-gap: 10px;
+  }
+
   .fhead {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 7px 10px;
     height: auto;
     min-height: 48px;
   }
 
-  .fheadToggle {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-    align-items: center;
-    gap: 7px 10px;
+  .fheadIdentity {
+    flex-wrap: wrap;
+    row-gap: 2px;
+  }
+
+  .fheadIdentity .frepo {
     width: 100%;
   }
 
-  .fheadToggle .frepo {
-    grid-row: 2;
-    grid-column: 2 / -1;
+  .fcount {
+    grid-column: 3;
   }
 
-  .fheadMeta {
-    width: 100%;
-    justify-content: flex-end;
-    margin-left: 0;
-  }
-
-  .fcount,
   .fmenu {
-    margin-left: 0;
+    grid-column: 4;
+  }
+
+  .arowMenu {
+    grid-column: 4;
   }
 
   .arow {
-    grid-template-columns: 26px minmax(0, 1fr) 7.5rem 40px;
-    gap: 10px;
     align-items: center;
   }
 

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -31,6 +31,7 @@ import { Button } from "@/components/ui/button"
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -43,6 +44,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import {
   V2_PAGE_BODY,
   V2_PAGE_FRAME,
@@ -247,18 +249,23 @@ function AgentRow({
           if (!open) setRenameValue(agent.display_name ?? "")
         }}
       >
-        <DialogContent>
-          <form onSubmit={submitRename}>
-            <DialogHeader>
-              <DialogTitle>Rename session</DialogTitle>
-            </DialogHeader>
-            <div className="py-4">
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Rename session</DialogTitle>
+            <DialogDescription>
+              Give this agent session a short, recognizable name.
+            </DialogDescription>
+          </DialogHeader>
+          <form className="space-y-4" onSubmit={submitRename}>
+            <div className="space-y-2">
+              <Label htmlFor="fleet-session-name">Session name</Label>
               <Input
+                id="fleet-session-name"
                 value={renameValue}
                 onChange={(event) => setRenameValue(event.target.value)}
                 maxLength={120}
                 autoFocus
-                aria-label="Session name"
+                placeholder="Session name"
               />
             </div>
             <DialogFooter>
@@ -377,7 +384,7 @@ function FleetCard({
     >
       <div className={styles.fhead}>
         {renaming ? (
-          <form onSubmit={submitRename} className="flex-1">
+          <form onSubmit={submitRename} className={styles.fheadRename}>
             <Input
               value={name}
               onChange={(event) => setName(event.target.value)}
@@ -401,16 +408,18 @@ function FleetCard({
             ) : (
               <ChevronDown className={styles.fchev} aria-hidden="true" />
             )}
-            <span className={styles.fname}>{fleetTitle(fleet)}</span>
-            {!isHistory &&
-              (repo ? (
-                <span className={styles.frepo}>
-                  <b>{repo.repo}</b>
-                  {repo.branch ? ` · ${repo.branch}` : ""}
-                </span>
-              ) : (
-                <span className={styles.frepo}>no repo bound</span>
-              ))}
+            <span className={styles.fheadIdentity}>
+              <span className={styles.fname}>{fleetTitle(fleet)}</span>
+              {!isHistory &&
+                (repo ? (
+                  <span className={styles.frepo}>
+                    <b>{repo.repo}</b>
+                    {repo.branch ? ` · ${repo.branch}` : ""}
+                  </span>
+                ) : (
+                  <span className={styles.frepo}>no repo bound</span>
+                ))}
+            </span>
           </button>
         )}
 
@@ -418,7 +427,7 @@ function FleetCard({
           <div className={styles.fheadMeta}>
             <span className={styles.fcount}>
               {running > 0
-                ? `${running} active ${total} total`
+                ? `${running} active · ${total} total`
                 : `${total} ${total === 1 ? "agent" : "agents"}`}
             </span>
             {!isHistory && (
@@ -686,7 +695,7 @@ export function FleetPage() {
           <header className="flex items-start justify-between gap-4">
             <div>
               <div className={V2_TAB_EYEBROW_CLASS}>
-                {eyebrowParts.join(" ")}
+                {eyebrowParts.join(" · ")}
               </div>
               <h1 className="mt-1 text-2xl font-semibold tracking-tight">
                 Fleet


### PR DESCRIPTION
## Summary
- Tighten the rename session modal to `sm:max-w-md` with labeled input and description, matching other dialogs
- Add middle-dot separators to fleet eyebrow stats and per-fleet agent counts (`2 fleets · 3 agents · 2 running · 1 awaiting prompt`, `2 active · 3 total`)
- Share a grid between session headers and agent rows so the ⋯ action menus align vertically

## Test plan
- [x] Open Fleet tab and confirm eyebrow shows middle-dot separators
- [x] Confirm fleet card header shows `N active · M total` with middle dot
- [x] Confirm session header ⋯ menu aligns with agent row ⋯ menus
- [x] Open Rename on an agent row and confirm compact modal layout


Made with [Cursor](https://cursor.com)