### PR TITLE
Fix fleet Cursor capture formatting and session header styling

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -75,9 +75,10 @@
   gap: var(--fl-row-gap);
   align-items: center;
   box-sizing: border-box;
-  height: 48px;
-  padding: 10px 18px;
+  height: 54px;
+  padding: 13px 18px;
   border-bottom: 1px solid var(--fl-hair);
+  background: color-mix(in srgb, var(--fl-surface) 68%, var(--background));
 }
 
 .fleetCollapsed .fhead {
@@ -1008,6 +1009,10 @@
 }
 
 .tt {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
   color: var(--fl-faint);
   font-family: var(--font-mono);
   font-size: calc(10.5px * var(--v2-scale, 1));
@@ -1015,7 +1020,6 @@
 }
 
 .tkind {
-  margin-left: 8px;
   color: var(--muted-foreground);
   text-transform: uppercase;
 }
@@ -1339,7 +1343,7 @@
 
   .fhead {
     height: auto;
-    min-height: 48px;
+    min-height: 54px;
     grid-template-rows: auto auto;
   }
 

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -174,24 +174,53 @@ export function formatClockTime(iso: string): string {
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
 }
 
+const USER_QUERY_RE = /^<user_query>\s*|\s*<\/user_query>\s*$/gim
+
 const FLEET_UI_MARKERS = [
   "View in Ledger",
   "Awaiting user prompt",
   "Running in this terminal",
+  "Activity capture is paused",
+  "Currently working on",
+  "Previously worked on",
+  "Activity",
 ]
+
+const ACTIVITY_LINE_RE =
+  /^(?:\d{1,2}:\d{2}\s*(?:AM|PM))?(?:prompt|command|reply|edit|note)?$/i
+
+function looksLikeActivityScrape(line: string): boolean {
+  const lowered = line.toLowerCase()
+  if (ACTIVITY_LINE_RE.test(line)) return true
+  if (lowered.endsWith("prompt") && line.length <= 24) return true
+  if (lowered.startsWith("$ ") || lowered.startsWith("pmcommand")) return true
+  if (lowered.startsWith("ran: ")) return true
+  return false
+}
+
+function stripCursorDiagnosticTail(text: string): string {
+  const ranIdx = text.search(/\sRan:\s/)
+  if (ranIdx >= 0) return text.slice(0, ranIdx).trim()
+  return text
+}
 
 /** Strip Cursor wrappers and Fleet UI paste noise for activity display. */
 export function cleanActivityPromptText(
   text: string | null | undefined,
 ): string {
   if (!text) return ""
-  const cleaned = text
-    .replace(/^<user_query>\s*/i, "")
-    .replace(/\s*<\/user_query>\s*$/i, "")
-    .trim()
+
+  const innerMatch = text.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/i)
+  const working = innerMatch ? innerMatch[1] : text
+
+  let cleaned = working.replace(USER_QUERY_RE, "").trim()
+  cleaned = stripCursorDiagnosticTail(cleaned)
+  if (!cleaned) return ""
+
   if (!FLEET_UI_MARKERS.some((marker) => cleaned.includes(marker))) {
     return cleaned
   }
+
   const blocks = cleaned
     .split(/\n\s*\n/)
     .map((block) => block.trim())
@@ -200,10 +229,25 @@ export function cleanActivityPromptText(
   if (
     tail &&
     tail.length <= 400 &&
-    !FLEET_UI_MARKERS.some((marker) => tail.includes(marker))
+    !FLEET_UI_MARKERS.some((marker) => tail.includes(marker)) &&
+    !looksLikeActivityScrape(tail)
   ) {
     return tail
   }
+
+  const lines = cleaned.split(/\r?\n/)
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const candidate = lines[index]?.trim() ?? ""
+    if (
+      !candidate ||
+      FLEET_UI_MARKERS.some((marker) => candidate.includes(marker))
+    ) {
+      continue
+    }
+    if (looksLikeActivityScrape(candidate)) continue
+    return candidate
+  }
+
   return cleaned
 }
 
@@ -223,7 +267,7 @@ export function liveActivityLabel(
   options: LiveActivityOptions = {},
 ): string {
   const status = agentStatus(agent)
-  const summary = agent.summary_markdown?.trim()
+  const summary = cleanActivityPromptText(agent.summary_markdown?.trim())
 
   if (status === "run") {
     return summary || "Running in this terminal"
@@ -260,16 +304,17 @@ function truncateLine(text: string, max = 120): string {
    to the captured work summary when no per-turn prompts are recorded yet. */
 export function agentActivityLine(agent: TaskforceFleetAgent): string {
   const recent = agentRecentActivity(agent)
-  const summary = agent.summary_markdown?.trim()
+  const summary = cleanActivityPromptText(agent.summary_markdown?.trim())
   const pick = isRunning(agent)
     ? (recent[1] ?? summary ?? recent[0])
     : (recent[0] ?? summary)
-  return pick ? truncateLine(pick) : ""
+  const cleaned = pick ? cleanActivityPromptText(pick) : ""
+  return cleaned ? truncateLine(cleaned) : ""
 }
 
 /** Session detail "Currently working on" body. */
 export function sessionWorkSummary(agent: TaskforceFleetAgent): string {
-  const summary = agent.summary_markdown?.trim()
+  const summary = cleanActivityPromptText(agent.summary_markdown?.trim())
   const status = agentStatus(agent)
 
   if (status === "run") {
@@ -293,7 +338,7 @@ export function sessionWorkSummary(agent: TaskforceFleetAgent): string {
 export function sessionPreviousWork(agent: TaskforceFleetAgent): string {
   if (agentStatus(agent) !== "run") return ""
   // recent[0] is the in-progress turn; recent[1] is what happened before it.
-  return agentRecentActivity(agent)[1] ?? ""
+  return cleanActivityPromptText(agentRecentActivity(agent)[1] ?? "")
 }
 
 /** Locale-aware date and time in the browser's local timezone. */

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -554,6 +554,30 @@ test("collapsed fleet cards share header height", async ({ page }) => {
   expect(Math.abs(historyHeight - workHeight)).toBeLessThan(2)
 })
 
+test("session detail strips Cursor capture noise from working-on text", async ({
+  page,
+}) => {
+  await mockFleet(page, {
+    agentOverrides: {
+      summary_markdown:
+        "<user_query> merge </user_query> Ran: cd /home/alexlee/dev && git status",
+      recent_activity: [
+        "<user_query> merge </user_query> Ran: cd /home/alexlee/dev && git status",
+        "Prior tax wiring",
+      ],
+    },
+  })
+  await page.goto("/v2/fleet/session-1")
+
+  const workingOn = page
+    .getByText("Currently working on")
+    .locator("xpath=following-sibling::*[1]")
+  await expect(workingOn).toContainText("merge")
+  await expect(workingOn).not.toContainText("Ran:")
+  await expect(page.getByText("Prior tax wiring")).toBeVisible()
+  await expect(page.getByText(/<user_query>/)).toHaveCount(0)
+})
+
 test("activity timeline live head shows waiting state", async ({ page }) => {
   await mockFleet(page, {
     agentOverrides: {


### PR DESCRIPTION
## Summary
- Harden `cleanActivityPromptText` to mirror backend Cursor prompt normalization: extract `<user_query>` bodies, drop `Ran:` diagnostic tails, ignore Sessions UI scrape lines, and recover the last meaningful user line from pasted activity blobs.
- Apply cleaning to "Currently working on", "Previously worked on", live activity head, and roster sub-lines so captured Cursor text no longer shows raw tags or shell dumps.
- Fix activity timeline timestamp/kind layout with flex gap so labels like `prompt`/`reply` no longer run into clock times.
- Darken and slightly increase height of session group headers for clearer separation from agent rows.

## Test plan
- [x] Added Playwright coverage for stripped Cursor capture noise on session detail
- [x] Existing fleet responsive/layout tests unchanged except new cleaning assertion
- [ ] Open a live Cursor session detail and confirm working-on/activity text shows the user prompt only
- [ ] Confirm session headers read darker/taller than agent rows

Made with [Cursor](https://cursor.com)