### PR TITLE
Fleet: sync pulse, smooth marquee rewind, header spacing

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -5,6 +5,7 @@
 
 .page,
 .detail {
+  --fleet-pulse-period: 2.6s;
   --fl-surface: color-mix(in srgb, var(--card) 94%, var(--muted));
   --fl-faint: color-mix(
     in srgb,
@@ -70,7 +71,7 @@
 
 .fhead {
   display: grid;
-  grid-template-columns: var(--fl-row-cols);
+  grid-template-columns: 26px minmax(0, 1fr) max-content max-content 40px;
   gap: var(--fl-row-gap);
   align-items: center;
   box-sizing: border-box;
@@ -175,6 +176,7 @@
   flex-shrink: 0;
   width: max-content;
   box-sizing: border-box;
+  margin-inline-end: 10px;
   padding: 4px 9px;
   border: 1px solid var(--fl-primary-line);
   background: var(--fl-surface);
@@ -372,7 +374,8 @@
 }
 
 .pulse {
-  animation: fleet-pulse 2.6s ease-in-out infinite;
+  animation: fleet-pulse var(--fleet-pulse-period) ease-in-out infinite;
+  animation-delay: var(--fleet-pulse-delay, 0s);
 }
 
 .idle {
@@ -485,28 +488,7 @@
 
 .aactivityTrackScroll {
   padding-left: var(--activity-fade, 12px);
-  transform: translateX(0);
-  transition: transform 0.25s ease-out;
-}
-
-.aactivityTrackForward {
-  animation: fleet-activity-scroll-forward var(--activity-duration, 6s)
-    ease-in-out forwards;
-  transition: none;
-}
-
-@keyframes fleet-activity-scroll-forward {
-  from {
-    transform: translateX(0);
-  }
-
-  to {
-    transform: translateX(calc(-1 * var(--activity-scroll, 0px)));
-  }
-}
-
-.acaret {
-  color: var(--primary);
+  transition: transform var(--activity-motion-duration, 0.25s) ease-in-out;
 }
 
 /* client chip — which coding tool drives the session. Fixed width so the chips
@@ -1270,9 +1252,7 @@
     animation: none;
   }
 
-  .aactivityTrackScroll,
-  .aactivityTrackForward {
-    animation: none;
+  .aactivityTrackScroll {
     transition: none;
   }
 

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -13,6 +13,7 @@ import {
   type CSSProperties,
   type DragEvent,
   type FormEvent,
+  type TransitionEvent,
   useCallback,
   useEffect,
   useRef,
@@ -58,6 +59,7 @@ import { persistedKey, usePersistentState } from "@/hooks/usePersistentState"
 import { peekTaskforceSession } from "@/lib/taskforceSession"
 import { cn } from "@/lib/utils"
 import styles from "./FleetPage.module.css"
+import { useFleetPulseSync } from "./fleetPulseSync"
 import {
   AGENT_KIND_LABEL,
   type AgentKind,
@@ -150,11 +152,9 @@ function ClientChip({ kind }: { kind: AgentKind }) {
 
 function ActivityMarquee({
   activity,
-  isRunning,
   active,
 }: {
   activity: string
-  isRunning: boolean
   active: boolean
 }) {
   const containerRef = useRef<HTMLSpanElement>(null)
@@ -182,19 +182,36 @@ function ActivityMarquee({
 
   useEffect(() => {
     activeRef.current = active
-    if (!active) setAtEnd(false)
+    if (active) setAtEnd(false)
   }, [active])
 
   const scrolls = scrollDistance > 0
+  const forwardDuration = scrolls
+    ? Math.max(1.6, (scrollDistance / 32 + 2) / 2.5)
+    : 0
+  const rewindDuration = forwardDuration / 6
+
   const marqueeStyle = scrolls
     ? ({
         "--activity-scroll": `${scrollDistance}px`,
-        "--activity-duration": `${Math.max(1.6, (scrollDistance / 32 + 2) / 2.5)}s`,
+        "--activity-fade": "12px",
       } as CSSProperties)
     : undefined
 
-  const handleAnimationEnd = () => {
-    if (activeRef.current) setAtEnd(true)
+  const trackStyle = scrolls
+    ? ({
+        "--activity-motion-duration": `${active ? forwardDuration : rewindDuration}s`,
+        transform: active
+          ? "translateX(calc(-1 * var(--activity-scroll, 0px)))"
+          : "translateX(0)",
+      } as CSSProperties)
+    : undefined
+
+  const handleTransitionEnd = (event: TransitionEvent<HTMLSpanElement>) => {
+    if (event.propertyName !== "transform" || event.target !== trackRef.current) {
+      return
+    }
+    setAtEnd(activeRef.current)
   }
 
   return (
@@ -210,18 +227,10 @@ function ActivityMarquee({
     >
       <span
         ref={trackRef}
-        className={cn(
-          styles.aactivityTrack,
-          scrolls && styles.aactivityTrackScroll,
-          scrolls && active && styles.aactivityTrackForward,
-        )}
-        onAnimationEnd={handleAnimationEnd}
+        className={cn(styles.aactivityTrack, scrolls && styles.aactivityTrackScroll)}
+        style={trackStyle}
+        onTransitionEnd={handleTransitionEnd}
       >
-        {isRunning && (
-          <span className={styles.acaret} aria-hidden="true">
-            ▸{" "}
-          </span>
-        )}
         {activity}
       </span>
     </span>
@@ -333,7 +342,6 @@ function AgentRow({
                   </span>
                   <ActivityMarquee
                     activity={activity}
-                    isRunning={status === "run"}
                     active={rowHovered}
                   />
                 </>
@@ -626,6 +634,7 @@ function FleetCard({
 }
 
 export function FleetPage() {
+  const setPulseRoot = useFleetPulseSync()
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const currentUser = peekTaskforceSession()
@@ -805,6 +814,7 @@ export function FleetPage() {
 
   return (
     <section
+      ref={setPulseRoot}
       className={cn(
         V2_PAGE_FRAME,
         styles.page,

--- a/src/components/V2/Fleet/fleetPulseSync.ts
+++ b/src/components/V2/Fleet/fleetPulseSync.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef } from "react"
+
+/** Matches `.pulse` / `fleet-pulse` in FleetPage.module.css */
+export const FLEET_PULSE_MS = 2600
+
+function fleetPulseDelaySec(now = Date.now()) {
+  return -((now % FLEET_PULSE_MS) / 1000)
+}
+
+function bindFleetPulseSync(node: HTMLElement) {
+  const apply = () => {
+    node.style.setProperty("--fleet-pulse-delay", `${fleetPulseDelaySec()}s`)
+  }
+
+  apply()
+  const intervalId = window.setInterval(apply, FLEET_PULSE_MS)
+  const onVisibility = () => {
+    if (document.visibilityState === "visible") apply()
+  }
+  document.addEventListener("visibilitychange", onVisibility)
+
+  return () => {
+    window.clearInterval(intervalId)
+    document.removeEventListener("visibilitychange", onVisibility)
+  }
+}
+
+/** Keep every `.pulse` indicator on the node in phase with wall clock. */
+export function useFleetPulseSync() {
+  const cleanupRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => () => cleanupRef.current?.(), [])
+
+  return useCallback((node: HTMLElement | null) => {
+    cleanupRef.current?.()
+    cleanupRef.current = null
+    if (!node) return
+    cleanupRef.current = bindFleetPulseSync(node)
+  }, [])
+}

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { V2_TAB_CONTENT_CLASS } from "@/components/V2/v2PageShell"
 import styles from "@/components/V2/Fleet/FleetPage.module.css"
+import { useFleetPulseSync } from "@/components/V2/Fleet/fleetPulseSync"
 import {
   agentCapturePaused,
   agentDisplayName,
@@ -108,6 +109,7 @@ function eventDetail(event: TaskforceSessionActivityEntry): string | null {
 }
 
 function FleetAgentDetailRoute() {
+  const setPulseRoot = useFleetPulseSync()
   const { sessionId } = Route.useParams()
   const fleetQuery = useQuery({
     queryKey: FLEET_QUERY_KEY,
@@ -133,7 +135,10 @@ function FleetAgentDetailRoute() {
 
   if (fleetQuery.isLoading) {
     return (
-      <div className={cn(styles.detail, "items-center justify-center")}>
+      <div
+        ref={setPulseRoot}
+        className={cn(styles.detail, "items-center justify-center")}
+      >
         <p className="text-sm text-muted-foreground">Loading session…</p>
       </div>
     )
@@ -141,7 +146,10 @@ function FleetAgentDetailRoute() {
 
   if (!located) {
     return (
-      <div className={cn(styles.detail, "items-start gap-4")}>
+      <div
+        ref={setPulseRoot}
+        className={cn(styles.detail, "items-start gap-4")}
+      >
         <p className="text-sm text-muted-foreground">
           {fleetQuery.error
             ? "This session could not be loaded."
@@ -183,7 +191,7 @@ function FleetAgentDetailRoute() {
   )
 
   return (
-    <div className={styles.detail} data-testid="fleet-agent-detail">
+    <div className={styles.detail} data-testid="fleet-agent-detail" ref={setPulseRoot}>
       <div className={styles.dtop}>
         <div className={styles.crumb}>
           <Link to="/v2/fleet" className={styles.back}>


### PR DESCRIPTION
## Summary
- Sync all purple running status dots in phase via a shared wall-clock pulse delay on the fleet page root.
- Replace one-way activity marquee animation with transform transitions so hover-off rewinds smoothly at 6× forward speed.
- Remove the purple activity caret from agent sub-lines.
- Widen the session header count column and add margin after Session context so the count no longer crowds the button.

## Test plan
- [ ] Open Sessions with multiple running agents — status dots pulse in sync
- [ ] Hover a row with long activity text — text scrolls forward; on hover off it rewinds smoothly (not instant)
- [ ] Confirm no purple ▸ before activity text on running rows
- [ ] Confirm Session context button has comfortable spacing before "N active · N total"
- [ ] Reduced motion still disables pulse and marquee transitions


Made with [Cursor](https://cursor.com)