### PR TITLE
Fleet roster subline and session context drawer polish

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -213,19 +213,68 @@
 }
 
 /* ----- shared-context drawer body ----- */
-.ctxRow {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
+.ctxDrawer {
+  --ctx-pad-inline: 26px;
+  --ctx-lead-col: 62px;
+  --ctx-col-gap: 12px;
+  width: 100%;
+  max-width: min(100vw, 520px);
 }
 
-.ctxRow + .ctxRow {
+.ctxPanel {
+  padding-inline: var(--ctx-pad-inline);
+}
+
+.ctxPanelHeader {
+  padding-block: 22px 20px;
+  border-bottom: 1px solid var(--fl-hair);
+}
+
+.ctxPanelBody {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding-block: 20px 24px;
+}
+
+.ctxGrid {
+  display: grid;
+  grid-template-columns: var(--ctx-lead-col) minmax(0, 1fr);
+  column-gap: var(--ctx-col-gap);
+  align-items: start;
+}
+
+.ctxGrid + .ctxGrid {
   margin-top: 14px;
 }
 
-.ctxRowBody {
+.ctxLead {
+  display: flex;
+  justify-content: center;
   min-width: 0;
-  flex: 1;
+}
+
+.ctxCol {
+  min-width: 0;
+}
+
+.ctxTitle {
+  margin: 0;
+  font-size: calc(14px * var(--v2-scale, 1));
+  font-weight: 600;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+}
+
+.ctxScope {
+  margin: 4px 0 0;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: calc(12px * var(--v2-scale, 1));
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ctxIcon {
@@ -246,12 +295,30 @@
 
 .ctxInjectText {
   margin: 0;
-  padding: 9px 11px 9px 0;
+  padding: 9px 12px;
   border: 1px solid var(--fl-primary-line);
-  border-left: 0;
   background: var(--fl-primary-soft);
   font-size: calc(12px * var(--v2-scale, 1));
-  line-height: 1.4;
+  line-height: 1.45;
+}
+
+.ctxMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: calc(11px * var(--v2-scale, 1));
+  line-height: 1.35;
+}
+
+.ctxList {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .ctxEntry {
@@ -261,6 +328,65 @@
 
 .ctxEntry:last-child {
   border-bottom: 0;
+}
+
+.ctxEntryHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.ctxEntryTitle {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  font-size: calc(13px * var(--v2-scale, 1));
+  font-weight: 500;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ctxEntryTime {
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: calc(10.5px * var(--v2-scale, 1));
+  line-height: 1.35;
+}
+
+.ctxEntrySummary {
+  margin: 8px 0 0;
+  color: var(--muted-foreground);
+  font-size: calc(13px * var(--v2-scale, 1));
+  line-height: 1.5;
+}
+
+.ctxEmptyText {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: calc(13px * var(--v2-scale, 1));
+  line-height: 1.5;
+}
+
+.ctxErrorText {
+  margin: 0;
+  color: var(--destructive);
+  font-size: calc(13px * var(--v2-scale, 1));
+  line-height: 1.5;
+}
+
+.ctxLoading {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ctxLoadingRow {
+  height: 80px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--muted) 20%, transparent);
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
 .ctxBadge {

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -436,7 +436,7 @@
   white-space: nowrap;
 }
 
-/* second identity line — model · branch · live activity */
+/* second identity line — model, branch, live activity */
 .asub {
   display: flex;
   min-width: 0;
@@ -447,11 +447,6 @@
   font-size: calc(11px * var(--v2-scale, 1));
   line-height: 1.35;
   white-space: nowrap;
-}
-
-.asep {
-  flex-shrink: 0;
-  color: color-mix(in srgb, var(--fl-faint) 55%, var(--background));
 }
 
 .amodel,
@@ -469,11 +464,9 @@
 
 .aactivityMarquee {
   --activity-fade: 12px;
-  --activity-end-inset: calc(var(--activity-fade) + 4px);
   mask-image: linear-gradient(
     90deg,
-    transparent 0,
-    #000 var(--activity-fade),
+    #000 0,
     #000 calc(100% - var(--activity-fade)),
     transparent 100%
   );
@@ -485,8 +478,7 @@
 }
 
 .aactivityTrackScroll {
-  padding-left: var(--activity-fade, 12px);
-  padding-right: var(--activity-end-inset, 16px);
+  padding-right: calc(var(--activity-fade, 12px) + 4px);
   transition: transform var(--activity-motion-duration, 0.25s) ease-in-out;
 }
 

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -261,10 +261,11 @@
   flex-shrink: 0;
   padding: 2px 6px;
   border: 1px solid var(--border);
-  color: var(--muted-foreground);
   font-family: var(--font-mono);
   font-size: calc(10.5px * var(--v2-scale, 1));
-  font-weight: 500;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.01em;
   white-space: nowrap;
 }
 

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -213,6 +213,21 @@
 }
 
 /* ----- shared-context drawer body ----- */
+.ctxRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.ctxRow + .ctxRow {
+  margin-top: 14px;
+}
+
+.ctxRowBody {
+  min-width: 0;
+  flex: 1;
+}
+
 .ctxIcon {
   display: grid;
   flex-shrink: 0;
@@ -229,23 +244,14 @@
   height: 16px;
 }
 
-.ctxInject {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  margin-top: 14px;
-  padding: 9px 11px;
+.ctxInjectText {
+  margin: 0;
+  padding: 9px 11px 9px 0;
   border: 1px solid var(--fl-primary-line);
+  border-left: 0;
   background: var(--fl-primary-soft);
   font-size: calc(12px * var(--v2-scale, 1));
   line-height: 1.4;
-}
-
-.ctxInject svg {
-  width: 15px;
-  height: 15px;
-  flex-shrink: 0;
-  color: var(--primary);
 }
 
 .ctxEntry {

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -310,24 +310,9 @@ function AgentRow({
             </div>
             <div className={styles.asub} data-testid="fleet-agent-sub">
               <span className={styles.amodel}>{model}</span>
-              {branch && (
-                <>
-                  <span className={styles.asep} aria-hidden="true">
-                    ·
-                  </span>
-                  <span className={styles.abranch}>{branch}</span>
-                </>
-              )}
+              {branch && <span className={styles.abranch}>{branch}</span>}
               {activity && (
-                <>
-                  <span className={styles.asep} aria-hidden="true">
-                    ·
-                  </span>
-                  <ActivityMarquee
-                    activity={activity}
-                    active={rowHovered}
-                  />
-                </>
+                <ActivityMarquee activity={activity} active={rowHovered} />
               )}
             </div>
           </div>

--- a/src/components/V2/Fleet/SharedContextDrawer.tsx
+++ b/src/components/V2/Fleet/SharedContextDrawer.tsx
@@ -95,7 +95,8 @@ export function SharedContextDrawer({
             </span>
             <div className={styles.ctxCol}>
               <p className={styles.ctxInjectText}>
-                Injected into this group's agents each turn, up to{" "}
+                Shared context between all agents in this session. Automatically
+                injected into each agent, up to{" "}
                 <b>
                   {(data?.inject_token_budget ?? 2000).toLocaleString()} tokens
                 </b>

--- a/src/components/V2/Fleet/SharedContextDrawer.tsx
+++ b/src/components/V2/Fleet/SharedContextDrawer.tsx
@@ -74,11 +74,11 @@ export function SharedContextDrawer({
         data-testid="fleet-context-drawer"
       >
         <div className="border-border border-b p-5">
-          <div className="flex items-center gap-3">
+          <div className={styles.ctxRow}>
             <span className={styles.ctxIcon}>
               <FileText aria-hidden="true" />
             </span>
-            <div className="min-w-0">
+            <div className={styles.ctxRowBody}>
               <h2 className="text-sm font-semibold tracking-tight">
                 Session context
               </h2>
@@ -87,26 +87,30 @@ export function SharedContextDrawer({
               </p>
             </div>
           </div>
-          <div className={styles.ctxInject}>
-            <Zap aria-hidden="true" />
-            <span>
-              Injected into this group's agents each turn, up to{" "}
-              <b>
-                {(data?.inject_token_budget ?? 2000).toLocaleString()} tokens
-              </b>
-              .
+          <div className={styles.ctxRow}>
+            <span className={styles.ctxIcon}>
+              <Zap aria-hidden="true" />
             </span>
-          </div>
-          {data && (
-            <div className="text-muted-foreground mt-3 flex flex-wrap gap-x-2 gap-y-1 font-mono text-[11px]">
-              <span>
-                {data.entry_count}{" "}
-                {data.entry_count === 1 ? "document" : "documents"}
-              </span>
-              <span aria-hidden="true">·</span>
-              <span>~{data.token_estimate.toLocaleString()} tokens</span>
+            <div className={styles.ctxRowBody}>
+              <p className={styles.ctxInjectText}>
+                Injected into this group's agents each turn, up to{" "}
+                <b>
+                  {(data?.inject_token_budget ?? 2000).toLocaleString()} tokens
+                </b>
+                .
+              </p>
+              {data && (
+                <div className="text-muted-foreground mt-3 flex flex-wrap gap-x-2 gap-y-1 font-mono text-[11px]">
+                  <span>
+                    {data.entry_count}{" "}
+                    {data.entry_count === 1 ? "document" : "documents"}
+                  </span>
+                  <span aria-hidden="true">·</span>
+                  <span>~{data.token_estimate.toLocaleString()} tokens</span>
+                </div>
+              )}
             </div>
-          )}
+          </div>
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto p-5">

--- a/src/components/V2/Fleet/SharedContextDrawer.tsx
+++ b/src/components/V2/Fleet/SharedContextDrawer.tsx
@@ -7,21 +7,20 @@ import {
   type TaskforceSessionContextEntry,
 } from "@/api/v2Taskforce"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import { cn } from "@/lib/utils"
 import styles from "./FleetPage.module.css"
-import { fleetTitle } from "./fleetStatus"
+import {
+  clientKind,
+  clientLabel,
+  fleetTitle,
+  type AgentKind,
+} from "./fleetStatus"
 
-// The harness that produced a document, mapped to the same short labels the
-// roster row chips use. Falls back to the raw client string when unknown.
-const CLIENT_LABEL: Record<string, string> = {
-  "claude-code": "Claude",
-  claude: "Claude",
-  codex: "Codex",
-  cursor: "Cursor",
-}
-
-function clientLabel(value: string | null): string {
-  if (!value) return "Agent"
-  return CLIENT_LABEL[value] ?? value
+const CHIP_CLASS: Record<AgentKind, string> = {
+  claude: styles.chipClaude,
+  codex: styles.chipCodex,
+  cursor: styles.chipCursor,
+  other: styles.chipOther,
 }
 
 function timeAgo(iso: string | null): string {
@@ -143,10 +142,11 @@ export function SharedContextDrawer({
 }
 
 function ContextEntry({ entry }: { entry: TaskforceSessionContextEntry }) {
+  const kind = clientKind(entry.produced_by_client)
   return (
     <li className={styles.ctxEntry} data-testid="fleet-context-entry">
       <div className="mb-1.5 flex items-center gap-2">
-        <span className={styles.ctxBadge}>
+        <span className={cn(styles.ctxBadge, CHIP_CLASS[kind])}>
           {clientLabel(entry.produced_by_client)}
         </span>
         <span className="min-w-0 flex-1 truncate text-[13px] font-medium">

--- a/src/components/V2/Fleet/SharedContextDrawer.tsx
+++ b/src/components/V2/Fleet/SharedContextDrawer.tsx
@@ -70,28 +70,30 @@ export function SharedContextDrawer({
       </SheetTrigger>
       <SheetContent
         side="right"
-        className="w-full gap-0 p-0 sm:max-w-md"
+        className={cn("w-full gap-0 p-0 sm:max-w-none", styles.ctxDrawer)}
         data-testid="fleet-context-drawer"
       >
-        <div className="border-border border-b p-5">
-          <div className={styles.ctxRow}>
-            <span className={styles.ctxIcon}>
-              <FileText aria-hidden="true" />
+        <div className={cn(styles.ctxPanel, styles.ctxPanelHeader)}>
+          <div className={styles.ctxGrid}>
+            <span className={styles.ctxLead}>
+              <span className={styles.ctxIcon}>
+                <FileText aria-hidden="true" />
+              </span>
             </span>
-            <div className={styles.ctxRowBody}>
-              <h2 className="text-sm font-semibold tracking-tight">
-                Session context
-              </h2>
-              <p className="text-muted-foreground truncate font-mono text-xs">
+            <div className={styles.ctxCol}>
+              <h2 className={styles.ctxTitle}>Session context</h2>
+              <p className={styles.ctxScope}>
                 {data?.scope ?? fleetTitle(fleet)}
               </p>
             </div>
           </div>
-          <div className={styles.ctxRow}>
-            <span className={styles.ctxIcon}>
-              <Zap aria-hidden="true" />
+          <div className={styles.ctxGrid}>
+            <span className={styles.ctxLead}>
+              <span className={styles.ctxIcon}>
+                <Zap aria-hidden="true" />
+              </span>
             </span>
-            <div className={styles.ctxRowBody}>
+            <div className={styles.ctxCol}>
               <p className={styles.ctxInjectText}>
                 Injected into this group's agents each turn, up to{" "}
                 <b>
@@ -100,7 +102,7 @@ export function SharedContextDrawer({
                 .
               </p>
               {data && (
-                <div className="text-muted-foreground mt-3 flex flex-wrap gap-x-2 gap-y-1 font-mono text-[11px]">
+                <div className={styles.ctxMeta}>
                   <span>
                     {data.entry_count}{" "}
                     {data.entry_count === 1 ? "document" : "documents"}
@@ -113,27 +115,34 @@ export function SharedContextDrawer({
           </div>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto p-5">
+        <div className={cn(styles.ctxPanel, styles.ctxPanelBody)}>
           {query.isLoading ? (
-            <div className="space-y-3">
+            <div className={styles.ctxLoading}>
               {[0, 1, 2].map((item) => (
-                <div
-                  key={item}
-                  className="border-border bg-muted/20 h-20 animate-pulse border"
-                />
+                <div key={item} className={styles.ctxGrid}>
+                  <span className={styles.ctxLead} aria-hidden="true" />
+                  <div className={styles.ctxLoadingRow} />
+                </div>
               ))}
             </div>
           ) : query.error ? (
-            <p className="text-destructive text-sm">
-              Session context could not load.
-            </p>
+            <div className={styles.ctxGrid}>
+              <span className={styles.ctxLead} aria-hidden="true" />
+              <p className={styles.ctxErrorText}>
+                Session context could not load.
+              </p>
+            </div>
           ) : entries.length === 0 ? (
-            <p className="text-muted-foreground text-sm leading-relaxed">
-              No session context yet. As this group's agents capture work, their
-              documents appear here and are injected into each agent's turn.
-            </p>
+            <div className={styles.ctxGrid}>
+              <span className={styles.ctxLead} aria-hidden="true" />
+              <p className={styles.ctxEmptyText}>
+                No session context yet. As this group's agents capture work,
+                their documents appear here and are injected into each agent's
+                turn.
+              </p>
+            </div>
           ) : (
-            <ul className="flex flex-col">
+            <ul className={styles.ctxList}>
               {entries.map((entry) => (
                 <ContextEntry key={entry.document_id} entry={entry} />
               ))}
@@ -149,25 +158,27 @@ function ContextEntry({ entry }: { entry: TaskforceSessionContextEntry }) {
   const kind = clientKind(entry.produced_by_client)
   return (
     <li className={styles.ctxEntry} data-testid="fleet-context-entry">
-      <div className="mb-1.5 flex items-center gap-2">
-        <span className={cn(styles.ctxBadge, CHIP_CLASS[kind])}>
-          {clientLabel(entry.produced_by_client)}
+      <div className={styles.ctxGrid}>
+        <span className={styles.ctxLead}>
+          <span className={cn(styles.ctxBadge, CHIP_CLASS[kind])}>
+            {clientLabel(entry.produced_by_client)}
+          </span>
         </span>
-        <span className="min-w-0 flex-1 truncate text-[13px] font-medium">
-          {entry.title}
-        </span>
-        <span className="text-muted-foreground shrink-0 font-mono text-[10.5px]">
-          {timeAgo(entry.last_touched_at)}
-        </span>
+        <div className={styles.ctxCol}>
+          <div className={styles.ctxEntryHeader}>
+            <span className={styles.ctxEntryTitle}>{entry.title}</span>
+            <span className={styles.ctxEntryTime}>
+              {timeAgo(entry.last_touched_at)}
+            </span>
+          </div>
+          {entry.summary_markdown && (
+            <p className={styles.ctxEntrySummary}>{entry.summary_markdown}</p>
+          )}
+          {entry.outcome && (
+            <p className={styles.ctxOutcome}>Outcome: {entry.outcome}</p>
+          )}
+        </div>
       </div>
-      {entry.summary_markdown && (
-        <p className="text-muted-foreground text-[13px] leading-relaxed">
-          {entry.summary_markdown}
-        </p>
-      )}
-      {entry.outcome && (
-        <p className={styles.ctxOutcome}>Outcome: {entry.outcome}</p>
-      )}
     </li>
   )
 }

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -45,6 +45,22 @@ export const AGENT_KIND_LABEL: Record<AgentKind, string> = {
   other: "Other",
 }
 
+/** Map a harness client string to the roster chip kind. */
+export function clientKind(value: string | null): AgentKind {
+  if (!value) return "other"
+  const normalized = value.toLowerCase()
+  if (normalized === "claude" || normalized === "claude-code") return "claude"
+  if (normalized === "codex") return "codex"
+  if (normalized === "cursor") return "cursor"
+  return "other"
+}
+
+export function clientLabel(value: string | null): string {
+  if (!value) return "Agent"
+  const kind = clientKind(value)
+  return kind === "other" ? value : AGENT_KIND_LABEL[kind]
+}
+
 /** Defensive against APIs that predate `agent_kind`. */
 export function agentKind(agent: TaskforceFleetAgent): AgentKind {
   const kind = agent.agent_kind


### PR DESCRIPTION
## Summary
- Remove divider dots between fleet row model name and activity/branch text; fix marquee spacing so scrolling and static sublines align consistently
- Apply Claude/Codex/Cursor chip colors in the session context drawer
- Rework drawer layout: wider panel, increased horizontal padding, shared lead/text grid for aligned icons and copy
- Update inject callout copy to describe shared session context

## Test plan
- [x] Fleet row subline spacing verified locally
- [x] Context drawer chip colors, alignment, and width verified locally
- [x] Inject callout copy updated


Made with [Cursor](https://cursor.com)