### PR TITLE
Fix session context inject token formatting

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -266,6 +266,11 @@
   line-height: 1.45;
 }
 
+.ctxInjectText > span {
+  min-width: 0;
+  flex: 1;
+}
+
 .ctxInjectIcon {
   width: 15px;
   height: 15px;

--- a/src/components/V2/Fleet/SharedContextDrawer.tsx
+++ b/src/components/V2/Fleet/SharedContextDrawer.tsx
@@ -80,12 +80,14 @@ export function SharedContextDrawer({
           </p>
           <p className={styles.ctxInjectText}>
             <Zap aria-hidden="true" className={styles.ctxInjectIcon} />
-            Shared context between all agents in this session. Automatically
-            injected into each agent, up to{" "}
-            <b>
-              {(data?.inject_token_budget ?? 2000).toLocaleString()} tokens
-            </b>
-            .
+            <span>
+              Shared context between all agents in this session. Automatically
+              injected into each agent, up to{" "}
+              <b>
+                {(data?.inject_token_budget ?? 2000).toLocaleString()} tokens
+              </b>
+              .
+            </span>
           </p>
           {data && (
             <div className={styles.ctxMeta}>


### PR DESCRIPTION
## Summary
- Wrap inject callout prose in a single span so flex layout does not treat the bold token count as a separate right-aligned item

## Test plan
- [x] "up to 2,000 tokens." flows as normal inline text after the icon


Made with [Cursor](https://cursor.com)