### PR TITLE
Full-block hover on session context entries

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -321,24 +321,26 @@
   padding: 14px var(--ctx-pad-inline);
   color: inherit;
   text-decoration: none;
+  cursor: pointer;
   transition:
-    background-color 0.12s ease,
-    color 0.12s ease;
+    background-color 120ms ease,
+    box-shadow 120ms ease;
 }
 
-.ctxEntryLink:hover {
-  background: var(--fl-primary-soft);
+.ctxEntryLink:hover,
+.ctxEntryLink:focus-visible {
+  background: var(--fl-primary-softer);
+  box-shadow: inset 0 0 0 1px var(--fl-primary-line-soft);
 }
 
-.ctxEntryLink:hover .ctxEntryTitle {
+.ctxEntryLink:hover .ctxEntryTitle,
+.ctxEntryLink:focus-visible .ctxEntryTitle {
   color: var(--primary);
-  text-decoration: underline;
-  text-underline-offset: 3px;
+  text-decoration: none;
 }
 
 .ctxEntryLink:focus-visible {
-  outline: 2px solid var(--primary);
-  outline-offset: -2px;
+  outline: none;
 }
 
 .ctxEntryTop {


### PR DESCRIPTION
## Summary
- Apply fleet session drop-target hover styling to the entire context drawer entry (title, summary, outcome)
- Remove title-only underline; the whole row is the click/hover target

## Test plan
- [x] Hover anywhere on a context entry body highlights the full block


Made with [Cursor](https://cursor.com)