### PR TITLE
Fleet: keep activity marquee fades and clear text ending

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -463,21 +463,13 @@
 
 .aactivityMarquee {
   --activity-fade: 12px;
+  --activity-end-inset: calc(var(--activity-fade) + 4px);
   mask-image: linear-gradient(
     90deg,
     transparent 0,
     #000 var(--activity-fade),
     #000 calc(100% - var(--activity-fade)),
     transparent 100%
-  );
-}
-
-.aactivityMarqueeAtEnd {
-  mask-image: linear-gradient(
-    90deg,
-    transparent 0,
-    #000 var(--activity-fade),
-    #000 100%
   );
 }
 
@@ -488,6 +480,7 @@
 
 .aactivityTrackScroll {
   padding-left: var(--activity-fade, 12px);
+  padding-right: var(--activity-end-inset, 16px);
   transition: transform var(--activity-motion-duration, 0.25s) ease-in-out;
 }
 

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -13,7 +13,6 @@ import {
   type CSSProperties,
   type DragEvent,
   type FormEvent,
-  type TransitionEvent,
   useCallback,
   useEffect,
   useRef,
@@ -160,8 +159,6 @@ function ActivityMarquee({
   const containerRef = useRef<HTMLSpanElement>(null)
   const trackRef = useRef<HTMLSpanElement>(null)
   const [scrollDistance, setScrollDistance] = useState(0)
-  const [atEnd, setAtEnd] = useState(false)
-  const activeRef = useRef(false)
 
   useEffect(() => {
     const container = containerRef.current
@@ -179,11 +176,6 @@ function ActivityMarquee({
     observer.observe(track)
     return () => observer.disconnect()
   }, [activity])
-
-  useEffect(() => {
-    activeRef.current = active
-    if (active) setAtEnd(false)
-  }, [active])
 
   const scrolls = scrollDistance > 0
   const forwardDuration = scrolls
@@ -207,21 +199,10 @@ function ActivityMarquee({
       } as CSSProperties)
     : undefined
 
-  const handleTransitionEnd = (event: TransitionEvent<HTMLSpanElement>) => {
-    if (event.propertyName !== "transform" || event.target !== trackRef.current) {
-      return
-    }
-    setAtEnd(activeRef.current)
-  }
-
   return (
     <span
       ref={containerRef}
-      className={cn(
-        styles.aactivity,
-        scrolls && styles.aactivityMarquee,
-        scrolls && atEnd && styles.aactivityMarqueeAtEnd,
-      )}
+      className={cn(styles.aactivity, scrolls && styles.aactivityMarquee)}
       style={marqueeStyle}
       title={activity}
     >
@@ -229,7 +210,6 @@ function ActivityMarquee({
         ref={trackRef}
         className={cn(styles.aactivityTrack, scrolls && styles.aactivityTrackScroll)}
         style={trackStyle}
-        onTransitionEnd={handleTransitionEnd}
       >
         {activity}
       </span>


### PR DESCRIPTION
## Summary
- Keep the right-edge fade on overflowing activity text at all times (no end-state mask override).
- Add right track padding so the last characters sit in the clear zone when fully scrolled, slightly left of the right fade.

## Test plan
- [ ] Hover a row with long activity text — both edge fades stay visible while scrolling
- [ ] At full scroll, the text ending is readable and not sitting under the right blur
- [ ] On hover off, text rewinds smoothly to the start


Made with [Cursor](https://cursor.com)