### PR TITLE
Fix context entry hover to row highlight

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -322,25 +322,19 @@
   color: inherit;
   text-decoration: none;
   cursor: pointer;
-  transition:
-    background-color 120ms ease,
-    box-shadow 120ms ease;
+  user-select: none;
+  -webkit-user-select: none;
+  transition: background-color 120ms ease;
 }
 
 .ctxEntryLink:hover,
 .ctxEntryLink:focus-visible {
-  background: var(--fl-primary-softer);
-  box-shadow: inset 0 0 0 1px var(--fl-primary-line-soft);
-}
-
-.ctxEntryLink:hover .ctxEntryTitle,
-.ctxEntryLink:focus-visible .ctxEntryTitle {
-  color: var(--primary);
-  text-decoration: none;
+  background: var(--fl-hair);
 }
 
 .ctxEntryLink:focus-visible {
-  outline: none;
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
 }
 
 .ctxEntryTop {


### PR DESCRIPTION
## Summary
- Use the same `fl-hair` row background as fleet agent rows on context drawer entry hover
- Disable text selection across the linked entry block
- Remove purple title recolor that read as text highlight

## Test plan
- [x] Hovering summary/title highlights the full row, not individual text


Made with [Cursor](https://cursor.com)