### PR TITLE
Relabel session work sections + split "Previously worked on"

### DIFF
--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -253,27 +253,33 @@ export function agentActivityLine(agent: TaskforceFleetAgent): string {
   return pick ? truncateLine(pick) : ""
 }
 
-/** Session detail "Working on" body.
-
-   For a running agent we surface both that something new is in progress *and*
-   the most recent thing it did just before, so the user can orient quickly. */
+/** Session detail "Currently working on" body. */
 export function sessionWorkSummary(agent: TaskforceFleetAgent): string {
   const summary = agent.summary_markdown?.trim()
   const status = agentStatus(agent)
 
   if (status === "run") {
-    const base =
+    return (
       summary ||
       "Running in this terminal. A summary appears after Taskforce capture records work."
-    // recent[0] is the in-progress turn; recent[1] is what happened before it.
-    const previous = agentRecentActivity(agent)[1]
-    return previous ? `${base}\n\nMost recently: ${previous}` : base
+    )
   }
   if (summary) return summary
   if (status === "paused" || agentCapturePaused(agent)) {
     return "Activity capture is paused, so no summary is being updated."
   }
   return "No summary has been captured for this session yet."
+}
+
+/** Session detail "Previously worked on" body.
+
+   For a running agent, surface the thing it did just before the in-progress
+   turn so the user can orient quickly. Empty when there's nothing prior or the
+   agent isn't actively running. */
+export function sessionPreviousWork(agent: TaskforceFleetAgent): string {
+  if (agentStatus(agent) !== "run") return ""
+  // recent[0] is the in-progress turn; recent[1] is what happened before it.
+  return agentRecentActivity(agent)[1] ?? ""
 }
 
 /** Locale-aware date and time in the browser's local timezone. */

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -40,6 +40,7 @@ import {
   modelLabel,
   presenceLabel,
   STATE_LABEL,
+  sessionPreviousWork,
   sessionWorkSummary,
 } from "@/components/V2/Fleet/fleetStatus"
 import { Markdown } from "@/components/V2/Fleet/Markdown"
@@ -306,7 +307,7 @@ function FleetAgentDetailRoute() {
           data-testid="fleet-detail-body"
         >
         <div className={styles.dmain}>
-          {/* Working on — waiting agents surface a question when present. */}
+          {/* Currently working on — waiting agents surface a question when present. */}
           {status === "waiting" ? (
             question ? (
               <div className={styles.section}>
@@ -328,12 +329,22 @@ function FleetAgentDetailRoute() {
             ) : null
           ) : (
             <div className={styles.section}>
-              <div className={styles.seclabel}>Working on</div>
+              <div className={styles.seclabel}>Currently working on</div>
               <div className={styles.nowtask}>
                 <Markdown>{sessionWorkSummary(agent)}</Markdown>
               </div>
             </div>
           )}
+
+          {/* Previously worked on — the turn just before the in-progress one. */}
+          {sessionPreviousWork(agent) ? (
+            <div className={styles.section}>
+              <div className={styles.seclabel}>Previously worked on</div>
+              <div className={styles.nowtask}>
+                <Markdown>{sessionPreviousWork(agent)}</Markdown>
+              </div>
+            </div>
+          ) : null}
 
           {/* Document */}
           {agent.active_document_id && (

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -380,7 +380,7 @@ test("clicking an agent row opens the session detail and back returns", async ({
       name: "Wiring automatic tax on Stripe checkout",
     }),
   ).toBeVisible()
-  await expect(page.getByText("Working on")).toBeVisible()
+  await expect(page.getByText("Currently working on")).toBeVisible()
   await expect(page.getByText("Activity")).toBeVisible()
   await expect(page.getByText("Session", { exact: true }).first()).toBeVisible()
   await expect(page.getByText("4 conventions applied")).toBeVisible()


### PR DESCRIPTION
## What

In the session-detail view (Sessions → a running agent):

- **"Working on" → "Currently working on"** for the live summary heading.
- **"Most recently: …" → its own "Previously worked on" section**, rendered with the same `seclabel` formatting as the heading above it, instead of being inlined as a text prefix in the body.

## Why

User feedback: the inline `Most recently: …` prefix read awkwardly; the prior turn deserves its own labeled section matching the surrounding formatting.

## Changes

- `fleetStatus.ts`: `sessionWorkSummary()` now returns only the in-progress summary. New `sessionPreviousWork()` returns the prior recent-activity turn (running agents only, empty otherwise).
- `fleet.$sessionId.tsx`: renders a separate "Previously worked on" section when prior work exists.
- `tests/fleet.spec.ts`: asserts the new "Currently working on" label.

## Validation

- `tsc --noEmit` clean.
- Biome clean on changed lines (3 pre-existing format-drift errors elsewhere in `fleet.spec.ts` are untouched).
- Playwright e2e webserver has a pre-existing `node`-on-PATH env issue unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)