### PR TITLE
feat(fleet): "Make default" action + (default) badge for session groups

### DIFF
--- a/src/api/v2Taskforce.ts
+++ b/src/api/v2Taskforce.ts
@@ -66,6 +66,7 @@ export interface TaskforceFleetSession {
   id: string
   name: string
   is_history: boolean
+  is_default: boolean
   created_at: string
   updated_at: string
   agents: TaskforceFleetAgent[]
@@ -186,6 +187,20 @@ export function updateTaskforceFleetSession(
       fleet_session_id: fleetSessionId,
     },
     body: { name },
+  })
+}
+
+/** Mark a session group as the default that new agents join. */
+export function setDefaultTaskforceFleetSession(
+  fleetSessionId: string,
+): CancelablePromise<TaskforceFleetSession> {
+  return request(OpenAPI, {
+    method: "PATCH",
+    url: "/api/v1/v2/taskforce/fleet/{fleet_session_id}",
+    path: {
+      fleet_session_id: fleetSessionId,
+    },
+    body: { is_default: true },
   })
 }
 

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -135,6 +135,14 @@
   white-space: nowrap;
 }
 
+.fdefault {
+  flex-shrink: 0;
+  color: var(--fl-faint);
+  font-size: calc(11px * var(--v2-scale, 1));
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
 .fnameButton {
   text-align: left;
 }

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -7,6 +7,7 @@ import {
   MoreHorizontal,
   Pencil,
   Plus,
+  Star,
   Trash2,
 } from "lucide-react"
 import {
@@ -24,6 +25,7 @@ import {
   deleteTaskforceFleetSession,
   readTaskforceFleet,
   renameTaskforceSession,
+  setDefaultTaskforceFleetSession,
   type TaskforceFleetAgent,
   type TaskforceFleetResponse,
   type TaskforceFleetSession,
@@ -427,6 +429,7 @@ function FleetCard({
   onRenameAgent,
   onRename,
   onDelete,
+  onSetDefault,
   draggingAgent,
   dropTargetId,
   movingSessionId,
@@ -442,6 +445,7 @@ function FleetCard({
   onRenameAgent: (agent: TaskforceFleetAgent, displayName: string) => void
   onRename: (fleet: TaskforceFleetSession, name: string) => void
   onDelete: (fleet: TaskforceFleetSession) => void
+  onSetDefault: (fleet: TaskforceFleetSession) => void
   draggingAgent: TaskforceFleetAgent | null
   dropTargetId: string | null
   movingSessionId: string | null
@@ -536,6 +540,9 @@ function FleetCard({
             )}
             <span className={styles.fheadIdentity}>
               <span className={styles.fname}>{fleetTitle(fleet)}</span>
+              {fleet.is_default && !isHistory && (
+                <span className={styles.fdefault}>(default)</span>
+              )}
             </span>
           </button>
         )}
@@ -570,6 +577,12 @@ function FleetCard({
                     <Pencil />
                     Rename
                   </DropdownMenuItem>
+                  {!fleet.is_default && (
+                    <DropdownMenuItem onSelect={() => onSetDefault(fleet)}>
+                      <Star />
+                      Make default
+                    </DropdownMenuItem>
+                  )}
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
                     variant="destructive"
@@ -674,6 +687,15 @@ export function FleetPage() {
     onSuccess: refreshFleet,
     onError: setMutationError,
   })
+  const setDefaultMutation = useMutation({
+    mutationFn: (fleet: TaskforceFleetSession) =>
+      setDefaultTaskforceFleetSession(fleet.id),
+    onSuccess: () => {
+      setMutationError(null)
+      refreshFleet()
+    },
+    onError: setMutationError,
+  })
   const moveMutation = useMutation({
     mutationFn: ({
       sessionId,
@@ -762,6 +784,10 @@ export function FleetPage() {
       setMutationError(null)
       deleteMutation.mutate(fleet.id)
     }
+  }
+  const setDefaultFleet = (fleet: TaskforceFleetSession) => {
+    setMutationError(null)
+    setDefaultMutation.mutate(fleet)
   }
   const endAgentDrag = () => {
     setDraggingAgent(null)
@@ -892,6 +918,7 @@ export function FleetPage() {
                   onRenameAgent={renameAgent}
                   onRename={renameFleet}
                   onDelete={deleteFleet}
+                  onSetDefault={setDefaultFleet}
                   draggingAgent={draggingAgent}
                   dropTargetId={dropTargetId}
                   movingSessionId={


### PR DESCRIPTION
## What

Lets users pick which session group new agents join. Adds a **"Make default"** dropdown action and a `(default)` badge on the chosen group.

Pairs with backend PR **al-exe/EnderAI#175** (adds the `is_default` flag + `PATCH /fleet/{id}` support).

## Changes
- `is_default` on the `TaskforceFleetSession` type; new `setDefaultTaskforceFleetSession()` API call.
- `FleetPage`: "Make default" `DropdownMenuItem` (hidden for the current default and the Archive group), wired to a mutation that invalidates the fleet query.
- `(default)` badge rendered next to the default group's title.

## Behavior
- Exactly one default at a time (enforced server-side). A lone session is always marked default.

## Validation
- `tsc -p tsconfig.build.json --noEmit` clean; biome clean on changed files. Rebased on latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)