### PR TITLE
Fleet: lighter purple on all drop targets while dragging

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -13,7 +13,9 @@
   );
   --fl-hair: color-mix(in srgb, var(--foreground) 12%, var(--background));
   --fl-primary-soft: color-mix(in srgb, var(--primary) 14%, var(--background));
+  --fl-primary-softer: color-mix(in srgb, var(--primary) 7%, var(--background));
   --fl-primary-line: color-mix(in srgb, var(--primary) 40%, var(--border));
+  --fl-primary-line-soft: color-mix(in srgb, var(--primary) 22%, var(--border));
   --fl-attention: color-mix(
     in oklab,
     oklch(0.68 0.12 62) 72%,
@@ -39,6 +41,12 @@
     border-color 120ms ease,
     background-color 120ms ease,
     opacity 120ms ease;
+}
+
+.fleetDropCandidate {
+  border-color: color-mix(in srgb, var(--primary) 55%, var(--border));
+  background: var(--fl-primary-softer);
+  box-shadow: inset 0 0 0 1px var(--fl-primary-line-soft);
 }
 
 .fleetDropTarget {

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -389,6 +389,7 @@ function FleetCard({
         styles.fleet,
         isHistory && styles.history,
         isCollapsed && styles.fleetCollapsed,
+        isDropCandidate && styles.fleetDropCandidate,
         isDropTarget && styles.fleetDropTarget,
         hasPendingMove && styles.fleetDropPending,
       )}


### PR DESCRIPTION
## Summary
- When dragging an agent session, all valid destination session groups now show a lighter purple tint immediately.
- The session group under the cursor keeps the stronger purple highlight to indicate the drop target.

## Test plan
- [x] Start dragging an agent from one session group
- [x] Confirm other session groups show a light purple tint
- [x] Hover over a destination and confirm it switches to the darker purple
- [x] Drop or cancel drag and confirm highlights clear


Made with [Cursor](https://cursor.com)