### PR TITLE
Polish fleet session roster copy and header counts

### DIFF
--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -434,15 +434,12 @@ function FleetCard({
             )}
             <span className={styles.fheadIdentity}>
               <span className={styles.fname}>{fleetTitle(fleet)}</span>
-              {!isHistory &&
-                (repo ? (
-                  <span className={styles.frepo}>
-                    <b>{repo.repo}</b>
-                    {repo.branch ? ` · ${repo.branch}` : ""}
-                  </span>
-                ) : (
-                  <span className={styles.frepo}>no repo bound</span>
-                ))}
+              {!isHistory && repo ? (
+                <span className={styles.frepo}>
+                  <b>{repo.repo}</b>
+                  {repo.branch ? ` · ${repo.branch}` : ""}
+                </span>
+              ) : null}
             </span>
           </button>
         )}
@@ -450,9 +447,7 @@ function FleetCard({
         {!renaming && (
           <div className={styles.fheadMeta}>
             <span className={styles.fcount}>
-              {running > 0
-                ? `${running} active · ${total} total`
-                : `${total} ${total === 1 ? "agent" : "agents"}`}
+              {`${running} active · ${total} total`}
             </span>
             {!isHistory && (
               <DropdownMenu>
@@ -646,7 +641,7 @@ export function FleetPage() {
   const waiting = waitingCount(activeAgents)
 
   const eyebrowParts = [
-    `${workFleets.length} ${workFleets.length === 1 ? "group" : "groups"}`,
+    `${workFleets.length} ${workFleets.length === 1 ? "session" : "sessions"}`,
     `${activeAgents.length} ${activeAgents.length === 1 ? "agent" : "agents"}`,
     `${running} running`,
   ]
@@ -735,7 +730,7 @@ export function FleetPage() {
               }}
             >
               <Plus />
-              New group
+              New session
             </Button>
           </header>
         </div>

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -336,7 +336,7 @@ test("Fleet renders the calm roster from live API data", async ({ page }) => {
   )
   await expect(page.getByText("10m")).toBeVisible()
   // Calm summary line — fleets, agents, running; no spend/token metrics.
-  await expect(page.getByText("1 group · 1 agent · 1 running")).toBeVisible()
+  await expect(page.getByText("1 session · 1 agent · 1 running")).toBeVisible()
 
   // The rejected metrics direction must not reappear.
   await expect(page.getByText(/tokens/i)).toHaveCount(0)
@@ -359,7 +359,7 @@ test("Fleet renders the calm roster from live API data", async ({ page }) => {
       request.url().endsWith("/api/v1/v2/taskforce/fleet") &&
       request.method() === "POST",
   )
-  await page.getByRole("button", { name: "New group" }).click()
+  await page.getByRole("button", { name: "New session" }).click()
   expect((await createRequest).postDataJSON()).toEqual({})
 })
 


### PR DESCRIPTION
## Summary
- Rename fleet eyebrow and CTA from **groups** to **sessions** (`2 sessions · …`, **+ New session**).
- Remove the **no repo bound** placeholder; repo/branch only renders when an agent reports one.
- Always show session card counts as **`X active · Y total`** instead of falling back to `1 agent` when nothing is running.

## Test plan
- [x] Updated Playwright assertions for eyebrow summary and New session button
- [ ] `npm test` fleet spec in CI


Made with [Cursor](https://cursor.com)