### PR TITLE
feat(fleet): two-line Sessions agent rows (model · repo · activity)

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -294,9 +294,16 @@
   min-width: 0;
 }
 
+.identity {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
 .nm {
   overflow: hidden;
-  flex: 1;
   min-width: 0;
   color: var(--foreground);
   font-size: calc(14px * var(--v2-scale, 1));
@@ -306,6 +313,41 @@
   text-overflow: ellipsis;
   text-transform: none;
   white-space: nowrap;
+}
+
+/* second identity line — model · repo · live activity */
+.asub {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  color: var(--fl-faint);
+  font-family: var(--font-mono);
+  font-size: calc(11px * var(--v2-scale, 1));
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.asep {
+  flex-shrink: 0;
+  color: color-mix(in srgb, var(--fl-faint) 55%, var(--background));
+}
+
+.amodel,
+.arepo {
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+}
+
+.aactivity {
+  overflow: hidden;
+  min-width: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.acaret {
+  color: var(--primary);
 }
 
 /* client chip — which coding tool drives the session. Fixed width so the chips

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -59,12 +59,15 @@ import styles from "./FleetPage.module.css"
 import {
   AGENT_KIND_LABEL,
   type AgentKind,
+  agentActivityLine,
   agentDisplayName,
   agentKind,
+  agentModelName,
   agentStatus,
   compactPresence,
   type FleetStatus,
   fleetTitle,
+  repoLabel,
   rosterStatusLabel,
   runningCount,
   waitingCount,
@@ -171,6 +174,9 @@ function AgentRow({
   const status = agentStatus(agent)
   const age = compactPresence(agent)
   const sessionLabel = agentDisplayName(agent)
+  const model = agentModelName(agent)
+  const repo = agent.cwd ? repoLabel(agent) : null
+  const activity = agentActivityLine(agent)
 
   const submitRename = (event: FormEvent) => {
     event.preventDefault()
@@ -225,8 +231,36 @@ function AgentRow({
         </span>
         <div className={styles.who}>
           <ClientChip kind={agentKind(agent)} />
-          <div className={styles.nm} data-testid="fleet-agent-name">
-            {sessionLabel}
+          <div className={styles.identity}>
+            <div className={styles.nm} data-testid="fleet-agent-name">
+              {sessionLabel}
+            </div>
+            <div className={styles.asub} data-testid="fleet-agent-sub">
+              <span className={styles.amodel}>{model}</span>
+              {repo && (
+                <>
+                  <span className={styles.asep} aria-hidden="true">
+                    ·
+                  </span>
+                  <span className={styles.arepo}>{repo}</span>
+                </>
+              )}
+              {activity && (
+                <>
+                  <span className={styles.asep} aria-hidden="true">
+                    ·
+                  </span>
+                  <span className={styles.aactivity} title={activity}>
+                    {status === "run" && (
+                      <span className={styles.acaret} aria-hidden="true">
+                        ▸{" "}
+                      </span>
+                    )}
+                    {activity}
+                  </span>
+                </>
+              )}
+            </div>
           </div>
         </div>
         <div

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -220,6 +220,17 @@ export function liveActivityLabel(
   return "Connected but not actively running"
 }
 
+/** Compact single-line activity for the roster row sub-line. Collapses the
+   live activity copy to its first line and clamps length so it never wraps. */
+export function agentActivityLine(
+  agent: TaskforceFleetAgent,
+  options: LiveActivityOptions = {},
+): string {
+  const firstLine =
+    liveActivityLabel(agent, options).split(/\r?\n/)[0]?.trim() ?? ""
+  return firstLine.length > 120 ? `${firstLine.slice(0, 119)}…` : firstLine
+}
+
 /** Session detail "Working on" body when no summary is stored yet. */
 export function sessionWorkSummary(agent: TaskforceFleetAgent): string {
   const summary = agent.summary_markdown?.trim()


### PR DESCRIPTION
## What

Brings the **two-line agent-row identity** from the *"Sessions redesign"* Claude Design mockup ([handoff](https://api.anthropic.com/v1/design/h/pKUf3mHZ4AeAJMEACNIIiQ?open_file=mockups%2Fsessions%2FSessions+redesign.html)) into the real Sessions/Fleet roster.

Each agent row now shows:
- **Line 1** — the existing session title (unchanged).
- **Line 2** — a calm mono sub-line: `model · repo · live-activity`, with a purple `▸` caret while the agent is running.

All values come from fields the fleet API **already returns** (`model_id`, `cwd`, `summary_markdown`) via existing helpers (`agentModelName`, `repoLabel`, `liveActivityLabel`). No backend or API changes.

## Scope

The user asked to "just get some of these new ideas in," not a pixel-perfect rebuild. This lands the highest-value, fully-groundable idea from the mockup. **Deliberately skipped:** the mockup's shared-context drawer (per-session notes, pinning, auto-inject composer) — it needs a session-context API that doesn't exist yet, so it's out of scope here.

## Implementation notes
- `fleetStatus.ts`: new `agentActivityLine()` helper — collapses the live-activity copy to one line and clamps length so the row never wraps.
- `FleetPage.tsx`: `.who` now holds the chip + a two-line `.identity` block. Preserved the `fleet-agent-name`/`fleet-agent-row`/`fleet-agent-status` test ids and `.nm` truncation CSS.
- `FleetPage.module.css`: added `.identity`, `.asub`, `.asep`, `.amodel`, `.arepo`, `.aactivity`, `.acaret`; row grid stays `align-items: center` so dot/age/menu alignment is unchanged.

## Verification
- `tsc -p tsconfig.build.json --noEmit` ✅
- `vite build` ✅
- Playwright `fleet.spec.ts` could not run in this sandbox — the suite fails identically on clean `origin/main` (app shell doesn't mount under the local harness), so it's an environment issue, not a regression. Worth a CI run on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)