### PR TITLE
Session agent: render markdown in the activity timeline + Working-on

### DIFF
--- a/src/components/V2/Fleet/Markdown.module.css
+++ b/src/components/V2/Fleet/Markdown.module.css
@@ -1,0 +1,101 @@
+/* Compact markdown for session prose. Inherits font-size/color from the row;
+   only normalizes block spacing and code/list styling. Keeps the workspace's
+   globally sharp corners (no border-radius). */
+
+.md {
+  min-width: 0;
+}
+
+.md > :first-child {
+  margin-top: 0;
+}
+
+.md > :last-child {
+  margin-bottom: 0;
+}
+
+.md p {
+  margin: 0 0 6px;
+}
+
+.md ul,
+.md ol {
+  margin: 4px 0;
+  padding-left: 18px;
+}
+
+.md li {
+  margin: 2px 0;
+}
+
+.md li::marker {
+  color: var(--muted-foreground);
+}
+
+.md code {
+  padding: 0.08em 0.34em;
+  background: color-mix(in srgb, var(--foreground) 9%, transparent);
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+}
+
+.md pre {
+  margin: 6px 0;
+  padding: 9px 11px;
+  overflow-x: auto;
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+}
+
+.md pre code {
+  padding: 0;
+  background: none;
+  font-size: 0.92em;
+}
+
+.md a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.md strong {
+  font-weight: 600;
+}
+
+.md h1,
+.md h2,
+.md h3,
+.md h4,
+.md h5,
+.md h6 {
+  margin: 8px 0 4px;
+  font-size: 1em;
+  font-weight: 600;
+}
+
+.md blockquote {
+  margin: 6px 0;
+  padding-left: 10px;
+  border-left: 2px solid var(--border);
+  color: var(--muted-foreground);
+}
+
+.md hr {
+  margin: 8px 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+}
+
+/* Tables can appear in richer summaries; keep them readable but compact. */
+.md table {
+  display: block;
+  overflow-x: auto;
+  border-collapse: collapse;
+}
+
+.md th,
+.md td {
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  text-align: left;
+}

--- a/src/components/V2/Fleet/Markdown.tsx
+++ b/src/components/V2/Fleet/Markdown.tsx
@@ -1,0 +1,35 @@
+import ReactMarkdown, { type Components } from "react-markdown"
+import remarkGfm from "remark-gfm"
+import { cn } from "@/lib/utils"
+import styles from "./Markdown.module.css"
+
+// Links captured in session prose are external; open them safely in a new tab.
+const COMPONENTS: Components = {
+  a: ({ children, href, title }) => (
+    <a href={href} title={title} target="_blank" rel="noreferrer noopener">
+      {children}
+    </a>
+  ),
+}
+
+/**
+ * Compact GitHub-flavored markdown for session prose (timeline entries, the
+ * live activity head, the "Working on" body). Tight block spacing so it sits
+ * cleanly inside the agent-detail rows instead of rendering as raw `*`/backtick
+ * text. Inherits the surrounding font size and color.
+ */
+export function Markdown({
+  children,
+  className,
+}: {
+  children: string
+  className?: string
+}) {
+  return (
+    <div className={cn(styles.md, className)}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={COMPONENTS}>
+        {children}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -36,6 +36,7 @@ import {
   STATE_LABEL,
   sessionWorkSummary,
 } from "@/components/V2/Fleet/fleetStatus"
+import { Markdown } from "@/components/V2/Fleet/Markdown"
 import { V2_TAB_CONTENT_CLASS } from "@/components/V2/v2PageShell"
 import { cn } from "@/lib/utils"
 
@@ -82,6 +83,11 @@ function metaRow(key: string, value: string, valueClass?: string) {
     </div>
   )
 }
+
+// Prompt/reply/note carry free-form prose worth rendering as markdown. Command
+// and edit titles are structured ("$ cmd", "Edited file") — leave them literal
+// so shell/path characters aren't mangled by the markdown parser.
+const PROSE_EVENT_KINDS = new Set(["prompt", "reply", "note"])
 
 function eventTitle(event: TaskforceSessionActivityEntry): string {
   if (event.kind === "command") return `$ ${event.cmd ?? "command"}`
@@ -192,7 +198,11 @@ function FleetAgentDetailRoute() {
   )
 
   return (
-    <div className={styles.detail} data-testid="fleet-agent-detail" ref={setPulseRoot}>
+    <div
+      className={styles.detail}
+      data-testid="fleet-agent-detail"
+      ref={setPulseRoot}
+    >
       <div className={styles.dtop}>
         <div className={styles.crumb}>
           <Link to="/v2/fleet" className={styles.back}>
@@ -285,7 +295,9 @@ function FleetAgentDetailRoute() {
           ) : (
             <div className={styles.section}>
               <div className={styles.seclabel}>Working on</div>
-              <div className={styles.nowtask}>{sessionWorkSummary(agent)}</div>
+              <div className={styles.nowtask}>
+                <Markdown>{sessionWorkSummary(agent)}</Markdown>
+              </div>
             </div>
           )}
 
@@ -315,10 +327,12 @@ function FleetAgentDetailRoute() {
                 <span className={styles.tdot} />
                 <div className={styles.tt}>{liveActivityTime(agent)}</div>
                 <div className={styles.tx}>
-                  {liveActivityLabel(agent, {
-                    capturePaused,
-                    pauseReason,
-                  })}
+                  <Markdown>
+                    {liveActivityLabel(agent, {
+                      capturePaused,
+                      pauseReason,
+                    })}
+                  </Markdown>
                 </div>
               </div>
               {activityEntries.map((entry) => {
@@ -330,7 +344,13 @@ function FleetAgentDetailRoute() {
                       {formatClockTime(entry.occurred_at)}
                       <span className={styles.tkind}>{entry.kind}</span>
                     </div>
-                    <div className={styles.tx}>{eventTitle(entry)}</div>
+                    <div className={styles.tx}>
+                      {PROSE_EVENT_KINDS.has(entry.kind) ? (
+                        <Markdown>{eventTitle(entry)}</Markdown>
+                      ) : (
+                        eventTitle(entry)
+                      )}
+                    </div>
                     {detail && <div className={styles.tsub}>{detail}</div>}
                   </>
                 )


### PR DESCRIPTION
## What

In the session-agent detail view, prompts/summaries were rendered as **raw text** — so backticks, `**bold**`, lists and code fences showed up as literal characters in the timeline. This makes them readable.

Adds a compact GFM `<Markdown>` component (reuses the app's existing `react-markdown` + `remark-gfm`) with tight block spacing that inherits the surrounding font size/color and keeps the workspace's sharp corners. Applied to:

- **Activity timeline entries** — only `prompt`/`reply`/`note` kinds (prose). `command` (`$ …`) and `edit` (`Edited …`) titles stay literal so shell/path characters aren't mangled by the parser.
- **Live activity head** (the "now" row).
- **"Working on" body** — the richest markdown (multi-bullet summaries).

## Notes
- No new dependency; `react-markdown`/`remark-gfm` already ship in the app.
- react-markdown doesn't render raw HTML (no `rehype-raw`), so no XSS surface.
- `tsc` clean; biome clean on the changed files.
- Scoped to text rendering; a sibling is separately polishing this view's spacing, so this stays orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)