### PR TITLE
Inset fleet session detail header divider

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -742,7 +742,14 @@
 
 .dtop {
   flex-shrink: 0;
-  border-bottom: 1px solid var(--fl-hair);
+}
+
+.dtop::after {
+  display: block;
+  height: 1px;
+  margin-top: 16px;
+  background: var(--fl-hair);
+  content: "";
 }
 
 .crumb {


### PR DESCRIPTION
## Summary
- Replace the full-width `border-bottom` on the session detail sticky header with an inset `::after` divider inside the padded content box.
- The horizontal rule now aligns with the breadcrumb, title, and body text instead of running edge-to-edge.

## Test plan
- [ ] Open `/v2/fleet/{sessionId}` and confirm the header divider matches the left/right inset of the content below
- [ ] Scroll the page and confirm the sticky header background still bleeds full width while the divider stays inset

Made with [Cursor](https://cursor.com)