### PR TITLE
Rename Fleet to Sessions and polish roster UI

### DIFF
--- a/design/redesign.html
+++ b/design/redesign.html
@@ -297,7 +297,7 @@ html.dark .theme-toggle .sun { display: none; }
 /* ---------- Feature rows ---------- */
 .features { padding: 0 0 8px; }
 .features .row:first-child { border-top: 0; padding-top: 32px; }
-#fleet { scroll-margin-top: 28px; }
+#sessions { scroll-margin-top: 28px; }
 .row {
   display: grid; grid-template-columns: 1fr 1fr; gap: 64px; align-items: center;
   padding: 64px 0; border-top: 1px solid var(--hairline);
@@ -550,7 +550,7 @@ footer.foot { padding: 40px 0 56px; }
       Taskforce
     </a>
     <nav class="nav-links">
-      <a href="#fleet">Orchestration</a>
+      <a href="#sessions">Orchestration</a>
       <a href="#profiles">Profiles</a>
       <a href="#library">Docs</a>
       <a href="#ledger">Audit</a>
@@ -581,9 +581,9 @@ footer.foot { padding: 40px 0 56px; }
       <div class="hero-copy reveal">
         <span class="eyebrow">AI work memory for engineering teams</span>
         <h1><span class="lead">Stop </span><span class="phrase">losing track<br>of your agents.</span></h1>
-        <div class="hero-cap"><span class="ck">Fleet</span><span class="sep">·</span><span class="cap-name">Orchestration</span></div>
+        <div class="hero-cap"><span class="ck">Sessions</span><span class="sep">·</span><span class="cap-name">Orchestration</span></div>
         <div class="hero-dots" role="tablist" aria-label="Capabilities">
-          <button class="on" type="button" aria-label="Fleet"></button>
+          <button class="on" type="button" aria-label="Sessions"></button>
           <button type="button" aria-label="Profiles"></button>
           <button type="button" aria-label="Library"></button>
           <button type="button" aria-label="Ledger"></button>
@@ -615,7 +615,7 @@ footer.foot { padding: 40px 0 56px; }
               <div class="tline ag"><span class="d grn"></span><span class="anm">api-deprecation</span><span class="ah">claude · vm-02</span><span class="ast">38 left</span></div>
               <div class="tline live-line"><span class="acc">live ▸</span> <span class="dim">tax-refactor referenced “Stripe checkout wiring”</span></div>
               <div class="tsum">
-                <div><div class="k">fleet</div><div class="v big">6 active</div></div>
+                <div><div class="k">sessions</div><div class="v big">6 active</div></div>
                 <div><div class="k">across</div><div class="v">3 terminals · 3 VMs</div></div>
                 <div><div class="k">context</div><div class="v">shared</div></div>
               </div>
@@ -685,7 +685,7 @@ footer.foot { padding: 40px 0 56px; }
   </div>
   </div>
 
-  <a class="scroll-cue" href="#fleet" aria-label="Scroll to capabilities">
+  <a class="scroll-cue" href="#sessions" aria-label="Scroll to capabilities">
     <span class="cue-rule"></span>
     <span class="cue-arrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"></path></svg></span>
     <span class="cue-rule"></span>
@@ -697,18 +697,18 @@ footer.foot { padding: 40px 0 56px; }
   <div class="wrap">
 
     <!-- ROW 1 — FLEET (visual left) -->
-    <div class="row img-left reveal" id="fleet">
+    <div class="row img-left reveal" id="sessions">
       <div class="copy">
         <div class="feat-label">
           <span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg></span>
-          <span class="lbl">Fleet</span>
+          <span class="lbl">Sessions</span>
         </div>
         <h2>Orchestration</h2>
         <p class="desc">Track every agent in one live view. Group them into fleets and enable them to contribute to a shared context window for compounding effectiveness.</p>
       </div>
       <div class="visual">
         <div class="panel">
-          <div class="panel-head"><span class="dot purple"></span>Fleet<span class="spacer"></span><span class="chip">4 active</span></div>
+          <div class="panel-head"><span class="dot purple"></span>Sessions<span class="spacer"></span><span class="chip">4 active</span></div>
           <div class="fleet-body">
             <div class="fleet-group">
               <div class="gh">Checkout squad <span class="count">2</span><span class="bar"></span></div>
@@ -978,7 +978,7 @@ document.documentElement.classList.add('js');
 <script>
 (function () {
   var SCENES = [
-    { key: 'Fleet',    name: 'Orchestration',      phrase: 'losing track<br>of your agents.' },
+    { key: 'Sessions',    name: 'Orchestration',      phrase: 'losing track<br>of your agents.' },
     { key: 'Profiles', name: 'Agent profiles',     phrase: 're-briefing<br>every agent.' },
     { key: 'Library',  name: 'Self-updating documents',  phrase: 're-explaining<br>your codebase.' },
     { key: 'Ledger',   name: 'Audit trail',        phrase: 'guessing what<br>agents did.' },

--- a/src/components/UserSettings/ConnectAgent.tsx
+++ b/src/components/UserSettings/ConnectAgent.tsx
@@ -132,7 +132,7 @@ function buildAgentInstructionSnippet({
       "If Taskforce V2 MCP tools are available:",
       "- When creating or rotating a Taskforce MCP credential during setup, tell the user to start from a fresh terminal before reconnecting the AI client so the updated shell environment is loaded.",
       "- For Cursor, Codex, and other hookless MCP clients, call `taskforce_session_start` at the start of meaningful user-initiated work with `client` set to your harness (`cursor`, `codex`, etc.). Thread the returned `session_id` through every subsequent `taskforce_session_observe` call.",
-      "- When hooks are installed (Claude Code, Codex, Cursor Connect flows), discovery and Fleet registration happen automatically; still call `taskforce_session_start` when you need explicit preamble injection in Cursor.",
+      "- When hooks are installed (Claude Code, Codex, Cursor Connect flows), discovery and Sessions registration happen automatically; still call `taskforce_session_start` when you need explicit preamble injection in Cursor.",
       "- Create or reuse a Taskforce document at the start of meaningful user-initiated work with `taskforce_begin_document`. It scores existing documents against the request, reuses + self-heals a strong match, or creates a fresh one. Read the returned `match_reasons`, `candidate_summaries`, and `self_healed_fields` before continuing.",
       "- Maintain both document views: a concise Summary view shown by default and a comprehensive Details view available on demand.",
       "- Use `taskforce_update_document` as material progress develops (commands, files, links, decisions, changes, open questions, progress notes). Pass `details_sections` with stable `anchor_id`s to upsert specific Details sections, and `summary_points` for new Summary claims.",
@@ -595,7 +595,7 @@ const ConnectAgent = () => {
 
               <SnippetBlock
                 title="Connect Codex"
-                description="Persists the credential and installs Fleet registration plus prior-work discovery hooks."
+                description="Persists the credential and installs Sessions registration plus prior-work discovery hooks."
                 snippet={codexConnectSnippet ?? ""}
                 copiedText={copiedText}
                 onCopy={(value) => {
@@ -607,7 +607,7 @@ const ConnectAgent = () => {
 
               <SnippetBlock
                 title="Connect Cursor"
-                description="Persists the credential and installs Fleet registration, discovery metrics, and conversation capture hooks."
+                description="Persists the credential and installs Sessions registration, discovery metrics, and conversation capture hooks."
                 snippet={cursorConnectSnippet ?? ""}
                 copiedText={copiedText}
                 onCopy={(value) => {
@@ -623,7 +623,7 @@ const ConnectAgent = () => {
                 <AlertDescription>
                   After installing, restart Codex, run `/hooks`, trust the
                   Taskforce hooks, then start a new Codex session. New sessions
-                  will appear in Fleet immediately.
+                  will appear in Sessions immediately.
                 </AlertDescription>
               </Alert>
 
@@ -632,7 +632,7 @@ const ConnectAgent = () => {
                 <AlertTitle>Reload Cursor hooks</AlertTitle>
                 <AlertDescription>
                   After installing, restart Cursor or reload hooks from Settings
-                  → Hooks. New Agent sessions will appear in Fleet immediately.
+                  → Hooks. New Agent sessions will appear in Sessions immediately.
                   For full prior-work preamble injection in Cursor, also keep the
                   Taskforce MCP server connected and follow the agent
                   instructions below.

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -19,6 +19,7 @@
     oklch(0.68 0.12 62) 72%,
     var(--foreground)
   );
+  --fl-waiting: var(--destructive);
 }
 
 /* ===== Fleet group (enclosed session card) ===== */
@@ -150,7 +151,7 @@
 
 .fcount {
   display: inline-flex;
-  grid-column: 3;
+  grid-column: 4;
   justify-self: end;
   flex-shrink: 0;
   align-items: center;
@@ -158,8 +159,10 @@
   color: var(--fl-faint);
   font-family: var(--font-mono);
   font-size: calc(11px * var(--v2-scale, 1));
+  font-variant-numeric: tabular-nums;
   letter-spacing: 0.01em;
   white-space: nowrap;
+  text-align: right;
 }
 
 .fheadMeta {
@@ -277,7 +280,7 @@
 }
 
 .waiting {
-  background: var(--fl-attention);
+  background: var(--fl-waiting);
 }
 
 @keyframes fleet-pulse {
@@ -300,6 +303,7 @@
 
 .nm {
   overflow: hidden;
+  flex: 1;
   min-width: 0;
   color: var(--foreground);
   font-size: calc(14px * var(--v2-scale, 1));
@@ -337,11 +341,11 @@
   color: color-mix(in srgb, #d97757 72%, var(--foreground));
 }
 
-/* ChatGPT white — a light chip that reads on either theme. */
+/* Codex indigo — blue/purple brand tint on either theme. */
 .chipCodex {
-  border-color: color-mix(in srgb, var(--foreground) 24%, var(--border));
-  background: #ffffff;
-  color: #1a1a1a;
+  border-color: color-mix(in srgb, #5b6ce8 52%, var(--border));
+  background: color-mix(in srgb, #5b6ce8 18%, var(--background));
+  color: color-mix(in srgb, #5b6ce8 84%, var(--foreground));
 }
 
 /* Cursor gray. */
@@ -379,7 +383,7 @@
 }
 
 .stateWaiting {
-  color: var(--fl-attention);
+  color: var(--fl-waiting);
 }
 
 .statePaused,
@@ -655,7 +659,10 @@
   background: var(--primary);
 }
 
-.tevWait .tdot,
+.tevWait .tdot {
+  background: var(--fl-waiting);
+}
+
 .tevPause .tdot {
   background: var(--fl-attention);
 }

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -196,7 +196,7 @@ function AgentRow({
       draggable={draggable && !isMoving}
       title={
         draggable
-          ? "Drag to move this agent to another fleet"
+          ? "Drag to move this agent to another session group"
           : "View this agent session"
       }
       onDragStart={(event) => {
@@ -384,7 +384,7 @@ function FleetCard({
 
   return (
     <section
-      aria-label={`${fleetTitle(fleet)} fleet`}
+      aria-label={`${fleetTitle(fleet)} session group`}
       data-testid={`fleet-card-${fleet.id}`}
       data-collapsed={isCollapsed ? "true" : "false"}
       className={cn(
@@ -414,7 +414,7 @@ function FleetCard({
               onChange={(event) => setName(event.target.value)}
               maxLength={120}
               autoFocus
-              aria-label="Fleet name"
+              aria-label="Session group name"
               className="h-7"
             />
           </form>
@@ -499,7 +499,7 @@ function FleetCard({
               <div className={styles.emptyRows}>
                 {isHistory
                   ? "Inactive agent sessions appear here."
-                  : "No active agents in this fleet yet."}
+                  : "No active agents in this session group yet."}
               </div>
             ) : (
               fleet.agents.map((agent) => (
@@ -646,7 +646,7 @@ export function FleetPage() {
   const waiting = waitingCount(activeAgents)
 
   const eyebrowParts = [
-    `${workFleets.length} ${workFleets.length === 1 ? "fleet" : "fleets"}`,
+    `${workFleets.length} ${workFleets.length === 1 ? "group" : "groups"}`,
     `${activeAgents.length} ${activeAgents.length === 1 ? "agent" : "agents"}`,
     `${running} running`,
   ]
@@ -722,7 +722,7 @@ export function FleetPage() {
                 {eyebrowParts.join(" · ")}
               </div>
               <h1 className="mt-1 text-2xl font-semibold tracking-tight">
-                Fleet
+                Sessions
               </h1>
             </div>
             <Button
@@ -735,7 +735,7 @@ export function FleetPage() {
               }}
             >
               <Plus />
-              New fleet
+              New group
             </Button>
           </header>
         </div>
@@ -759,7 +759,7 @@ export function FleetPage() {
           ) : fleetQuery.error ? (
             <div className="border border-destructive/30 bg-destructive/5 p-6">
               <h2 className="font-medium text-destructive">
-                Fleet could not load
+                Sessions could not load
               </h2>
               <p className="mt-1 text-sm text-muted-foreground">
                 {errorMessage(fleetQuery.error)}

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -155,6 +155,37 @@ export function formatClockTime(iso: string): string {
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
 }
 
+const FLEET_UI_MARKERS = [
+  "View in Ledger",
+  "Awaiting user prompt",
+  "Running in this terminal",
+]
+
+/** Strip Cursor wrappers and Fleet UI paste noise for activity display. */
+export function cleanActivityPromptText(text: string | null | undefined): string {
+  if (!text) return ""
+  let cleaned = text
+    .replace(/^<user_query>\s*/i, "")
+    .replace(/\s*<\/user_query>\s*$/i, "")
+    .trim()
+  if (!FLEET_UI_MARKERS.some((marker) => cleaned.includes(marker))) {
+    return cleaned
+  }
+  const blocks = cleaned
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .filter(Boolean)
+  const tail = blocks[blocks.length - 1]
+  if (
+    tail &&
+    tail.length <= 400 &&
+    !FLEET_UI_MARKERS.some((marker) => tail.includes(marker))
+  ) {
+    return tail
+  }
+  return cleaned
+}
+
 /** Relative time for the live timeline head — matches the session header. */
 export function liveActivityTime(agent: TaskforceFleetAgent): string {
   return compactPresence(agent)
@@ -221,7 +252,7 @@ export function presenceLabel(agent: TaskforceFleetAgent): string {
 
 /** Display name for a fleet (server may create nameless fleets). */
 export function fleetTitle(fleet: TaskforceFleetSession): string {
-  return fleet.name?.trim() || "Untitled fleet"
+  return fleet.name?.trim() || "Untitled group"
 }
 
 /** Repo/branch shown on a fleet card header, derived from its agents. */

--- a/src/components/V2/Landing/FeatureSection.tsx
+++ b/src/components/V2/Landing/FeatureSection.tsx
@@ -10,12 +10,12 @@ export function FeatureSection() {
     <section className={styles.features}>
       <div className={styles.wrap}>
         <FeatureRow
-          body="Track every agent in one live view. Group them into fleets and enable them to contribute to a shared context window for compounding effectiveness."
+          body="Track every agent in one live view. Organize sessions into groups and enable them to contribute to a shared context window for compounding effectiveness."
           icon={Boxes}
-          id="fleet"
-          label="Fleet"
+          id="sessions"
+          label="Sessions"
           title="Orchestration"
-          visual={<FleetPanel />}
+          visual={<SessionsPanel />}
           visualLeft
         />
         <FeatureRow
@@ -109,9 +109,9 @@ function Panel({
   )
 }
 
-function FleetPanel() {
+function SessionsPanel() {
   return (
-    <Panel chip="4 active" label="Fleet">
+    <Panel chip="4 active" label="Sessions">
       <div className={styles.fleetBody}>
         <FleetGroup
           agents={[

--- a/src/components/V2/Landing/Hero.tsx
+++ b/src/components/V2/Landing/Hero.tsx
@@ -10,7 +10,7 @@ import styles from "./Landing.module.css"
 
 const SCENES = [
   {
-    key: "Fleet",
+    key: "Sessions",
     name: "Orchestration",
     phrase: ["losing track", "of your agents."],
   },
@@ -224,7 +224,7 @@ export function LandingHero() {
       <a
         aria-label="Scroll to capabilities"
         className={styles.scrollCue}
-        href="#fleet"
+        href="#sessions"
       >
         <span className={styles.cueRule} />
         <span className={styles.cueArrow}>
@@ -308,7 +308,7 @@ function FleetScene() {
       </div>
       <SummaryGrid
         items={[
-          ["fleet", "6 active", true],
+          ["sessions", "6 active", true],
           ["across", "3 terminals - 3 VMs"],
           ["context", "shared"],
         ]}

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -694,7 +694,7 @@
   padding: 0 0 8px;
 }
 
-#fleet {
+#sessions {
   scroll-margin-top: 28px;
 }
 

--- a/src/components/V2/Landing/LandingFooter.tsx
+++ b/src/components/V2/Landing/LandingFooter.tsx
@@ -23,7 +23,7 @@ export function LandingFooter() {
           <div className={styles.footerLinks}>
             <a href="#library">Docs</a>
             <Link to="/pricing">Pricing</Link>
-            <a href="#fleet">Changelog</a>
+            <a href="#sessions">Changelog</a>
             <a href="#top">Privacy</a>
           </div>
           <span className={styles.copyright}>2026 Taskforce</span>

--- a/src/components/V2/Landing/LandingNav.tsx
+++ b/src/components/V2/Landing/LandingNav.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button"
 import styles from "./Landing.module.css"
 
 const navItems = [
-  { href: "#fleet", label: "Orchestration" },
+  { href: "#sessions", label: "Orchestration" },
   { href: "#profiles", label: "Profiles" },
   { href: "#library", label: "Docs" },
   { href: "#ledger", label: "Audit" },

--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -66,7 +66,7 @@ type TaskforceNavItem = {
 }
 
 const taskforceItems: TaskforceNavItem[] = [
-  { icon: LayoutGrid, title: "Fleet", path: "/v2/fleet" },
+  { icon: LayoutGrid, title: "Sessions", path: "/v2/fleet" },
   { icon: Bot, title: "Profiles", path: "/v2/agents" },
   { icon: BookOpen, title: "Library", path: "/v2/library" },
   { icon: ReceiptText, title: "Ledger", path: "/v2/ledger" },

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -22,6 +22,7 @@ import {
   agentSpecialistRuleCount,
   agentStartedAt,
   agentStatus,
+  cleanActivityPromptText,
   compactPresence,
   type FleetStatus,
   fleetTitle,
@@ -83,7 +84,11 @@ function metaRow(key: string, value: string, valueClass?: string) {
 function eventTitle(event: TaskforceSessionActivityEntry): string {
   if (event.kind === "command") return `$ ${event.cmd ?? "command"}`
   if (event.kind === "edit") return `Edited ${event.file ?? "file"}`
-  return event.text ?? event.note ?? event.kind
+  const raw = event.text ?? event.note ?? event.kind
+  if (event.kind === "prompt" || event.kind === "reply") {
+    return cleanActivityPromptText(raw) || raw
+  }
+  return raw
 }
 
 function eventDetail(event: TaskforceSessionActivityEntry): string | null {
@@ -143,7 +148,7 @@ function FleetAgentDetailRoute() {
             : "This agent is no longer active."}
         </p>
         <Button asChild variant="outline">
-          <Link to="/v2/fleet">Back to Fleet</Link>
+          <Link to="/v2/fleet">Back to Sessions</Link>
         </Button>
       </div>
     )
@@ -185,7 +190,7 @@ function FleetAgentDetailRoute() {
         <div className={styles.crumb}>
           <Link to="/v2/fleet" className={styles.back}>
             <ChevronLeft />
-            Fleet
+            Sessions
           </Link>
           <span className={styles.sep}>/</span>
           <span>{fleetName}</span>
@@ -392,7 +397,7 @@ function FleetAgentDetailRoute() {
           {/* Session meta */}
           <div className={styles.block}>
             <div className={styles.seclabel}>Session</div>
-            {metaRow("Fleet", fleetName)}
+            {metaRow("Group", fleetName)}
             {agent.branch && metaRow("Branch", agent.branch)}
             {(host || agent.repo) &&
               metaRow("Host", host ?? (agent.repo as string))}

--- a/src/routes/v2/fleet.tsx
+++ b/src/routes/v2/fleet.tsx
@@ -5,7 +5,7 @@ export const Route = createFileRoute("/v2/fleet")({
   head: () => ({
     meta: [
       {
-        title: "Taskforce | Fleet",
+        title: "Taskforce | Sessions",
       },
     ],
   }),

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -270,11 +270,11 @@ test("hard refresh on /v2/fleet/ keeps Fleet selected and renders content", asyn
   await page.goto("/v2/fleet/")
   await page.reload()
 
-  await expect(page.getByRole("link", { name: "Fleet" })).toHaveAttribute(
+  await expect(page.getByRole("link", { name: "Sessions" })).toHaveAttribute(
     "data-active",
     "true",
   )
-  await expect(page.getByRole("heading", { name: "Fleet" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Sessions" })).toBeVisible()
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
 })
 
@@ -285,11 +285,11 @@ test("hard refresh on /v2/fleet keeps Fleet selected and renders content", async
   await page.goto("/v2/fleet")
   await page.reload()
 
-  await expect(page.getByRole("link", { name: "Fleet" })).toHaveAttribute(
+  await expect(page.getByRole("link", { name: "Sessions" })).toHaveAttribute(
     "data-active",
     "true",
   )
-  await expect(page.getByRole("heading", { name: "Fleet" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Sessions" })).toBeVisible()
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
 })
 
@@ -329,14 +329,14 @@ test("Fleet renders the calm roster from live API data", async ({ page }) => {
   await mockFleet(page)
   await page.goto("/v2/fleet")
 
-  await expect(page.getByRole("heading", { name: "Fleet" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Sessions" })).toBeVisible()
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
   await expect(page.getByTestId("fleet-agent-status")).toHaveText(
     "Agent responding",
   )
   await expect(page.getByText("10m")).toBeVisible()
   // Calm summary line — fleets, agents, running; no spend/token metrics.
-  await expect(page.getByText("1 fleet 1 agent 1 running")).toBeVisible()
+  await expect(page.getByText("1 group · 1 agent · 1 running")).toBeVisible()
 
   // The rejected metrics direction must not reappear.
   await expect(page.getByText(/tokens/i)).toHaveCount(0)
@@ -359,7 +359,7 @@ test("Fleet renders the calm roster from live API data", async ({ page }) => {
       request.url().endsWith("/api/v1/v2/taskforce/fleet") &&
       request.method() === "POST",
   )
-  await page.getByRole("button", { name: "New fleet" }).click()
+  await page.getByRole("button", { name: "New group" }).click()
   expect((await createRequest).postDataJSON()).toEqual({})
 })
 
@@ -394,7 +394,7 @@ test("clicking an agent row opens the session detail and back returns", async ({
   await expect(page.getByText(expectedStarted)).toBeVisible()
 
   // Breadcrumb returns to the roster.
-  await page.getByRole("link", { name: "Fleet" }).first().click()
+  await page.getByRole("link", { name: "Sessions" }).first().click()
   await expect(page).toHaveURL(/\/v2\/fleet$/)
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
 })
@@ -661,7 +661,7 @@ for (const theme of ["light", "dark"] as const) {
     for (const width of [360, 768, 1280]) {
       await page.setViewportSize({ width, height: 900 })
       await page.goto("/v2/fleet")
-      await expect(page.getByRole("heading", { name: "Fleet" })).toBeVisible()
+      await expect(page.getByRole("heading", { name: "Sessions" })).toBeVisible()
       await expect(page.locator("html")).toHaveClass(new RegExp(theme))
 
       const rosterOverflow = await page.evaluate(

--- a/tests/ledger.spec.ts
+++ b/tests/ledger.spec.ts
@@ -123,7 +123,7 @@ function ledgerDetail(rawTranscriptAvailable: boolean) {
         occurred_at: "2026-06-12T20:00:45Z",
         role: "assistant",
         who: "Codex",
-        text: "Ledger timeline now matches Fleet.",
+        text: "Ledger timeline now matches Sessions.",
         cmd: null,
         exit_code: null,
         output: null,

--- a/tests/user-settings.spec.ts
+++ b/tests/user-settings.spec.ts
@@ -734,7 +734,7 @@ test("Connect agent generates the hosted MCP setup and hides revoked credentials
   await expect(page.getByText("Trust Codex hooks once")).toBeVisible()
   await expect(page.getByText("Reload Cursor hooks")).toBeVisible()
   await expect(
-    page.getByText("New sessions will appear in Fleet immediately."),
+    page.getByText("New sessions will appear in Sessions immediately."),
   ).toBeVisible()
   await expect(page.getByText("3. Advanced MCP setup")).toBeVisible()
   await expect(


### PR DESCRIPTION
## Summary
- Rename the Fleet tab, page title, landing/marketing copy, and settings strings to **Sessions** (session groups keep the "group" label in the roster).
- Polish Sessions roster UI: waiting state uses destructive red, fleet header count aligns with the age column, Codex client chip uses indigo brand tint instead of white/black.
- Update tests and static redesign mock to match.

## Test plan
- [x] Typecheck passes (`tsc -p tsconfig.build.json`)
- [ ] Sessions tab shows renamed labels, red waiting state, and indigo Codex chips
- [ ] Landing `#sessions` anchor and hero/feature copy read "Sessions"
- [ ] `fleet.spec.ts` and `user-settings.spec.ts` pass in CI


Made with [Cursor](https://cursor.com)