### PR TITLE
feat(fleet): tool chip (Claude/Codex/Cursor/Other) on each agent row

### DIFF
--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -59,6 +59,7 @@ export interface TaskforceFleetAgent {
   specialist_slug: string | null
   specialist_rule_count: number | null
   model_id: string | null
+  agent_kind: "claude" | "codex" | "cursor" | "other"
 }
 
 export interface TaskforceFleetSession {

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -292,11 +292,15 @@
 
 /* identity */
 .who {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   min-width: 0;
 }
 
 .nm {
   overflow: hidden;
+  min-width: 0;
   color: var(--foreground);
   font-size: calc(14px * var(--v2-scale, 1));
   font-weight: 500;
@@ -305,6 +309,57 @@
   text-overflow: ellipsis;
   text-transform: none;
   white-space: nowrap;
+}
+
+/* client chip — which coding tool drives the session. Fixed width so the chips
+   line up in a column to the left of the agent names. */
+.chip {
+  display: inline-flex;
+  box-sizing: border-box;
+  width: 62px;
+  height: 20px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 0 6px;
+  border: 1px solid var(--border);
+  font-size: calc(10.5px * var(--v2-scale, 1));
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+/* Anthropic orange. */
+.chipClaude {
+  border-color: color-mix(in srgb, #d97757 50%, var(--border));
+  background: color-mix(in srgb, #d97757 16%, var(--background));
+  color: color-mix(in srgb, #d97757 72%, var(--foreground));
+}
+
+/* ChatGPT white — a light chip that reads on either theme. */
+.chipCodex {
+  border-color: color-mix(in srgb, var(--foreground) 24%, var(--border));
+  background: #ffffff;
+  color: #1a1a1a;
+}
+
+/* Cursor gray. */
+.chipCursor {
+  border-color: color-mix(in srgb, var(--foreground) 16%, var(--border));
+  background: color-mix(
+    in srgb,
+    var(--muted-foreground) 18%,
+    var(--background)
+  );
+  color: var(--muted-foreground);
+}
+
+/* Unknown / unreported tool. */
+.chipOther {
+  border-color: var(--border);
+  background: transparent;
+  color: var(--fl-faint);
 }
 
 /* roster status */

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -57,7 +57,10 @@ import { peekTaskforceSession } from "@/lib/taskforceSession"
 import { cn } from "@/lib/utils"
 import styles from "./FleetPage.module.css"
 import {
+  AGENT_KIND_LABEL,
+  type AgentKind,
   agentDisplayName,
+  agentKind,
   agentStatus,
   compactPresence,
   type FleetStatus,
@@ -118,6 +121,26 @@ function StatusDot({ status }: { status: FleetStatus }) {
         status === "run" && styles.pulse,
       )}
     />
+  )
+}
+
+const CHIP_CLASS: Record<AgentKind, string> = {
+  claude: styles.chipClaude,
+  codex: styles.chipCodex,
+  cursor: styles.chipCursor,
+  other: styles.chipOther,
+}
+
+function ClientChip({ kind }: { kind: AgentKind }) {
+  const label = AGENT_KIND_LABEL[kind]
+  return (
+    <span
+      data-testid="fleet-agent-chip"
+      className={cn(styles.chip, CHIP_CLASS[kind])}
+      title={`Driven by ${label}`}
+    >
+      {label}
+    </span>
   )
 }
 
@@ -202,6 +225,7 @@ function AgentRow({
           <StatusDot status={status} />
         </span>
         <div className={styles.who}>
+          <ClientChip kind={agentKind(agent)} />
           <div className={styles.nm} data-testid="fleet-agent-name">
             {sessionLabel}
           </div>

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -30,6 +30,25 @@ export function rosterStatusLabel(agent: TaskforceFleetAgent): string {
   return ROSTER_STATUS_LABEL[agentStatus(agent)]
 }
 
+/** Which coding tool drives a session — backend-classified for the row chip. */
+export type AgentKind = "claude" | "codex" | "cursor" | "other"
+
+/** Short chip label per tool. "Other" covers unknown/unreported clients. */
+export const AGENT_KIND_LABEL: Record<AgentKind, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  cursor: "Cursor",
+  other: "Other",
+}
+
+/** Defensive against APIs that predate `agent_kind`. */
+export function agentKind(agent: TaskforceFleetAgent): AgentKind {
+  const kind = agent.agent_kind
+  return kind === "claude" || kind === "codex" || kind === "cursor"
+    ? kind
+    : "other"
+}
+
 // Ingestion does not capture these fields yet. Keep the accessors defensive so
 // the detail route can adopt them without fabricating data in the API.
 type FutureAgentFields = TaskforceFleetAgent & {


### PR DESCRIPTION
## What
Adds a fixed-width, color-coded chip to the **left of every Fleet agent name** showing which coding tool drives the session.

- **Claude** — Anthropic orange
- **Codex** — ChatGPT white
- **Cursor** — gray
- **Other** — muted (unknown / unreported client)

Chips are a uniform 62px wide and live at the start of the `.who` column, so they line up in a clean column down the roster regardless of name length.

## How
- Reads the backend-classified `agent_kind` field (see backend PR al-exe/EnderAI#161).
- `agentKind()` helper falls back to `"other"` defensively, so the UI is safe against API responses that predate the field.

## Validation
- `tsc -p tsconfig.build.json --noEmit` clean.
- `biome check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)