### PR TITLE
Rename fleet running status to Agent running

### DIFF
--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -21,7 +21,7 @@ export const STATE_LABEL: Record<FleetStatus, string> = {
 
 /** One-line roster status in the agent row's second column. */
 export const ROSTER_STATUS_LABEL: Record<FleetStatus, string> = {
-  run: "Agent responding",
+  run: "Agent running",
   waiting: "Agent waiting",
   paused: "Capture paused",
   idle: "Agent idle",

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -332,7 +332,7 @@ test("Fleet renders the calm roster from live API data", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Sessions" })).toBeVisible()
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
   await expect(page.getByTestId("fleet-agent-status")).toHaveText(
-    "Agent responding",
+    "Agent running",
   )
   await expect(page.getByText("10m")).toBeVisible()
   // Calm summary line — fleets, agents, running; no spend/token metrics.
@@ -497,7 +497,7 @@ test("roster shows agent status when summary is empty", async ({ page }) => {
 
   const row = page.getByTestId("fleet-agent-row")
   await expect(row.getByTestId("fleet-agent-status")).toHaveText(
-    "Agent responding",
+    "Agent running",
   )
   await expect(row.getByText("No current work captured yet")).toHaveCount(0)
 


### PR DESCRIPTION
## Summary
- Change roster status label from "Agent responding" to "Agent running"
- Update fleet e2e tests to match

## Test plan
- [x] Updated fleet.spec.ts assertions


Made with [Cursor](https://cursor.com)