### PR TITLE
Fix session context drawer left alignment

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -215,8 +215,9 @@
 /* ----- shared-context drawer body ----- */
 .ctxDrawer {
   --ctx-pad-inline: 26px;
-  --ctx-lead-col: 62px;
+  --ctx-icon-size: 30px;
   --ctx-col-gap: 12px;
+  --ctx-text-inset: calc(var(--ctx-icon-size) + var(--ctx-col-gap));
   width: 100%;
   max-width: min(100vw, 520px);
 }
@@ -239,7 +240,7 @@
 
 .ctxGrid {
   display: grid;
-  grid-template-columns: var(--ctx-lead-col) minmax(0, 1fr);
+  grid-template-columns: var(--ctx-icon-size) minmax(0, 1fr);
   column-gap: var(--ctx-col-gap);
   align-items: start;
 }
@@ -250,7 +251,7 @@
 
 .ctxLead {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   min-width: 0;
 }
 
@@ -330,10 +331,10 @@
   border-bottom: 0;
 }
 
-.ctxEntryHeader {
+.ctxEntryTop {
   display: flex;
   align-items: baseline;
-  gap: 10px;
+  gap: 8px;
 }
 
 .ctxEntryTitle {
@@ -355,8 +356,16 @@
   line-height: 1.35;
 }
 
+.ctxBodyText {
+  margin: 0;
+  padding-left: var(--ctx-text-inset);
+  font-size: calc(13px * var(--v2-scale, 1));
+  line-height: 1.5;
+}
+
 .ctxEntrySummary {
   margin: 8px 0 0;
+  padding-left: var(--ctx-text-inset);
   color: var(--muted-foreground);
   font-size: calc(13px * var(--v2-scale, 1));
   line-height: 1.5;
@@ -365,15 +374,10 @@
 .ctxEmptyText {
   margin: 0;
   color: var(--muted-foreground);
-  font-size: calc(13px * var(--v2-scale, 1));
-  line-height: 1.5;
 }
 
 .ctxErrorText {
-  margin: 0;
   color: var(--destructive);
-  font-size: calc(13px * var(--v2-scale, 1));
-  line-height: 1.5;
 }
 
 .ctxLoading {
@@ -384,6 +388,7 @@
 
 .ctxLoadingRow {
   height: 80px;
+  margin-left: var(--ctx-text-inset);
   border: 1px solid var(--border);
   background: color-mix(in srgb, var(--muted) 20%, transparent);
   animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
@@ -402,7 +407,8 @@
 }
 
 .ctxOutcome {
-  margin-top: 6px;
+  margin: 6px 0 0;
+  padding-left: var(--ctx-text-inset);
   color: var(--primary);
   font-size: calc(12px * var(--v2-scale, 1));
   line-height: 1.45;

--- a/src/components/V2/Fleet/SharedContextDrawer.tsx
+++ b/src/components/V2/Fleet/SharedContextDrawer.tsx
@@ -120,28 +120,20 @@ export function SharedContextDrawer({
           {query.isLoading ? (
             <div className={styles.ctxLoading}>
               {[0, 1, 2].map((item) => (
-                <div key={item} className={styles.ctxGrid}>
-                  <span className={styles.ctxLead} aria-hidden="true" />
-                  <div className={styles.ctxLoadingRow} />
-                </div>
+                <div key={item} className={styles.ctxLoadingRow} />
               ))}
             </div>
           ) : query.error ? (
-            <div className={styles.ctxGrid}>
-              <span className={styles.ctxLead} aria-hidden="true" />
-              <p className={styles.ctxErrorText}>
+            <p className={styles.ctxBodyText}>
+              <span className={styles.ctxErrorText}>
                 Session context could not load.
-              </p>
-            </div>
+              </span>
+            </p>
           ) : entries.length === 0 ? (
-            <div className={styles.ctxGrid}>
-              <span className={styles.ctxLead} aria-hidden="true" />
-              <p className={styles.ctxEmptyText}>
-                No session context yet. As this group's agents capture work,
-                their documents appear here and are injected into each agent's
-                turn.
-              </p>
-            </div>
+            <p className={cn(styles.ctxBodyText, styles.ctxEmptyText)}>
+              No session context yet. As this group's agents capture work, their
+              documents appear here and are injected into each agent's turn.
+            </p>
           ) : (
             <ul className={styles.ctxList}>
               {entries.map((entry) => (
@@ -159,27 +151,21 @@ function ContextEntry({ entry }: { entry: TaskforceSessionContextEntry }) {
   const kind = clientKind(entry.produced_by_client)
   return (
     <li className={styles.ctxEntry} data-testid="fleet-context-entry">
-      <div className={styles.ctxGrid}>
-        <span className={styles.ctxLead}>
-          <span className={cn(styles.ctxBadge, CHIP_CLASS[kind])}>
-            {clientLabel(entry.produced_by_client)}
-          </span>
+      <div className={styles.ctxEntryTop}>
+        <span className={cn(styles.ctxBadge, CHIP_CLASS[kind])}>
+          {clientLabel(entry.produced_by_client)}
         </span>
-        <div className={styles.ctxCol}>
-          <div className={styles.ctxEntryHeader}>
-            <span className={styles.ctxEntryTitle}>{entry.title}</span>
-            <span className={styles.ctxEntryTime}>
-              {timeAgo(entry.last_touched_at)}
-            </span>
-          </div>
-          {entry.summary_markdown && (
-            <p className={styles.ctxEntrySummary}>{entry.summary_markdown}</p>
-          )}
-          {entry.outcome && (
-            <p className={styles.ctxOutcome}>Outcome: {entry.outcome}</p>
-          )}
-        </div>
+        <span className={styles.ctxEntryTitle}>{entry.title}</span>
+        <span className={styles.ctxEntryTime}>
+          {timeAgo(entry.last_touched_at)}
+        </span>
       </div>
+      {entry.summary_markdown && (
+        <p className={styles.ctxEntrySummary}>{entry.summary_markdown}</p>
+      )}
+      {entry.outcome && (
+        <p className={styles.ctxOutcome}>Outcome: {entry.outcome}</p>
+      )}
     </li>
   )
 }


### PR DESCRIPTION
## Summary
- Shrink the header icon column to 30px and left-align icons (no longer centered in a 62px chip-width column)
- Entry chips sit inline before titles; summaries, outcomes, and empty states align with the header text column
- Body copy no longer indents to the right of agent badges

## Test plan
- [x] Header icons vertically aligned on the left
- [x] Entry title row shows chip + title inline
- [x] Summary and outcome text aligns with Session context / inject copy


Made with [Cursor](https://cursor.com)