### PR TITLE
Restore fleet subline dots and marquee fade alignment

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -569,7 +569,7 @@
   white-space: nowrap;
 }
 
-/* second identity line — model, branch, live activity */
+/* second identity line — model · branch · live activity */
 .asub {
   display: flex;
   min-width: 0;
@@ -582,6 +582,11 @@
   white-space: nowrap;
 }
 
+.asep {
+  flex-shrink: 0;
+  color: color-mix(in srgb, var(--fl-faint) 55%, var(--background));
+}
+
 .amodel,
 .abranch {
   flex-shrink: 0;
@@ -592,14 +597,17 @@
   overflow: hidden;
   flex: 1;
   min-width: 0;
+  padding-left: var(--activity-fade, 12px);
   white-space: nowrap;
 }
 
 .aactivityMarquee {
   --activity-fade: 12px;
+  --activity-end-inset: calc(var(--activity-fade) + 4px);
   mask-image: linear-gradient(
     90deg,
-    #000 0,
+    transparent 0,
+    #000 var(--activity-fade),
     #000 calc(100% - var(--activity-fade)),
     transparent 100%
   );
@@ -611,7 +619,7 @@
 }
 
 .aactivityTrackScroll {
-  padding-right: calc(var(--activity-fade, 12px) + 4px);
+  padding-right: var(--activity-end-inset, 16px);
   transition: transform var(--activity-motion-duration, 0.25s) ease-in-out;
 }
 

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -310,9 +310,24 @@ function AgentRow({
             </div>
             <div className={styles.asub} data-testid="fleet-agent-sub">
               <span className={styles.amodel}>{model}</span>
-              {branch && <span className={styles.abranch}>{branch}</span>}
+              {branch && (
+                <>
+                  <span className={styles.asep} aria-hidden="true">
+                    ·
+                  </span>
+                  <span className={styles.abranch}>{branch}</span>
+                </>
+              )}
               {activity && (
-                <ActivityMarquee activity={activity} active={rowHovered} />
+                <>
+                  <span className={styles.asep} aria-hidden="true">
+                    ·
+                  </span>
+                  <ActivityMarquee
+                    activity={activity}
+                    active={rowHovered}
+                  />
+                </>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Restore `·` divider between model name and branch/activity subtitle
- Restore bilateral marquee fade (including left-side blur)
- Fix alignment by moving the left inset to `.aactivity` so scrolling and static activity text start at the same position

## Test plan
- [x] Short activity subtitle aligns with long scrolling subtitle after the divider dot
- [x] Left fade visible on overflowing activity text


Made with [Cursor](https://cursor.com)