### PR TITLE
Align header search bar with v2 tab content

### DIFF
--- a/src/components/V2/TaskforceShell.tsx
+++ b/src/components/V2/TaskforceShell.tsx
@@ -52,6 +52,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar"
+import { V2_HEADER_SEARCH_INSET } from "@/components/V2/v2PageShell"
 import { normalizeTaskforceDiscordUrl } from "@/lib/taskforceExternalLinks"
 import { cn } from "@/lib/utils"
 
@@ -639,10 +640,12 @@ export function TaskforceShell({ currentUser }: TaskforceShellProps) {
         </SidebarFooter>
       </Sidebar>
       <SidebarInset className="min-h-0 overflow-hidden">
-        <header className="shrink-0 border-b bg-background px-5 md:px-8">
+        <header className="shrink-0 border-b bg-background px-6 md:px-8">
           <div className="flex h-16 items-center gap-3">
             <SidebarTrigger className="md:hidden" />
-            <DocumentSearch />
+            <div className={cn(V2_HEADER_SEARCH_INSET, "min-w-0 flex-1")}>
+              <DocumentSearch />
+            </div>
           </div>
         </header>
         <main className="flex min-h-0 flex-1 flex-col overflow-hidden px-6 pt-4 pb-6 md:px-8 md:pt-5 md:pb-8">

--- a/src/components/V2/v2PageShell.ts
+++ b/src/components/V2/v2PageShell.ts
@@ -3,8 +3,14 @@ import { cn } from "@/lib/utils"
 /** Scrollable v2 page frame inside TaskforceShell (no extra inset). */
 export const V2_PAGE_FRAME = "flex min-h-0 flex-1 flex-col overflow-y-auto"
 
+/** Horizontal gutter inside TaskforceShell main padding (tab bodies + header search). */
+export const V2_TAB_GUTTER_X = "px-6"
+
+/** Left inset for shell header search so it lines up with tab content containers. */
+export const V2_HEADER_SEARCH_INSET = "pl-6"
+
 /** Shared horizontal/bottom padding for v2 tab bodies; top inset comes from the shell. */
-export const V2_PAGE_PADDING = "px-6 pb-6 pt-0 md:pb-8"
+export const V2_PAGE_PADDING = cn(V2_TAB_GUTTER_X, "pb-6 pt-0 md:pb-8")
 
 /**
  * Scrollable tab body — matches Agents list/detail layout inside shell main
@@ -35,7 +41,9 @@ export const V2_TAB_EYEBROW_CLASS =
 
 /** Sticky page header inside a padded scroll area (offsets horizontal `V2_PAGE_PADDING`). */
 export const V2_STICKY_HEADER_CLASS = cn(
-  "sticky top-0 z-30 -mx-6 shrink-0 border-b bg-background px-6 pt-4 pb-4",
+  "sticky top-0 z-30 shrink-0 border-b bg-background pt-4 pb-4",
+  "-mx-6",
+  V2_TAB_GUTTER_X,
 )
 
 /** Title block plus filter bar stacked inside `V2_STICKY_HEADER_CLASS`. */


### PR DESCRIPTION
## Summary
- Add shared `V2_TAB_GUTTER_X` / `V2_HEADER_SEARCH_INSET` constants in `v2PageShell.ts`
- Apply the inner tab gutter to the shell header search so it left-aligns with session cards and other tab containers
- Match shell header horizontal padding to main (`px-6 md:px-8`)

## Test plan
- [x] Verified layout math: header padding + search inset = main padding + tab body gutter
- [ ] Manual: open Sessions, Library, Profiles — search bar left edge aligns with content containers

Made with [Cursor](https://cursor.com)