### PR TITLE
Fix fleet agent detail continuous scroll

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -307,12 +307,37 @@
 }
 
 .ctxEntry {
-  padding: 14px 0;
   border-bottom: 1px solid var(--fl-hair);
 }
 
 .ctxEntry:last-child {
   border-bottom: 0;
+}
+
+.ctxEntryLink {
+  display: block;
+  margin-inline: calc(-1 * var(--ctx-pad-inline));
+  padding: 14px var(--ctx-pad-inline);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.ctxEntryLink:hover {
+  background: var(--fl-primary-soft);
+}
+
+.ctxEntryLink:hover .ctxEntryTitle {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.ctxEntryLink:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
 }
 
 .ctxEntryTop {
@@ -709,9 +734,7 @@
    ============================================================ */
 .detail {
   display: flex;
-  flex: 1;
   flex-direction: column;
-  min-height: 0;
 }
 
 .dtop {
@@ -817,22 +840,18 @@
 
 .dbody {
   display: grid;
-  flex: 1;
   grid-template-columns: minmax(0, 1fr) 286px;
-  min-height: 0;
 }
 
 .dmain {
-  overflow-y: auto;
-  padding: 30px 28px 0 0;
-  min-height: 0;
+  overflow: visible;
+  padding: 30px 28px 24px 0;
 }
 
 .drail {
-  overflow-y: auto;
-  padding: 30px 0 0 22px;
+  overflow: visible;
+  padding: 30px 0 24px 22px;
   border-left: 1px solid var(--fl-hair);
-  min-height: 0;
 }
 
 .seclabel {
@@ -1285,22 +1304,16 @@
 
 /* ===== responsive ===== */
 @media (max-width: 880px) {
-  .detail {
-    overflow-y: auto;
-  }
-
   .dbody {
     display: block;
-    flex: none;
     grid-template-columns: 1fr;
-    min-height: auto;
   }
 
   .dmain,
   .drail {
     overflow: visible;
     border-left: 0;
-    padding: 24px 0 0;
+    padding: 24px 0;
   }
 
   .drail {
@@ -1368,7 +1381,7 @@
 
   .dmain,
   .drail {
-    padding: 24px 0 0;
+    padding: 24px 0;
   }
 
   .dactions {

--- a/src/components/V2/Fleet/SharedContextDrawer.tsx
+++ b/src/components/V2/Fleet/SharedContextDrawer.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
 import { FileText, Zap } from "lucide-react"
 import { type ReactNode, useState } from "react"
 import {
@@ -169,21 +170,29 @@ function ContextEntry({ entry }: { entry: TaskforceSessionContextEntry }) {
   const kind = clientKind(entry.produced_by_client)
   return (
     <li className={styles.ctxEntry} data-testid="fleet-context-entry">
-      <div className={styles.ctxEntryTop}>
-        <span className={cn(styles.ctxBadge, CHIP_CLASS[kind])}>
-          {clientLabel(entry.produced_by_client)}
-        </span>
-        <span className={styles.ctxEntryTitle}>{entry.title}</span>
-        <span className={styles.ctxEntryTime}>
-          {timeAgo(entry.last_touched_at)}
-        </span>
-      </div>
-      {entry.summary_markdown && (
-        <p className={styles.ctxEntrySummary}>{entry.summary_markdown}</p>
-      )}
-      {entry.outcome && (
-        <p className={styles.ctxOutcome}>Outcome: {entry.outcome}</p>
-      )}
+      <Link
+        to="/v2/library/$documentId"
+        params={{ documentId: entry.document_id }}
+        className={styles.ctxEntryLink}
+        title={`Open "${entry.title}" in Library`}
+        aria-label={`Open ${entry.title} in Library`}
+      >
+        <div className={styles.ctxEntryTop}>
+          <span className={cn(styles.ctxBadge, CHIP_CLASS[kind])}>
+            {clientLabel(entry.produced_by_client)}
+          </span>
+          <span className={styles.ctxEntryTitle}>{entry.title}</span>
+          <span className={styles.ctxEntryTime}>
+            {timeAgo(entry.last_touched_at)}
+          </span>
+        </div>
+        {entry.summary_markdown && (
+          <p className={styles.ctxEntrySummary}>{entry.summary_markdown}</p>
+        )}
+        {entry.outcome && (
+          <p className={styles.ctxOutcome}>Outcome: {entry.outcome}</p>
+        )}
+      </Link>
     </li>
   )
 }

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -233,7 +233,7 @@ function FleetAgentDetailRoute() {
       )}
     >
       <div
-        className={cn(V2_PAGE_BODY, styles.detail, "gap-0 pb-0")}
+        className={cn(V2_PAGE_BODY, styles.detail, "gap-0 pb-6 md:pb-8")}
         data-testid="fleet-agent-detail"
         ref={setPulseRoot}
       >
@@ -307,7 +307,7 @@ function FleetAgentDetailRoute() {
           className={cn(styles.dbody, V2_TAB_CONTENT_CLASS, "pt-0")}
           data-testid="fleet-detail-body"
         >
-        <div className={styles.dmain}>
+        <div className={styles.dmain} data-testid="fleet-detail-main">
           {/* Currently working on — waiting agents surface a question when present. */}
           {status === "waiting" ? (
             question ? (

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -734,6 +734,12 @@ for (const theme of ["light", "dark"] as const) {
             document.documentElement.scrollWidth -
             document.documentElement.clientWidth,
           detailOverflowY: getComputedStyle(detail).overflowY,
+          mainOverflowY: getComputedStyle(
+            document.querySelector<HTMLElement>(
+              '[data-testid="fleet-detail-main"]',
+            )!,
+          ).overflowY,
+          railOverflowY: getComputedStyle(rail).overflowY,
           bodyDisplay: getComputedStyle(body).display,
           railBorderTop: getComputedStyle(rail).borderTopWidth,
           railBorderLeft: getComputedStyle(rail).borderLeftWidth,
@@ -741,8 +747,10 @@ for (const theme of ["light", "dark"] as const) {
       })
 
       expect(detailLayout.overflow).toBeLessThanOrEqual(0)
+      expect(detailLayout.detailOverflowY).toBe("visible")
+      expect(detailLayout.mainOverflowY).toBe("visible")
+      expect(detailLayout.railOverflowY).toBe("visible")
       if (width <= 880) {
-        expect(detailLayout.detailOverflowY).toBe("auto")
         expect(detailLayout.bodyDisplay).toBe("block")
         expect(detailLayout.railBorderTop).toBe("1px")
         expect(detailLayout.railBorderLeft).toBe("0px")


### PR DESCRIPTION
## Summary
- Remove nested scroll containers on the fleet session-agent detail page so `V2_PAGE_FRAME` is the sole scroll surface and activity/rail content scroll continuously without dead viewport space at the bottom.
- Restore bottom padding on the detail body and main/rail columns for a clean scroll end.
- Link session context drawer entries to their Library documents with hover/focus styling.
- Update fleet responsive tests to assert visible overflow on detail/main/rail instead of nested `auto` scrolling.

## Test plan
- [x] Updated `tests/fleet.spec.ts` layout assertions for session detail overflow behavior
- [ ] Open `/v2/fleet/{sessionId}` and scroll from Activity through the right rail — no blank gap or scroll handoff break
- [ ] Open Session context drawer and confirm entries navigate to Library documents

Made with [Cursor](https://cursor.com)