### PR TITLE
Timeline hover block instead of purple text

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -1071,14 +1071,29 @@
   line-height: 1.45;
 }
 
-.tevLink {
+.tev.tevLink {
   display: block;
+  margin-inline: -12px;
+  padding: 8px 12px 18px;
   color: inherit;
   text-decoration: none;
+  cursor: pointer;
+  transition: background-color 120ms ease;
 }
 
-.tevLink:hover .tx {
-  color: var(--primary);
+.tev.tevLink:last-child {
+  padding-bottom: 8px;
+}
+
+.tev.tevLink:hover,
+.tev.tevLink:focus-visible {
+  background: var(--fl-primary-softer);
+  box-shadow: inset 0 0 0 1px var(--fl-primary-line-soft);
+}
+
+.tev.tevLink:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
 }
 
 /* rail blocks */


### PR DESCRIPTION
## Summary
- Activity timeline ledger links get a light purple inset background on hover
- Text keeps its normal color instead of turning primary purple

## Test plan
- [x] Hovering a linked timeline entry highlights the surrounding block


Made with [Cursor](https://cursor.com)