### PR TITLE
Remove repo and branch from Sessions roster UI

### DIFF
--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -45,8 +45,6 @@ export interface TaskforceFleetAgent {
   session_id: string
   fleet_session_id: string
   cwd: string | null
-  branch: string | null
-  repo: string | null
   active_document_id: string | null
   referenced_document_ids: string[]
   display_name: string

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -134,21 +134,6 @@
   outline-offset: 2px;
 }
 
-.frepo {
-  overflow: hidden;
-  color: var(--fl-faint);
-  font-family: var(--font-mono);
-  font-size: calc(11px * var(--v2-scale, 1));
-  letter-spacing: 0.01em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.frepo b {
-  color: var(--muted-foreground);
-  font-weight: 400;
-}
-
 .fcount {
   display: inline-flex;
   grid-column: 4;
@@ -1022,10 +1007,6 @@
   .fheadIdentity {
     flex-wrap: wrap;
     row-gap: 2px;
-  }
-
-  .fheadIdentity .frepo {
-    width: 100%;
   }
 
   .fcount {

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -64,7 +64,6 @@ import {
   agentStatus,
   compactPresence,
   type FleetStatus,
-  fleetRepo,
   fleetTitle,
   rosterStatusLabel,
   runningCount,
@@ -357,7 +356,6 @@ function FleetCard({
   const [renaming, setRenaming] = useState(false)
   const [name, setName] = useState(fleet.name ?? "")
 
-  const repo = fleetRepo(fleet)
   const running = runningCount(fleet.agents)
   const total = fleet.agents.length
   const isHistory = fleet.is_history
@@ -434,12 +432,6 @@ function FleetCard({
             )}
             <span className={styles.fheadIdentity}>
               <span className={styles.fname}>{fleetTitle(fleet)}</span>
-              {!isHistory && repo ? (
-                <span className={styles.frepo}>
-                  <b>{repo.repo}</b>
-                  {repo.branch ? ` · ${repo.branch}` : ""}
-                </span>
-              ) : null}
             </span>
           </button>
         )}

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -115,9 +115,10 @@ export function modelLabel(modelId: string | null): string | null {
   return version ? `${name} ${version}` : name
 }
 
+/** Fallback label when display_name is unset. Uses cwd basename only. */
 export function repoLabel(agent: TaskforceFleetAgent): string {
   const cwdParts = agent.cwd?.split("/").filter(Boolean) ?? []
-  return agent.repo || cwdParts[cwdParts.length - 1] || "Unknown repo"
+  return cwdParts[cwdParts.length - 1] || "Unknown repo"
 }
 
 /** Machine label, e.g. "mbp-16". Not captured by ingestion yet. */
@@ -253,19 +254,6 @@ export function presenceLabel(agent: TaskforceFleetAgent): string {
 /** Display name for a fleet (server may create nameless fleets). */
 export function fleetTitle(fleet: TaskforceFleetSession): string {
   return fleet.name?.trim() || "Untitled group"
-}
-
-/** Repo/branch shown on a fleet card header, derived from its agents. */
-export function fleetRepo(
-  fleet: TaskforceFleetSession,
-): { repo: string; branch: string | null } | null {
-  if (fleet.is_history) return null
-  for (const agent of fleet.agents) {
-    if (agent.repo) {
-      return { repo: agent.repo, branch: agent.branch }
-    }
-  }
-  return null
 }
 
 export function runningCount(agents: TaskforceFleetAgent[]): number {

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -175,9 +175,7 @@ function FleetAgentDetailRoute() {
     }
   })
 
-  const dmetaBits = [model, host, agent.branch].filter((bit): bit is string =>
-    Boolean(bit),
-  )
+  const dmetaBits = [model, host].filter((bit): bit is string => Boolean(bit))
 
   // The same canonical event stream shown by Ledger, newest-first here.
   const activityEntries = [...(activityQuery.data?.entries ?? [])].sort(
@@ -398,9 +396,6 @@ function FleetAgentDetailRoute() {
           <div className={styles.block}>
             <div className={styles.seclabel}>Session</div>
             {metaRow("Group", fleetName)}
-            {agent.branch && metaRow("Branch", agent.branch)}
-            {(host || agent.repo) &&
-              metaRow("Host", host ?? (agent.repo as string))}
             {model && metaRow("Model", model)}
             {startedAt && metaRow("Started", formatLocalDateTime(startedAt))}
             {metaRow(


### PR DESCRIPTION
## Summary
- Remove repo/branch subtitle from session group headers (e.g. `EnderAI-frontend · main`).
- Delete `fleetRepo` helper and related `.frepo` styles.
- Drop branch/repo from fleet agent TypeScript types and session detail meta rows.
- `repoLabel` now falls back to cwd basename only.

## Depends on
- Backend PR removing `repo`/`branch` from `TaskforceFleetAgentPublic` and `TaskforceActiveSession` (paired API change). Ledger archives still keep repo/branch.

## Test plan
- [ ] Sessions roster shows session name + counts only (no repo line)
- [ ] Session detail no longer shows Branch/Host rows from repo metadata
- [ ] CI frontend tests


Made with [Cursor](https://cursor.com)