### PR TITLE
Fleet: branch sub-line, activity marquee, cleaner status copy

### DIFF
--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -45,6 +45,7 @@ export interface TaskforceFleetAgent {
   session_id: string
   fleet_session_id: string
   cwd: string | null
+  branch: string | null
   active_document_id: string | null
   referenced_document_ids: string[]
   display_name: string

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -423,7 +423,7 @@
   white-space: nowrap;
 }
 
-/* second identity line — model · repo · live activity */
+/* second identity line — model · branch · live activity */
 .asub {
   display: flex;
   min-width: 0;
@@ -442,16 +442,53 @@
 }
 
 .amodel,
-.arepo {
+.abranch {
   flex-shrink: 0;
   color: var(--muted-foreground);
 }
 
 .aactivity {
   overflow: hidden;
+  flex: 1;
   min-width: 0;
-  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.aactivityMarquee {
+  mask-image: linear-gradient(
+    90deg,
+    transparent,
+    #000 10px,
+    #000 calc(100% - 10px),
+    transparent
+  );
+}
+
+.aactivityTrack {
+  display: inline-block;
+  white-space: nowrap;
+}
+
+.aactivityTrackScroll {
+  animation: fleet-activity-scroll var(--activity-duration, 10s) ease-in-out
+    infinite;
+}
+
+@keyframes fleet-activity-scroll {
+  0%,
+  14% {
+    transform: translateX(0);
+  }
+
+  46%,
+  54% {
+    transform: translateX(calc(-1 * var(--activity-scroll, 0px)));
+  }
+
+  86%,
+  100% {
+    transform: translateX(0);
+  }
 }
 
 .acaret {
@@ -1205,5 +1242,13 @@
 
   .pulse {
     animation: none;
+  }
+
+  .aactivityTrackScroll {
+    animation: none;
+  }
+
+  .aactivity {
+    text-overflow: ellipsis;
   }
 }

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -10,9 +10,11 @@ import {
   Trash2,
 } from "lucide-react"
 import {
+  type CSSProperties,
   type DragEvent,
   type FormEvent,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from "react"
@@ -67,7 +69,6 @@ import {
   compactPresence,
   type FleetStatus,
   fleetTitle,
-  repoLabel,
   rosterStatusLabel,
   runningCount,
   waitingCount,
@@ -147,6 +148,67 @@ function ClientChip({ kind }: { kind: AgentKind }) {
   )
 }
 
+function ActivityMarquee({
+  activity,
+  isRunning,
+}: {
+  activity: string
+  isRunning: boolean
+}) {
+  const containerRef = useRef<HTMLSpanElement>(null)
+  const trackRef = useRef<HTMLSpanElement>(null)
+  const [scrollDistance, setScrollDistance] = useState(0)
+
+  useEffect(() => {
+    const container = containerRef.current
+    const track = trackRef.current
+    if (!container || !track) return
+
+    const measure = () => {
+      const overflow = track.scrollWidth - container.clientWidth
+      setScrollDistance(overflow > 4 ? overflow : 0)
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(container)
+    observer.observe(track)
+    return () => observer.disconnect()
+  }, [activity])
+
+  const scrolls = scrollDistance > 0
+  const marqueeStyle = scrolls
+    ? ({
+        "--activity-scroll": `${scrollDistance}px`,
+        "--activity-duration": `${Math.max(8, scrollDistance / 24 + 6)}s`,
+      } as CSSProperties)
+    : undefined
+
+  return (
+    <span
+      ref={containerRef}
+      className={cn(styles.aactivity, scrolls && styles.aactivityMarquee)}
+      style={marqueeStyle}
+      title={activity}
+    >
+      <span
+        ref={trackRef}
+        className={cn(
+          styles.aactivityTrack,
+          scrolls && styles.aactivityTrackScroll,
+        )}
+      >
+        {isRunning && (
+          <span className={styles.acaret} aria-hidden="true">
+            ▸{" "}
+          </span>
+        )}
+        {activity}
+      </span>
+    </span>
+  )
+}
+
 function AgentRow({
   agent,
   onOpen,
@@ -176,7 +238,7 @@ function AgentRow({
   const age = compactPresence(agent)
   const sessionLabel = agentDisplayName(agent)
   const model = agentModelName(agent)
-  const repo = agent.cwd ? repoLabel(agent) : null
+  const branch = agent.branch?.trim() || null
   const activity = agentActivityLine(agent)
 
   const submitRename = (event: FormEvent) => {
@@ -238,12 +300,12 @@ function AgentRow({
             </div>
             <div className={styles.asub} data-testid="fleet-agent-sub">
               <span className={styles.amodel}>{model}</span>
-              {repo && (
+              {branch && (
                 <>
                   <span className={styles.asep} aria-hidden="true">
                     ·
                   </span>
-                  <span className={styles.arepo}>{repo}</span>
+                  <span className={styles.abranch}>{branch}</span>
                 </>
               )}
               {activity && (
@@ -251,14 +313,10 @@ function AgentRow({
                   <span className={styles.asep} aria-hidden="true">
                     ·
                   </span>
-                  <span className={styles.aactivity} title={activity}>
-                    {status === "run" && (
-                      <span className={styles.acaret} aria-hidden="true">
-                        ▸{" "}
-                      </span>
-                    )}
-                    {activity}
-                  </span>
+                  <ActivityMarquee
+                    activity={activity}
+                    isRunning={status === "run"}
+                  />
                 </>
               )}
             </div>

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -220,14 +220,12 @@ export function liveActivityLabel(
   return "Connected but not actively running"
 }
 
-/** Compact single-line activity for the roster row sub-line. Collapses the
-   live activity copy to its first line and clamps length so it never wraps. */
-export function agentActivityLine(
-  agent: TaskforceFleetAgent,
-  options: LiveActivityOptions = {},
-): string {
-  const firstLine =
-    liveActivityLabel(agent, options).split(/\r?\n/)[0]?.trim() ?? ""
+/** Compact single-line activity for the roster row sub-line. Only shows captured
+   work summary — status copy lives in the row's status column. */
+export function agentActivityLine(agent: TaskforceFleetAgent): string {
+  const summary = agent.summary_markdown?.trim()
+  if (!summary) return ""
+  const firstLine = summary.split(/\r?\n/)[0]?.trim() ?? ""
   return firstLine.length > 120 ? `${firstLine.slice(0, 119)}…` : firstLine
 }
 


### PR DESCRIPTION
## Summary
- Replace repo folder label on agent sub-lines with git `branch` from the fleet API.
- Scroll overflowing work-summary text horizontally (MP3-player style) when it does not fit.
- Keep roster status fallbacks out of the activity segment; only show captured work summaries there.

## Test plan
- [x] Sub-line shows `model · branch · activity` when branch is present
- [x] Long activity text scrolls; short text stays static
- [x] Purple/red status column unchanged
- [ ] After hook fix lands, send a prompt and confirm branch appears for Cursor sessions


Made with [Cursor](https://cursor.com)