### PR TITLE
Fix fleet agent detail rail formatting

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -811,13 +811,13 @@
 
 .dmain {
   overflow-y: auto;
-  padding: 30px 0 0;
+  padding: 30px 28px 0 0;
   min-height: 0;
 }
 
 .drail {
   overflow-y: auto;
-  padding: 30px 0 0;
+  padding: 30px 0 0 22px;
   border-left: 1px solid var(--fl-hair);
   min-height: 0;
 }
@@ -1105,27 +1105,15 @@
 }
 
 .ctxitem {
-  display: flex;
-  align-items: center;
-  gap: 9px;
   padding: 7px 0;
   border-bottom: 1px solid var(--fl-hair);
   color: var(--muted-foreground);
   font-size: calc(12.5px * var(--v2-scale, 1));
+  line-height: 1.45;
 }
 
 .ctxitem:last-child {
   border-bottom: 0;
-}
-
-.ctxitem::before {
-  width: 3px;
-  height: 3px;
-  flex-shrink: 0;
-  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten list bullets. */
-  border-radius: 999px !important;
-  background: var(--fl-faint);
-  content: "";
 }
 
 /* agent profile card */
@@ -1271,7 +1259,7 @@
   .drail {
     overflow: visible;
     border-left: 0;
-    padding-bottom: 0;
+    padding: 24px 0 0;
   }
 
   .drail {


### PR DESCRIPTION
## Summary
- Restore left padding in the session-agent detail rail so meta rows are not flush against the divider
- Add right padding on the main column for column spacing
- Remove bullet pseudo-elements on context-in-use items that staggered text past section labels

## Test plan
- [x] Detail rail labels and values left-aligned within the rail column
- [x] Context in use items align with Session meta rows


Made with [Cursor](https://cursor.com)