### PR TITLE
Polish fleet row marquee and session context button

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -33,7 +33,7 @@
 }
 
 .fleet {
-  --fl-row-cols: 26px minmax(0, 1fr) 9.5rem 2.75rem 40px;
+  --fl-row-cols: 26px minmax(0, 1fr) max-content 2.75rem 40px;
   --fl-row-gap: 18px;
   border: 1px solid var(--border);
   background: var(--fl-surface);
@@ -172,8 +172,8 @@
   justify-self: start;
   align-items: center;
   gap: 6px;
-  min-width: 0;
-  max-width: 100%;
+  flex-shrink: 0;
+  width: max-content;
   box-sizing: border-box;
   padding: 4px 9px;
   border: 1px solid var(--fl-primary-line);
@@ -207,8 +207,7 @@
 }
 
 .fctxLabel {
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ----- shared-context drawer body ----- */
@@ -291,6 +290,7 @@
   padding: 12px 18px;
   border-bottom: 1px solid var(--fl-hair);
   text-align: left;
+  cursor: pointer;
 }
 
 .arowMain {
@@ -459,20 +459,12 @@
 }
 
 .aactivityMarquee {
-  mask-image: linear-gradient(
-    90deg,
-    #000 0,
-    #000 calc(100% - 12px),
-    transparent 100%
-  );
-}
-
-.aactivityMarqueeLeftFade {
+  --activity-fade: 12px;
   mask-image: linear-gradient(
     90deg,
     transparent 0,
-    #000 12px,
-    #000 calc(100% - 12px),
+    #000 var(--activity-fade),
+    #000 calc(100% - var(--activity-fade)),
     transparent 100%
   );
 }
@@ -481,7 +473,7 @@
   mask-image: linear-gradient(
     90deg,
     transparent 0,
-    #000 12px,
+    #000 var(--activity-fade),
     #000 100%
   );
 }
@@ -492,6 +484,7 @@
 }
 
 .aactivityTrackScroll {
+  padding-left: var(--activity-fade, 12px);
   transform: translateX(0);
   transition: transform 0.25s ease-out;
 }

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -151,18 +151,17 @@ function ClientChip({ kind }: { kind: AgentKind }) {
 function ActivityMarquee({
   activity,
   isRunning,
+  active,
 }: {
   activity: string
   isRunning: boolean
+  active: boolean
 }) {
   const containerRef = useRef<HTMLSpanElement>(null)
   const trackRef = useRef<HTMLSpanElement>(null)
   const [scrollDistance, setScrollDistance] = useState(0)
-  const [hovered, setHovered] = useState(false)
-  const [showLeftFade, setShowLeftFade] = useState(false)
   const [atEnd, setAtEnd] = useState(false)
-  const leftFadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const hoveredRef = useRef(false)
+  const activeRef = useRef(false)
 
   useEffect(() => {
     const container = containerRef.current
@@ -182,43 +181,20 @@ function ActivityMarquee({
   }, [activity])
 
   useEffect(() => {
-    return () => {
-      if (leftFadeTimerRef.current) clearTimeout(leftFadeTimerRef.current)
-    }
-  }, [])
+    activeRef.current = active
+    if (!active) setAtEnd(false)
+  }, [active])
 
   const scrolls = scrollDistance > 0
   const marqueeStyle = scrolls
     ? ({
         "--activity-scroll": `${scrollDistance}px`,
-        "--activity-duration": `${Math.max(4, scrollDistance / 32 + 2)}s`,
+        "--activity-duration": `${Math.max(1.6, (scrollDistance / 32 + 2) / 2.5)}s`,
       } as CSSProperties)
     : undefined
 
-  const handleMouseEnter = () => {
-    if (!scrolls) return
-    hoveredRef.current = true
-    setHovered(true)
-    setAtEnd(false)
-    leftFadeTimerRef.current = setTimeout(() => {
-      leftFadeTimerRef.current = null
-      setShowLeftFade(true)
-    }, 180)
-  }
-
-  const handleMouseLeave = () => {
-    if (leftFadeTimerRef.current) {
-      clearTimeout(leftFadeTimerRef.current)
-      leftFadeTimerRef.current = null
-    }
-    hoveredRef.current = false
-    setHovered(false)
-    setShowLeftFade(false)
-    setAtEnd(false)
-  }
-
   const handleAnimationEnd = () => {
-    if (hoveredRef.current) setAtEnd(true)
+    if (activeRef.current) setAtEnd(true)
   }
 
   return (
@@ -227,20 +203,17 @@ function ActivityMarquee({
       className={cn(
         styles.aactivity,
         scrolls && styles.aactivityMarquee,
-        scrolls && (showLeftFade || atEnd) && styles.aactivityMarqueeLeftFade,
         scrolls && atEnd && styles.aactivityMarqueeAtEnd,
       )}
       style={marqueeStyle}
       title={activity}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
     >
       <span
         ref={trackRef}
         className={cn(
           styles.aactivityTrack,
           scrolls && styles.aactivityTrackScroll,
-          scrolls && hovered && styles.aactivityTrackForward,
+          scrolls && active && styles.aactivityTrackForward,
         )}
         onAnimationEnd={handleAnimationEnd}
       >
@@ -286,6 +259,7 @@ function AgentRow({
   const model = agentModelName(agent)
   const branch = agent.branch?.trim() || null
   const activity = agentActivityLine(agent)
+  const [rowHovered, setRowHovered] = useState(false)
 
   const submitRename = (event: FormEvent) => {
     event.preventDefault()
@@ -308,11 +282,9 @@ function AgentRow({
         isMoving && styles.arowMoving,
       )}
       draggable={draggable && !isMoving}
-      title={
-        draggable
-          ? "Drag to move this agent to another session group"
-          : "View this agent session"
-      }
+      title={draggable ? undefined : "View this agent session"}
+      onMouseEnter={() => setRowHovered(true)}
+      onMouseLeave={() => setRowHovered(false)}
       onDragStart={(event) => {
         suppressClick.current = true
         event.dataTransfer.effectAllowed = "move"
@@ -362,6 +334,7 @@ function AgentRow({
                   <ActivityMarquee
                     activity={activity}
                     isRunning={status === "run"}
+                    active={rowHovered}
                   />
                 </>
               )}


### PR DESCRIPTION
## Summary
- Activity marquee scrolls on full agent row hover (not just the activity text) at 2.5x speed
- Left fade sits ahead of the text via track padding so text scrolls into it naturally
- Session context button shows full label (no ellipsis); column sizes to content
- Agent rows use pointer cursor; drag tooltip removed

## Test plan
- [x] Hover anywhere on an agent row to scroll truncated activity text
- [x] Mouse leave snaps text back quickly
- [x] Session context button reads fully without cutoff
- [x] Row shows pointer cursor on hover


Made with [Cursor](https://cursor.com)