### PR TITLE
feat(fleet): shared-context drawer on session groups

### DIFF
--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -73,6 +73,25 @@ export interface TaskforceFleetResponse {
   fleet_sessions: TaskforceFleetSession[]
 }
 
+export interface TaskforceSessionContextEntry {
+  document_id: string
+  title: string
+  summary_markdown: string
+  produced_by_client: string | null
+  outcome: string | null
+  last_touched_at: string | null
+  token_cost: number
+}
+
+export interface TaskforceSessionContextResponse {
+  fleet_session_id: string
+  scope: string
+  entry_count: number
+  token_estimate: number
+  inject_token_budget: number
+  entries: TaskforceSessionContextEntry[]
+}
+
 export interface ReadTaskforceSessionSavingsArgs {
   sessionId: string
   pricingModelId?: string
@@ -131,6 +150,18 @@ export function readTaskforceFleet(): CancelablePromise<TaskforceFleetResponse> 
   return request(OpenAPI, {
     method: "GET",
     url: "/api/v1/v2/taskforce/fleet",
+  })
+}
+
+export function readTaskforceFleetSessionContext(
+  fleetSessionId: string,
+): CancelablePromise<TaskforceSessionContextResponse> {
+  return request(OpenAPI, {
+    method: "GET",
+    url: "/api/v1/v2/taskforce/fleet/{fleet_session_id}/context",
+    path: {
+      fleet_session_id: fleetSessionId,
+    },
   })
 }
 

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -162,6 +162,114 @@
   display: contents;
 }
 
+/* shared-context trigger — sits in the header's status column (col 3) */
+.fctx {
+  display: inline-flex;
+  grid-column: 3;
+  justify-self: start;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
+  padding: 4px 9px;
+  border: 1px solid var(--fl-primary-line);
+  background: var(--fl-primary-soft);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: calc(11px * var(--v2-scale, 1));
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.fctx:hover {
+  background: color-mix(in srgb, var(--primary) 22%, var(--background));
+}
+
+.fctx:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.fctx svg {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  color: var(--primary);
+}
+
+.fctxLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ----- shared-context drawer body ----- */
+.ctxIcon {
+  display: grid;
+  flex-shrink: 0;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--fl-primary-line);
+  background: var(--fl-primary-soft);
+  color: var(--primary);
+}
+
+.ctxIcon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.ctxInject {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 14px;
+  padding: 9px 11px;
+  border: 1px solid var(--fl-primary-line);
+  background: var(--fl-primary-soft);
+  font-size: calc(12px * var(--v2-scale, 1));
+  line-height: 1.4;
+}
+
+.ctxInject svg {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  color: var(--primary);
+}
+
+.ctxEntry {
+  padding: 14px 0;
+  border-bottom: 1px solid var(--fl-hair);
+}
+
+.ctxEntry:last-child {
+  border-bottom: 0;
+}
+
+.ctxBadge {
+  flex-shrink: 0;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: calc(10.5px * var(--v2-scale, 1));
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.ctxOutcome {
+  margin-top: 6px;
+  color: var(--primary);
+  font-size: calc(12px * var(--v2-scale, 1));
+  line-height: 1.45;
+}
+
 .fmenu {
   grid-column: 5;
   justify-self: end;

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -72,6 +72,7 @@ import {
   runningCount,
   waitingCount,
 } from "./fleetStatus"
+import { SharedContextDrawer } from "./SharedContextDrawer"
 
 const FLEET_QUERY_KEY = ["v2-taskforce-fleet"] as const
 
@@ -470,6 +471,8 @@ function FleetCard({
             </span>
           </button>
         )}
+
+        {!renaming && !isHistory && <SharedContextDrawer fleet={fleet} />}
 
         {!renaming && (
           <div className={styles.fheadMeta}>

--- a/src/components/V2/Fleet/SharedContextDrawer.tsx
+++ b/src/components/V2/Fleet/SharedContextDrawer.tsx
@@ -1,0 +1,169 @@
+import { useQuery } from "@tanstack/react-query"
+import { FileText, Zap } from "lucide-react"
+import { useState } from "react"
+import {
+  readTaskforceFleetSessionContext,
+  type TaskforceFleetSession,
+  type TaskforceSessionContextEntry,
+} from "@/api/v2Taskforce"
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import styles from "./FleetPage.module.css"
+import { fleetTitle } from "./fleetStatus"
+
+// The harness that produced a document, mapped to the same short labels the
+// roster row chips use. Falls back to the raw client string when unknown.
+const CLIENT_LABEL: Record<string, string> = {
+  "claude-code": "Claude",
+  claude: "Claude",
+  codex: "Codex",
+  cursor: "Cursor",
+}
+
+function clientLabel(value: string | null): string {
+  if (!value) return "Agent"
+  return CLIENT_LABEL[value] ?? value
+}
+
+function timeAgo(iso: string | null): string {
+  if (!iso) return ""
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ""
+  const minutes = Math.max(0, Math.round((Date.now() - then) / 60_000))
+  if (minutes < 1) return "just now"
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+/** Read-only "shared context" drawer for one session group.
+ *
+ * Surfaces the documents the group's agents have produced (served by
+ * GET /v2/taskforce/fleet/{id}/context). The feed is fetched lazily on open
+ * so the roster doesn't fire one request per group on every poll. */
+export function SharedContextDrawer({
+  fleet,
+}: {
+  fleet: TaskforceFleetSession
+}) {
+  const [open, setOpen] = useState(false)
+  const query = useQuery({
+    queryKey: ["v2-taskforce-fleet-context", fleet.id],
+    queryFn: () => readTaskforceFleetSessionContext(fleet.id),
+    enabled: open,
+  })
+
+  const data = query.data
+  const entries = data?.entries ?? []
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <button
+          type="button"
+          className={styles.fctx}
+          aria-label={`Shared context for ${fleetTitle(fleet)}`}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <FileText aria-hidden="true" />
+          <span className={styles.fctxLabel}>Shared context</span>
+        </button>
+      </SheetTrigger>
+      <SheetContent
+        side="right"
+        className="w-full gap-0 p-0 sm:max-w-md"
+        data-testid="fleet-context-drawer"
+      >
+        <div className="border-border border-b p-5">
+          <div className="flex items-center gap-3">
+            <span className={styles.ctxIcon}>
+              <FileText aria-hidden="true" />
+            </span>
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold tracking-tight">
+                Shared context
+              </h2>
+              <p className="text-muted-foreground truncate font-mono text-xs">
+                {data?.scope ?? fleetTitle(fleet)}
+              </p>
+            </div>
+          </div>
+          <div className={styles.ctxInject}>
+            <Zap aria-hidden="true" />
+            <span>
+              Injected into this group's agents each turn, up to{" "}
+              <b>
+                {(data?.inject_token_budget ?? 2000).toLocaleString()} tokens
+              </b>
+              .
+            </span>
+          </div>
+          {data && (
+            <div className="text-muted-foreground mt-3 flex flex-wrap gap-x-2 gap-y-1 font-mono text-[11px]">
+              <span>
+                {data.entry_count}{" "}
+                {data.entry_count === 1 ? "document" : "documents"}
+              </span>
+              <span aria-hidden="true">·</span>
+              <span>~{data.token_estimate.toLocaleString()} tokens</span>
+            </div>
+          )}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-5">
+          {query.isLoading ? (
+            <div className="space-y-3">
+              {[0, 1, 2].map((item) => (
+                <div
+                  key={item}
+                  className="border-border bg-muted/20 h-20 animate-pulse border"
+                />
+              ))}
+            </div>
+          ) : query.error ? (
+            <p className="text-destructive text-sm">
+              Shared context could not load.
+            </p>
+          ) : entries.length === 0 ? (
+            <p className="text-muted-foreground text-sm leading-relaxed">
+              No shared context yet. As this group's agents capture work, their
+              documents appear here and are injected into each agent's turn.
+            </p>
+          ) : (
+            <ul className="flex flex-col">
+              {entries.map((entry) => (
+                <ContextEntry key={entry.document_id} entry={entry} />
+              ))}
+            </ul>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function ContextEntry({ entry }: { entry: TaskforceSessionContextEntry }) {
+  return (
+    <li className={styles.ctxEntry} data-testid="fleet-context-entry">
+      <div className="mb-1.5 flex items-center gap-2">
+        <span className={styles.ctxBadge}>
+          {clientLabel(entry.produced_by_client)}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-[13px] font-medium">
+          {entry.title}
+        </span>
+        <span className="text-muted-foreground shrink-0 font-mono text-[10.5px]">
+          {timeAgo(entry.last_touched_at)}
+        </span>
+      </div>
+      {entry.summary_markdown && (
+        <p className="text-muted-foreground text-[13px] leading-relaxed">
+          {entry.summary_markdown}
+        </p>
+      )}
+      {entry.outcome && (
+        <p className={styles.ctxOutcome}>Outcome: {entry.outcome}</p>
+      )}
+    </li>
+  )
+}


### PR DESCRIPTION
## What

Wires the **shared-context drawer** from the *"Sessions redesign"* mockup into the real Sessions page, consuming the backend endpoint added in EnderAI#168.

Each non-history session group header gets a **"Shared context"** trigger (in the header's status column). Opening it slides out a right-side `Sheet` listing the documents that group's agents have produced — fetched from `GET /v2/taskforce/fleet/{id}/context`.

## Behavior
- **Lazy fetch**: react-query with `enabled: open`, so the roster does **not** fire one request per group on every 30s poll — only when a drawer is actually opened.
- **Read-only feed** (matches the backend, which reuses `/discover` rather than a notes table): drawer header shows scope, document count, and `~token_estimate` vs `inject_token_budget`; each entry shows a harness badge, title, summary, optional outcome, and relative time.
- Loading (skeletons), error, and empty states all handled.

## Scope notes
Deliberately **not** included from the mockup: the composer ("append a note"), pin/unpin, and the per-button unread count + "fresh" dot. Those need write/notes APIs that don't exist (the backend feed is read-only and document-sourced). The count was also left off the trigger to avoid eager per-group fetches. This is the honest read-only slice of the mockup.

## Changes
- `v2Taskforce.ts`: `TaskforceSessionContextEntry`/`Response` types + `readTaskforceFleetSessionContext()`.
- `SharedContextDrawer.tsx`: new component (trigger + Sheet + lazy query).
- `FleetPage.tsx`: render the trigger in each non-history group header.
- `FleetPage.module.css`: trigger + drawer-body styles, on the page's purple accent tokens.

## Verification
- `tsc -p tsconfig.build.json --noEmit` ✅
- `vite build` ✅
- biome clean on changed lines (one pre-existing drag-row a11y warning, untouched). Playwright mocked suite can't render under the local sandbox (fails identically on `origin/main`) — worth a CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)