### PR TITLE
Fix fleet activity marquee and session context header

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -90,6 +90,7 @@
   column-gap: var(--fl-row-gap);
   align-items: center;
   min-width: 0;
+  overflow: hidden;
   padding: 0;
   border: 0;
   background: transparent;
@@ -164,6 +165,8 @@
 
 /* shared-context trigger — sits in the header's status column (col 3) */
 .fctx {
+  position: relative;
+  z-index: 1;
   display: inline-flex;
   grid-column: 3;
   justify-self: start;
@@ -174,20 +177,21 @@
   box-sizing: border-box;
   padding: 4px 9px;
   border: 1px solid var(--fl-primary-line);
-  background: var(--fl-primary-soft);
+  background: var(--fl-surface);
   color: var(--foreground);
   font-family: var(--font-mono);
   font-size: calc(11px * var(--v2-scale, 1));
   letter-spacing: 0.01em;
   white-space: nowrap;
   cursor: pointer;
+  isolation: isolate;
   transition:
     background-color 120ms ease,
     border-color 120ms ease;
 }
 
 .fctx:hover {
-  background: color-mix(in srgb, var(--primary) 22%, var(--background));
+  background: color-mix(in srgb, var(--primary) 14%, var(--fl-surface));
 }
 
 .fctx:focus-visible {
@@ -457,10 +461,28 @@
 .aactivityMarquee {
   mask-image: linear-gradient(
     90deg,
-    transparent,
-    #000 10px,
-    #000 calc(100% - 10px),
-    transparent
+    #000 0,
+    #000 calc(100% - 12px),
+    transparent 100%
+  );
+}
+
+.aactivityMarqueeLeftFade {
+  mask-image: linear-gradient(
+    90deg,
+    transparent 0,
+    #000 12px,
+    #000 calc(100% - 12px),
+    transparent 100%
+  );
+}
+
+.aactivityMarqueeAtEnd {
+  mask-image: linear-gradient(
+    90deg,
+    transparent 0,
+    #000 12px,
+    #000 100%
   );
 }
 
@@ -470,24 +492,23 @@
 }
 
 .aactivityTrackScroll {
-  animation: fleet-activity-scroll var(--activity-duration, 10s) ease-in-out
-    infinite;
+  transform: translateX(0);
+  transition: transform 0.25s ease-out;
 }
 
-@keyframes fleet-activity-scroll {
-  0%,
-  14% {
+.aactivityTrackForward {
+  animation: fleet-activity-scroll-forward var(--activity-duration, 6s)
+    ease-in-out forwards;
+  transition: none;
+}
+
+@keyframes fleet-activity-scroll-forward {
+  from {
     transform: translateX(0);
   }
 
-  46%,
-  54% {
+  to {
     transform: translateX(calc(-1 * var(--activity-scroll, 0px)));
-  }
-
-  86%,
-  100% {
-    transform: translateX(0);
   }
 }
 
@@ -1197,6 +1218,18 @@
   .fhead {
     height: auto;
     min-height: 48px;
+    grid-template-rows: auto auto;
+  }
+
+  .fheadToggle {
+    grid-row: 1;
+  }
+
+  .fctx {
+    grid-column: 2 / 4;
+    grid-row: 2;
+    justify-self: start;
+    margin-top: 2px;
   }
 
   .fheadIdentity {
@@ -1244,8 +1277,10 @@
     animation: none;
   }
 
-  .aactivityTrackScroll {
+  .aactivityTrackScroll,
+  .aactivityTrackForward {
     animation: none;
+    transition: none;
   }
 
   .aactivity {

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -158,6 +158,11 @@ function ActivityMarquee({
   const containerRef = useRef<HTMLSpanElement>(null)
   const trackRef = useRef<HTMLSpanElement>(null)
   const [scrollDistance, setScrollDistance] = useState(0)
+  const [hovered, setHovered] = useState(false)
+  const [showLeftFade, setShowLeftFade] = useState(false)
+  const [atEnd, setAtEnd] = useState(false)
+  const leftFadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hoveredRef = useRef(false)
 
   useEffect(() => {
     const container = containerRef.current
@@ -176,27 +181,68 @@ function ActivityMarquee({
     return () => observer.disconnect()
   }, [activity])
 
+  useEffect(() => {
+    return () => {
+      if (leftFadeTimerRef.current) clearTimeout(leftFadeTimerRef.current)
+    }
+  }, [])
+
   const scrolls = scrollDistance > 0
   const marqueeStyle = scrolls
     ? ({
         "--activity-scroll": `${scrollDistance}px`,
-        "--activity-duration": `${Math.max(8, scrollDistance / 24 + 6)}s`,
+        "--activity-duration": `${Math.max(4, scrollDistance / 32 + 2)}s`,
       } as CSSProperties)
     : undefined
+
+  const handleMouseEnter = () => {
+    if (!scrolls) return
+    hoveredRef.current = true
+    setHovered(true)
+    setAtEnd(false)
+    leftFadeTimerRef.current = setTimeout(() => {
+      leftFadeTimerRef.current = null
+      setShowLeftFade(true)
+    }, 180)
+  }
+
+  const handleMouseLeave = () => {
+    if (leftFadeTimerRef.current) {
+      clearTimeout(leftFadeTimerRef.current)
+      leftFadeTimerRef.current = null
+    }
+    hoveredRef.current = false
+    setHovered(false)
+    setShowLeftFade(false)
+    setAtEnd(false)
+  }
+
+  const handleAnimationEnd = () => {
+    if (hoveredRef.current) setAtEnd(true)
+  }
 
   return (
     <span
       ref={containerRef}
-      className={cn(styles.aactivity, scrolls && styles.aactivityMarquee)}
+      className={cn(
+        styles.aactivity,
+        scrolls && styles.aactivityMarquee,
+        scrolls && (showLeftFade || atEnd) && styles.aactivityMarqueeLeftFade,
+        scrolls && atEnd && styles.aactivityMarqueeAtEnd,
+      )}
       style={marqueeStyle}
       title={activity}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       <span
         ref={trackRef}
         className={cn(
           styles.aactivityTrack,
           scrolls && styles.aactivityTrackScroll,
+          scrolls && hovered && styles.aactivityTrackForward,
         )}
+        onAnimationEnd={handleAnimationEnd}
       >
         {isRunning && (
           <span className={styles.acaret} aria-hidden="true">

--- a/src/components/V2/Fleet/SharedContextDrawer.tsx
+++ b/src/components/V2/Fleet/SharedContextDrawer.tsx
@@ -36,7 +36,7 @@ function timeAgo(iso: string | null): string {
   return `${Math.floor(hours / 24)}d ago`
 }
 
-/** Read-only "shared context" drawer for one session group.
+/** Read-only session context drawer for one session group.
  *
  * Surfaces the documents the group's agents have produced (served by
  * GET /v2/taskforce/fleet/{id}/context). The feed is fetched lazily on open
@@ -62,11 +62,11 @@ export function SharedContextDrawer({
         <button
           type="button"
           className={styles.fctx}
-          aria-label={`Shared context for ${fleetTitle(fleet)}`}
+          aria-label={`Session context for ${fleetTitle(fleet)}`}
           onClick={(event) => event.stopPropagation()}
         >
           <FileText aria-hidden="true" />
-          <span className={styles.fctxLabel}>Shared context</span>
+          <span className={styles.fctxLabel}>Session context</span>
         </button>
       </SheetTrigger>
       <SheetContent
@@ -81,7 +81,7 @@ export function SharedContextDrawer({
             </span>
             <div className="min-w-0">
               <h2 className="text-sm font-semibold tracking-tight">
-                Shared context
+                Session context
               </h2>
               <p className="text-muted-foreground truncate font-mono text-xs">
                 {data?.scope ?? fleetTitle(fleet)}
@@ -122,11 +122,11 @@ export function SharedContextDrawer({
             </div>
           ) : query.error ? (
             <p className="text-destructive text-sm">
-              Shared context could not load.
+              Session context could not load.
             </p>
           ) : entries.length === 0 ? (
             <p className="text-muted-foreground text-sm leading-relaxed">
-              No shared context yet. As this group's agents capture work, their
+              No session context yet. As this group's agents capture work, their
               documents appear here and are injected into each agent's turn.
             </p>
           ) : (

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -133,7 +133,7 @@ export function agentDisplayName(agent: TaskforceFleetAgent): string {
 }
 
 export function agentModelName(agent: TaskforceFleetAgent): string {
-  return modelLabel(agent.model_id) || "Connected agent"
+  return modelLabel(agent.model_id) || "Auto"
 }
 
 /** Mono identity meta — "Opus 4.8 · mbp-16", host omitted when unavailable. */


### PR DESCRIPTION
## Summary
- Activity marquee only scrolls on hover, holds at the end, and snaps back quickly on mouse leave
- Left edge fade appears only after scroll starts; right fade clears once fully scrolled
- Renamed "Shared context" to "Session context" across the drawer trigger and sheet copy
- Fixed session header overlap by clipping the title row and giving the context button a solid stacked surface
- On narrow screens, moved the context button to its own header row

## Test plan
- [x] Verified activity text is sharp at rest with no left blur
- [x] Hover scrolls forward once and stays at end while hovered
- [x] Mouse leave returns text quickly to start
- [x] Session context button no longer overlaps session title
- [x] Label reads "Session context" in header and drawer


Made with [Cursor](https://cursor.com)