### PR TITLE
Add archive agent row action

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -435,7 +435,10 @@
   gap: var(--fl-row-gap);
   align-items: center;
   width: 100%;
+  min-inline-size: 0;
+  margin: 0;
   padding: 12px 18px;
+  border: 0;
   border-bottom: 1px solid var(--fl-hair);
   text-align: left;
   cursor: pointer;

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
 import {
+  Archive,
   ChevronDown,
   ChevronRight,
   GripVertical,
@@ -213,7 +214,10 @@ function ActivityMarquee({
     >
       <span
         ref={trackRef}
-        className={cn(styles.aactivityTrack, scrolls && styles.aactivityTrackScroll)}
+        className={cn(
+          styles.aactivityTrack,
+          scrolls && styles.aactivityTrackScroll,
+        )}
         style={trackStyle}
       >
         {activity}
@@ -226,22 +230,26 @@ function AgentRow({
   agent,
   onOpen,
   onRename,
+  onArchive,
   onDragStart,
   onDragEnd,
   isDragging,
   isMoving,
+  canArchive,
   draggable = true,
 }: {
   agent: TaskforceFleetAgent
   onOpen: (agent: TaskforceFleetAgent) => void
   onRename: (agent: TaskforceFleetAgent, displayName: string) => void
+  onArchive: (agent: TaskforceFleetAgent) => void
   onDragStart: (
     agent: TaskforceFleetAgent,
-    event: DragEvent<HTMLDivElement>,
+    event: DragEvent<HTMLElement>,
   ) => void
   onDragEnd: () => void
   isDragging: boolean
   isMoving: boolean
+  canArchive: boolean
   draggable?: boolean
 }) {
   const suppressClick = useRef(false)
@@ -268,7 +276,8 @@ function AgentRow({
   }
 
   return (
-    <div
+    <fieldset
+      aria-label={`${sessionLabel} session row`}
       data-testid="fleet-agent-row"
       className={cn(
         styles.arow,
@@ -325,10 +334,7 @@ function AgentRow({
                   <span className={styles.asep} aria-hidden="true">
                     ·
                   </span>
-                  <ActivityMarquee
-                    activity={activity}
-                    active={rowHovered}
-                  />
+                  <ActivityMarquee activity={activity} active={rowHovered} />
                 </>
               )}
             </div>
@@ -367,6 +373,15 @@ function AgentRow({
             <Pencil />
             Rename
           </DropdownMenuItem>
+          {canArchive && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={() => onArchive(agent)}>
+                <Archive />
+                Archive agent
+              </DropdownMenuItem>
+            </>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -417,7 +432,7 @@ function AgentRow({
           </form>
         </DialogContent>
       </Dialog>
-    </div>
+    </fieldset>
   )
 }
 
@@ -427,6 +442,8 @@ function FleetCard({
   onToggleCollapse,
   onOpenAgent,
   onRenameAgent,
+  onArchiveAgent,
+  canArchiveAgents,
   onRename,
   onDelete,
   onSetDefault,
@@ -443,6 +460,8 @@ function FleetCard({
   onToggleCollapse: () => void
   onOpenAgent: (agent: TaskforceFleetAgent) => void
   onRenameAgent: (agent: TaskforceFleetAgent, displayName: string) => void
+  onArchiveAgent: (agent: TaskforceFleetAgent) => void
+  canArchiveAgents: boolean
   onRename: (fleet: TaskforceFleetSession, name: string) => void
   onDelete: (fleet: TaskforceFleetSession) => void
   onSetDefault: (fleet: TaskforceFleetSession) => void
@@ -451,7 +470,7 @@ function FleetCard({
   movingSessionId: string | null
   onAgentDragStart: (
     agent: TaskforceFleetAgent,
-    event: DragEvent<HTMLDivElement>,
+    event: DragEvent<HTMLElement>,
   ) => void
   onAgentDragEnd: () => void
   onDragOver: (fleetSessionId: string) => void
@@ -613,10 +632,12 @@ function FleetCard({
                 agent={agent}
                 onOpen={onOpenAgent}
                 onRename={onRenameAgent}
+                onArchive={onArchiveAgent}
                 onDragStart={onAgentDragStart}
                 onDragEnd={onAgentDragEnd}
                 isDragging={draggingAgent?.session_id === agent.session_id}
                 isMoving={movingSessionId === agent.session_id}
+                canArchive={!isHistory && canArchiveAgents}
                 draggable
               />
             ))
@@ -751,6 +772,7 @@ export function FleetPage() {
 
   const fleetSessions = fleetQuery.data?.fleet_sessions ?? []
   const workFleets = fleetSessions.filter((fleet) => !fleet.is_history)
+  const historyFleet = fleetSessions.find((fleet) => fleet.is_history)
   const allAgents = fleetSessions.flatMap((fleet) => fleet.agents)
   const activeAgents = workFleets.flatMap((fleet) => fleet.agents)
   const running = runningCount(activeAgents)
@@ -805,6 +827,10 @@ export function FleetPage() {
       sessionId: agent.session_id,
       destinationId: destination.id,
     })
+  }
+  const archiveAgent = (agent: TaskforceFleetAgent) => {
+    if (!historyFleet) return
+    moveAgent(agent, historyFleet)
   }
   const toggleFleetCollapsed = useCallback(
     (fleet: TaskforceFleetSession) => {
@@ -916,6 +942,8 @@ export function FleetPage() {
                   onToggleCollapse={() => toggleFleetCollapsed(fleet)}
                   onOpenAgent={openAgent}
                   onRenameAgent={renameAgent}
+                  onArchiveAgent={archiveAgent}
+                  canArchiveAgents={Boolean(historyFleet)}
                   onRename={renameFleet}
                   onDelete={deleteFleet}
                   onSetDefault={setDefaultFleet}

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -112,6 +112,9 @@ async function mockFleet(
             created_at: "2026-06-12T09:00:00Z",
             updated_at: "2026-06-12T09:00:00Z",
             agents: [
+              ...(agentFleetId === "fleet-history"
+                ? [{ ...agent, fleet_session_id: agentFleetId }]
+                : []),
               {
                 ...agent,
                 session_id: "session-history",
@@ -257,7 +260,8 @@ async function mockFleet(
     const documents: Record<string, { id: string; title: string }> = {
       "doc-1": {
         id: "doc-1",
-        title: "User requested feature: new agents should auto-join a designated 'Default' session",
+        title:
+          "User requested feature: new agents should auto-join a designated 'Default' session",
       },
       "doc-2": {
         id: "doc-2",
@@ -358,11 +362,12 @@ test("Fleet renders the calm roster from live API data", async ({ page }) => {
 
   const historyCard = page.getByTestId("fleet-card-fleet-history")
   await expect(historyCard.getByText("History", { exact: true })).toBeVisible()
-  await expect(historyCard.getByText("EnderAI-new-user-max-promo")).toHaveCount(0)
+  await expect(historyCard.getByText("EnderAI-new-user-max-promo")).toHaveCount(
+    0,
+  )
   await expect(
     historyCard.getByText(/feature\/new-user-max-promo/),
   ).toHaveCount(0)
-  await expect(page.getByTestId("fleet-card-fleet-1")).toContainText("billing")
   await expect(page.getByTestId("fleet-card-fleet-1")).toContainText(
     "feature/automatic-tax",
   )
@@ -434,6 +439,36 @@ test("agent session can be renamed from the row menu", async ({ page }) => {
     display_name: "Checkout tax rollout",
   })
   await expect(page.getByText("Checkout tax rollout")).toBeVisible()
+})
+
+test("agent session can be archived from the row menu", async ({ page }) => {
+  await mockFleet(page)
+  await page.goto("/v2/fleet")
+
+  await page
+    .getByRole("button", {
+      name: "Wiring automatic tax on Stripe checkout actions",
+    })
+    .click()
+  const archiveRequest = page.waitForRequest(
+    (request) =>
+      request.url().endsWith("/api/v1/v2/taskforce/session/session-1") &&
+      request.method() === "PATCH",
+  )
+  await page.getByRole("menuitem", { name: "Archive agent" }).click()
+
+  expect((await archiveRequest).postDataJSON()).toEqual({
+    fleet_session_id: "fleet-history",
+  })
+  await expect(page.getByTestId("fleet-card-fleet-1")).not.toContainText(
+    "Wiring automatic tax on Stripe checkout",
+  )
+
+  const historyCard = page.getByTestId("fleet-card-fleet-history")
+  await historyCard.getByRole("button", { name: /History/ }).click()
+  await expect(historyCard).toContainText(
+    "Wiring automatic tax on Stripe checkout",
+  )
 })
 
 test("activity timeline shows the full canonical event stream and exact Ledger links", async ({
@@ -541,9 +576,12 @@ test("collapsed fleet cards share header height", async ({ page }) => {
   )
 
   const headerHeight = (card: ReturnType<Page["getByTestId"]>) =>
-    card.locator(":scope > div").first().evaluate((el) => {
-      return el.getBoundingClientRect().height
-    })
+    card
+      .locator(":scope > div")
+      .first()
+      .evaluate((el) => {
+        return el.getBoundingClientRect().height
+      })
 
   const historyCard = page.getByTestId("fleet-card-fleet-history")
   const workCard = page.getByTestId("fleet-card-fleet-1")
@@ -590,9 +628,7 @@ test("activity timeline live head shows waiting state", async ({ page }) => {
 
   await expect(page.getByText("now", { exact: true })).toBeVisible()
   await expect(page.getByText("Awaiting user prompt")).toBeVisible()
-  await expect(
-    page.getByText("Stale summary from earlier work"),
-  ).toHaveCount(0)
+  await expect(page.getByText("Stale summary from earlier work")).toHaveCount(0)
 })
 
 test("activity timeline live head shows idle state", async ({ page }) => {
@@ -645,9 +681,7 @@ test("Fleet session collapse defaults and persists", async ({ page }) => {
 
   await page.getByTestId("fleet-header-toggle-fleet-history").click()
   await expect(historyCard).toHaveAttribute("data-collapsed", "false")
-  await expect(
-    historyCard.getByTestId("fleet-agent-row"),
-  ).toBeVisible()
+  await expect(historyCard.getByTestId("fleet-agent-row")).toBeVisible()
   await expect(historyCard.getByText("Prior promo session")).toBeVisible()
 
   await page.reload()
@@ -655,9 +689,7 @@ test("Fleet session collapse defaults and persists", async ({ page }) => {
 
   await page.getByTestId("fleet-header-toggle-fleet-1").click()
   await expect(workCard).toHaveAttribute("data-collapsed", "true")
-  await expect(
-    workCard.getByTestId("fleet-agent-row"),
-  ).not.toBeVisible()
+  await expect(workCard.getByTestId("fleet-agent-row")).not.toBeVisible()
 
   await page.reload()
   await expect(workCard).toHaveAttribute("data-collapsed", "true")
@@ -699,7 +731,9 @@ for (const theme of ["light", "dark"] as const) {
     for (const width of [360, 768, 1280]) {
       await page.setViewportSize({ width, height: 900 })
       await page.goto("/v2/fleet")
-      await expect(page.getByRole("heading", { name: "Sessions" })).toBeVisible()
+      await expect(
+        page.getByRole("heading", { name: "Sessions" }),
+      ).toBeVisible()
       await expect(page.locator("html")).toHaveClass(new RegExp(theme))
 
       const rosterOverflow = await page.evaluate(
@@ -723,9 +757,12 @@ for (const theme of ["light", "dark"] as const) {
       const rosterColumns = await page
         .getByTestId("fleet-agent-row")
         .evaluate((row) => getComputedStyle(row).gridTemplateColumns)
-      expect(rosterColumns.trim().split(/\s+/)).toHaveLength(
-        width <= 760 ? 4 : 5,
-      )
+      const rosterColumnCount = rosterColumns
+        .replace(/minmax\([^)]+\)/g, "minmax()")
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean).length
+      expect(rosterColumnCount).toBe(width <= 760 ? 4 : 5)
 
       await page.goto("/v2/fleet/session-1")
       await expect(


### PR DESCRIPTION
## Summary
- add an Archive agent action to the Sessions agent row overflow menu
- route archive through the existing move-session mutation into the History fleet
- cover the flow in the mocked fleet Playwright suite and update brittle fleet assertions

## Validation
- bunx biome check --write --unsafe src/components/V2/Fleet/FleetPage.tsx src/components/V2/Fleet/FleetPage.module.css tests/fleet.spec.ts
- git diff --check
- bun run build
- VITE_FIREBASE_API_KEY=AIzaSyDummydummydummydummydummydummy VITE_FIREBASE_AUTH_DOMAIN=demo.localhost VITE_FIREBASE_PROJECT_ID=demo-project VITE_FIREBASE_MESSAGING_SENDER_ID=123456789 VITE_FIREBASE_APP_ID=1:123456789:web:abcdef ./node_modules/.bin/playwright test --config=playwright.mocked.config.ts tests/fleet.spec.ts