### PR TITLE
Render fleet session command text in command blocks

### DIFF
--- a/src/components/V2/Fleet/ActivityProse.tsx
+++ b/src/components/V2/Fleet/ActivityProse.tsx
@@ -1,0 +1,34 @@
+import {
+  formatCommandBlockText,
+  isCommandLikeText,
+} from "@/components/V2/Fleet/fleetStatus"
+import { Markdown } from "@/components/V2/Fleet/Markdown"
+import { cn } from "@/lib/utils"
+import styles from "./FleetPage.module.css"
+
+export function ActivityProse({
+  children,
+  className,
+  compact,
+}: {
+  children: string
+  className?: string
+  compact?: boolean
+}) {
+  if (isCommandLikeText(children)) {
+    return (
+      <pre
+        className={cn(
+          styles.cmdBlock,
+          compact && styles.cmdBlockCompact,
+          className,
+        )}
+        data-testid="fleet-command-block"
+      >
+        <code>{formatCommandBlockText(children)}</code>
+      </pre>
+    )
+  }
+
+  return <Markdown className={className}>{children}</Markdown>
+}

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -919,6 +919,29 @@
   letter-spacing: -0.005em;
 }
 
+.cmdBlock {
+  margin: 0;
+  padding: 9px 11px;
+  overflow-x: auto;
+  border: 1px solid var(--fl-hair);
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: calc(12px * var(--v2-scale, 1));
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.cmdBlock code {
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.cmdBlockCompact {
+  font-size: calc(11.5px * var(--v2-scale, 1));
+}
+
 .question {
   padding: 16px 18px;
   border: 1px solid var(--border);

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -204,6 +204,29 @@ function stripCursorDiagnosticTail(text: string): string {
   return text
 }
 
+/** True when captured activity text should render as a shell command block. */
+export function isCommandLikeText(text: string | null | undefined): boolean {
+  if (!text) return false
+  const trimmed = text.trim()
+  const lowered = trimmed.toLowerCase()
+  if (lowered.startsWith("ran:")) return true
+  if (trimmed.startsWith("$ ")) return true
+  if (
+    trimmed.length > 80 &&
+    /\b(?:cd|grep|find|ls|git|npm|bunx|npx|pytest)\b/.test(lowered) &&
+    /(?:&&|;|\|\|)/.test(trimmed)
+  ) {
+    return true
+  }
+  return false
+}
+
+/** Normalize command text for display inside a command block. */
+export function formatCommandBlockText(text: string): string {
+  const trimmed = text.trim()
+  return trimmed.replace(/^Ran:\s*/i, "").trim()
+}
+
 /** Strip Cursor wrappers and Fleet UI paste noise for activity display. */
 export function cleanActivityPromptText(
   text: string | null | undefined,

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -42,6 +42,7 @@ import {
   sessionPreviousWork,
   sessionWorkSummary,
 } from "@/components/V2/Fleet/fleetStatus"
+import { ActivityProse } from "@/components/V2/Fleet/ActivityProse"
 import { Markdown } from "@/components/V2/Fleet/Markdown"
 import styles from "@/components/V2/Fleet/FleetPage.module.css"
 import { useFleetPulseSync } from "@/components/V2/Fleet/fleetPulseSync"
@@ -97,9 +98,8 @@ function metaRow(key: string, value: string, valueClass?: string) {
 }
 
 // Prompt/reply/note carry free-form prose worth rendering as markdown. Command
-// and edit titles are structured ("$ cmd", "Edited file") — leave them literal
-// so shell/path characters aren't mangled by the markdown parser.
-const PROSE_EVENT_KINDS = new Set(["prompt", "reply", "note"])
+// and edit titles are structured ("$ cmd", "Edited file") — ActivityProse picks
+// command blocks vs markdown automatically.
 
 function eventTitle(event: TaskforceSessionActivityEntry): string {
   if (event.kind === "command") return `$ ${event.cmd ?? "command"}`
@@ -332,7 +332,7 @@ function FleetAgentDetailRoute() {
             <div className={styles.section}>
               <div className={styles.seclabel}>Currently working on</div>
               <div className={styles.nowtask}>
-                <Markdown>{sessionWorkSummary(agent)}</Markdown>
+                <ActivityProse>{sessionWorkSummary(agent)}</ActivityProse>
               </div>
             </div>
           )}
@@ -342,7 +342,7 @@ function FleetAgentDetailRoute() {
             <div className={styles.section}>
               <div className={styles.seclabel}>Previously worked on</div>
               <div className={styles.nowtask}>
-                <Markdown>{sessionPreviousWork(agent)}</Markdown>
+                <ActivityProse>{sessionPreviousWork(agent)}</ActivityProse>
               </div>
             </div>
           ) : null}
@@ -355,12 +355,15 @@ function FleetAgentDetailRoute() {
                 <span className={styles.tdot} />
                 <div className={styles.tt}>{liveActivityTime(agent)}</div>
                 <div className={styles.tx}>
-                  <Markdown>
+                  <ActivityProse
+                    compact
+                    className={styles.txProse}
+                  >
                     {liveActivityLabel(agent, {
                       capturePaused,
                       pauseReason,
                     })}
-                  </Markdown>
+                  </ActivityProse>
                 </div>
               </div>
               {activityEntries.map((entry) => {
@@ -373,11 +376,9 @@ function FleetAgentDetailRoute() {
                       <span className={styles.tkind}>{entry.kind}</span>
                     </div>
                     <div className={styles.tx}>
-                      {PROSE_EVENT_KINDS.has(entry.kind) ? (
-                        <Markdown>{eventTitle(entry)}</Markdown>
-                      ) : (
-                        eventTitle(entry)
-                      )}
+                      <ActivityProse compact className={styles.txProse}>
+                        {eventTitle(entry)}
+                      </ActivityProse>
                     </div>
                     {detail && <div className={styles.tsub}>{detail}</div>}
                   </>

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -616,6 +616,23 @@ test("session detail strips Cursor capture noise from working-on text", async ({
   await expect(page.getByText(/<user_query>/)).toHaveCount(0)
 })
 
+test("session detail renders Ran diagnostics in a command block", async ({
+  page,
+}) => {
+  await mockFleet(page, {
+    agentOverrides: {
+      summary_markdown:
+        "Ran: cd /home/alexlee/dev && ls -la && echo test",
+    },
+  })
+  await page.goto("/v2/fleet/session-1")
+
+  const block = page.getByTestId("fleet-command-block").first()
+  await expect(block).toBeVisible()
+  await expect(block).toContainText("cd /home/alexlee/dev")
+  await expect(block).not.toContainText("Ran:")
+})
+
 test("activity timeline live head shows waiting state", async ({ page }) => {
   await mockFleet(page, {
     agentOverrides: {


### PR DESCRIPTION
## Summary
- Add `ActivityProse` to render command-like captured text (`Ran:`, `$ cmd`, long shell chains) in a compact monospace command block instead of plain prose.
- Apply to "Currently working on", "Previously worked on", live activity head, and timeline event titles.
- Strip the `Ran:` prefix inside the block and use slightly smaller text than normal session body copy.

## Test plan
- [x] Added Playwright test for `Ran:` diagnostics rendering in `fleet-command-block`
- [ ] Open a live session with shell diagnostics and confirm command text appears in a bordered mono block
- [ ] Confirm normal prompts/replies still render as markdown prose

Made with [Cursor](https://cursor.com)