### PR TITLE
Fleet: gray Inactive state, drag-to-Archive, recent activity on rows

### DIFF
--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -53,7 +53,8 @@ export interface TaskforceFleetAgent {
   summary_markdown: string
   last_seen_at: string
   minutes_ago: number
-  status: "running" | "waiting" | "paused" | "idle"
+  status: "running" | "waiting" | "paused" | "idle" | "inactive"
+  recent_activity: string[]
   started_at: string | null
   specialist_slug: string | null
   specialist_rule_count: number | null

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -379,6 +379,12 @@
   background: var(--fl-faint);
 }
 
+/* Stopped/Inactive: a calm gray dot (not red/purple) — the session is set
+   aside but still here, and revives if the user types in it again. */
+.inactive {
+  background: var(--fl-faint);
+}
+
 .paused {
   background: transparent;
   box-shadow: inset 0 0 0 1.5px var(--fl-faint);
@@ -478,12 +484,7 @@
 }
 
 .aactivityMarqueeAtEnd {
-  mask-image: linear-gradient(
-    90deg,
-    transparent 0,
-    #000 12px,
-    #000 100%
-  );
+  mask-image: linear-gradient(90deg, transparent 0, #000 12px, #000 100%);
 }
 
 .aactivityTrack {
@@ -588,7 +589,8 @@
 }
 
 .statePaused,
-.stateIdle {
+.stateIdle,
+.stateInactive {
   color: var(--fl-faint);
 }
 

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -79,7 +79,9 @@ const FLEET_QUERY_KEY = ["v2-taskforce-fleet"] as const
 
 type FleetCollapsedMap = Record<string, boolean>
 
-function deserializeFleetCollapsed(raw: unknown): FleetCollapsedMap | undefined {
+function deserializeFleetCollapsed(
+  raw: unknown,
+): FleetCollapsedMap | undefined {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined
   const result: FleetCollapsedMap = {}
   for (const [key, value] of Object.entries(raw)) {
@@ -113,6 +115,7 @@ const STATE_CLASS: Record<FleetStatus, string> = {
   waiting: styles.stateWaiting,
   paused: styles.statePaused,
   idle: styles.stateIdle,
+  inactive: styles.stateInactive,
 }
 
 function StatusDot({ status }: { status: FleetStatus }) {
@@ -179,7 +182,7 @@ function ActivityMarquee({
     observer.observe(container)
     observer.observe(track)
     return () => observer.disconnect()
-  }, [activity])
+  }, [])
 
   useEffect(() => {
     return () => {
@@ -498,10 +501,10 @@ function FleetCard({
   const running = runningCount(fleet.agents)
   const total = fleet.agents.length
   const isHistory = fleet.is_history
+  // The Archive group IS a valid drop target — archiving is the user dragging a
+  // session into it. (Agents never reach Archive automatically.)
   const isDropCandidate =
-    !isHistory &&
-    draggingAgent !== null &&
-    draggingAgent.fleet_session_id !== fleet.id
+    draggingAgent !== null && draggingAgent.fleet_session_id !== fleet.id
   const isDropTarget = isDropCandidate && dropTargetId === fleet.id
   const hasPendingMove =
     movingSessionId !== null &&
@@ -622,31 +625,29 @@ function FleetCard({
       </div>
 
       {!isCollapsed && (
-        <>
-          <div id={`fleet-body-${fleet.id}`}>
-            {fleet.agents.length === 0 ? (
-              <div className={styles.emptyRows}>
-                {isHistory
-                  ? "Inactive agent sessions appear here."
-                  : "No active agents in this session group yet."}
-              </div>
-            ) : (
-              fleet.agents.map((agent) => (
-                <AgentRow
-                  key={agent.session_id}
-                  agent={agent}
-                  onOpen={onOpenAgent}
-                  onRename={onRenameAgent}
-                  onDragStart={onAgentDragStart}
-                  onDragEnd={onAgentDragEnd}
-                  isDragging={draggingAgent?.session_id === agent.session_id}
-                  isMoving={movingSessionId === agent.session_id}
-                  draggable={!isHistory}
-                />
-              ))
-            )}
-          </div>
-        </>
+        <div id={`fleet-body-${fleet.id}`}>
+          {fleet.agents.length === 0 ? (
+            <div className={styles.emptyRows}>
+              {isHistory
+                ? "Drag a session here to archive it."
+                : "No active agents in this session group yet."}
+            </div>
+          ) : (
+            fleet.agents.map((agent) => (
+              <AgentRow
+                key={agent.session_id}
+                agent={agent}
+                onOpen={onOpenAgent}
+                onRename={onRenameAgent}
+                onDragStart={onAgentDragStart}
+                onDragEnd={onAgentDragEnd}
+                isDragging={draggingAgent?.session_id === agent.session_id}
+                isMoving={movingSessionId === agent.session_id}
+                draggable
+              />
+            ))
+          )}
+        </div>
       )}
     </section>
   )
@@ -658,10 +659,7 @@ export function FleetPage() {
   const currentUser = peekTaskforceSession()
   const [collapsedByFleetId, setCollapsedByFleetId] =
     usePersistentState<FleetCollapsedMap>(
-      persistedKey(
-        "fleet.session-collapsed",
-        currentUser?.id ?? "anonymous",
-      ),
+      persistedKey("fleet.session-collapsed", currentUser?.id ?? "anonymous"),
       {},
       { deserialize: deserializeFleetCollapsed },
     )

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -8,7 +8,7 @@ import type {
  * handoff. The API spells the active state `running`; this presentation model
  * keeps the shorter `run` key used by the CSS module.
  */
-export type FleetStatus = "run" | "waiting" | "paused" | "idle"
+export type FleetStatus = "run" | "waiting" | "paused" | "idle" | "inactive"
 
 /** Quiet word shown next to a non-running status dot. */
 export const STATE_LABEL: Record<FleetStatus, string> = {
@@ -16,6 +16,7 @@ export const STATE_LABEL: Record<FleetStatus, string> = {
   waiting: "awaiting prompt",
   paused: "capture paused",
   idle: "idle",
+  inactive: "inactive",
 }
 
 /** One-line roster status in the agent row's second column. */
@@ -24,6 +25,9 @@ export const ROSTER_STATUS_LABEL: Record<FleetStatus, string> = {
   waiting: "Agent waiting",
   paused: "Capture paused",
   idle: "Agent idle",
+  // Stopped (e.g. the user closed the terminal). Stays put until archived,
+  // and comes back to life if the user types in the chat again.
+  inactive: "Stopped",
 }
 
 export function rosterStatusLabel(agent: TaskforceFleetAgent): string {
@@ -163,9 +167,11 @@ const FLEET_UI_MARKERS = [
 ]
 
 /** Strip Cursor wrappers and Fleet UI paste noise for activity display. */
-export function cleanActivityPromptText(text: string | null | undefined): string {
+export function cleanActivityPromptText(
+  text: string | null | undefined,
+): string {
   if (!text) return ""
-  let cleaned = text
+  const cleaned = text
     .replace(/^<user_query>\s*/i, "")
     .replace(/\s*<\/user_query>\s*$/i, "")
     .trim()
@@ -220,24 +226,50 @@ export function liveActivityLabel(
   return "Connected but not actively running"
 }
 
-/** Compact single-line activity for the roster row sub-line. Only shows captured
-   work summary — status copy lives in the row's status column. */
-export function agentActivityLine(agent: TaskforceFleetAgent): string {
-  const summary = agent.summary_markdown?.trim()
-  if (!summary) return ""
-  const firstLine = summary.split(/\r?\n/)[0]?.trim() ?? ""
-  return firstLine.length > 120 ? `${firstLine.slice(0, 119)}…` : firstLine
+/** Newest-first recent per-turn prompts captured for this agent. */
+export function agentRecentActivity(agent: TaskforceFleetAgent): string[] {
+  return (agent.recent_activity ?? [])
+    .map((text) => text.trim())
+    .filter(Boolean)
 }
 
-/** Session detail "Working on" body when no summary is stored yet. */
+function truncateLine(text: string, max = 120): string {
+  const firstLine = text.split(/\r?\n/)[0]?.trim() ?? ""
+  return firstLine.length > max ? `${firstLine.slice(0, max - 1)}…` : firstLine
+}
+
+/** Compact single-line activity for the roster row sub-line.
+
+   Surfaces "what just happened" so the row stays glanceable. For a running
+   agent the newest prompt is the turn in progress, so we show the one before it
+   (the most recent *completed* work); otherwise we show the newest. Falls back
+   to the captured work summary when no per-turn prompts are recorded yet. */
+export function agentActivityLine(agent: TaskforceFleetAgent): string {
+  const recent = agentRecentActivity(agent)
+  const summary = agent.summary_markdown?.trim()
+  const pick = isRunning(agent)
+    ? (recent[1] ?? summary ?? recent[0])
+    : (recent[0] ?? summary)
+  return pick ? truncateLine(pick) : ""
+}
+
+/** Session detail "Working on" body.
+
+   For a running agent we surface both that something new is in progress *and*
+   the most recent thing it did just before, so the user can orient quickly. */
 export function sessionWorkSummary(agent: TaskforceFleetAgent): string {
   const summary = agent.summary_markdown?.trim()
-  if (summary) return summary
-
   const status = agentStatus(agent)
+
   if (status === "run") {
-    return "Running in this terminal. A summary appears after Taskforce capture records work."
+    const base =
+      summary ||
+      "Running in this terminal. A summary appears after Taskforce capture records work."
+    // recent[0] is the in-progress turn; recent[1] is what happened before it.
+    const previous = agentRecentActivity(agent)[1]
+    return previous ? `${base}\n\nMost recently: ${previous}` : base
   }
+  if (summary) return summary
   if (status === "paused" || agentCapturePaused(agent)) {
     return "Activity capture is paused, so no summary is being updated."
   }

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -10,7 +10,6 @@ import {
   type TaskforceSessionActivityEntry,
 } from "@/api/v2Taskforce"
 import { Button } from "@/components/ui/button"
-import { V2_TAB_CONTENT_CLASS } from "@/components/V2/v2PageShell"
 import styles from "@/components/V2/Fleet/FleetPage.module.css"
 import {
   agentCapturePaused,
@@ -33,9 +32,10 @@ import {
   liveActivityTime,
   modelLabel,
   presenceLabel,
-  sessionWorkSummary,
   STATE_LABEL,
+  sessionWorkSummary,
 } from "@/components/V2/Fleet/fleetStatus"
+import { V2_TAB_CONTENT_CLASS } from "@/components/V2/v2PageShell"
 import { cn } from "@/lib/utils"
 
 const FLEET_QUERY_KEY = ["v2-taskforce-fleet"] as const
@@ -68,6 +68,7 @@ const STATE_CLASS: Record<FleetStatus, string | undefined> = {
   waiting: styles.stateWaiting,
   paused: styles.statePaused,
   idle: styles.stateIdle,
+  inactive: styles.stateInactive,
 }
 
 function metaRow(key: string, value: string, valueClass?: string) {


### PR DESCRIPTION
## What

Frontend for the fleet Inactive/Archive rework (backend: al-exe/EnderAI#171).

- **Gray Inactive state**: renders the new server `inactive` status as a calm gray dot (not red/purple) with a **Stopped** label. The session stays in its group until the user acts on it.
- **Drag-to-Archive**: the Archive group (renamed from History) is now a valid drop target, so users archive a session by dragging it in; sessions can also be dragged back out.
- **Recent activity on rows**: a running agent's row shows the turn *before* the in-progress one ("what just happened"); the session detail **Working on** appends the most recent prior turn while running, so it's clear something new started and what came right before.

## Checks

- `tsc -p tsconfig.build.json` clean.
- biome: no new diagnostics (identical count to origin/main on the touched files).

Requires the backend PR for the `inactive` status, `recent_activity`, and the Archive rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)