### PR TITLE
[DEMO WORK] Sessions: routed-profile pill on each agent row

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -603,6 +603,33 @@
   color: var(--muted-foreground);
 }
 
+/* profile pill — the specialist Taskforce routed to steer this session.
+   Violet tint keeps it distinct from the tool client chip to its left. */
+.profilePill {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 4px;
+  max-width: 160px;
+  overflow: hidden;
+  padding: 1px 7px 1px 5px;
+  border: 1px solid color-mix(in srgb, #8b5cf6 50%, var(--border));
+  background: color-mix(in srgb, #8b5cf6 14%, var(--background));
+  color: color-mix(in srgb, #8b5cf6 78%, var(--foreground));
+  font-size: calc(10.5px * var(--v2-scale, 1));
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.profilePillIcon {
+  width: calc(11px * var(--v2-scale, 1));
+  height: calc(11px * var(--v2-scale, 1));
+  flex-shrink: 0;
+}
+
 .aactivity {
   overflow: hidden;
   flex: 1;

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
 import {
   Archive,
+  Bot,
   ChevronDown,
   ChevronRight,
   GripVertical,
@@ -69,6 +70,8 @@ import {
   agentDisplayName,
   agentKind,
   agentModelName,
+  agentSpecialistName,
+  agentSpecialistRuleCount,
   agentStatus,
   compactPresence,
   type FleetStatus,
@@ -261,6 +264,19 @@ function AgentRow({
   const model = agentModelName(agent)
   const branch = agent.branch?.trim() || null
   const activity = agentActivityLine(agent)
+  // The specialist profile steering this session, if Taskforce routed one.
+  // Prefer the resolved name; fall back to a humanized slug.
+  const specialistSlug = agent.specialist_slug?.trim() || null
+  const profileLabel =
+    agentSpecialistName(agent) ??
+    (specialistSlug
+      ? specialistSlug
+          .split(/[-_]/)
+          .filter(Boolean)
+          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+          .join(" ")
+      : null)
+  const profileRuleCount = agentSpecialistRuleCount(agent)
   const [rowHovered, setRowHovered] = useState(false)
 
   const submitRename = (event: FormEvent) => {
@@ -320,6 +336,28 @@ function AgentRow({
               {sessionLabel}
             </div>
             <div className={styles.asub} data-testid="fleet-agent-sub">
+              {profileLabel && (
+                <>
+                  <span
+                    className={styles.profilePill}
+                    data-testid="fleet-agent-profile"
+                    title={
+                      profileRuleCount
+                        ? `Profile: ${profileLabel} · ${profileRuleCount} routing rules`
+                        : `Profile: ${profileLabel}`
+                    }
+                  >
+                    <Bot
+                      className={styles.profilePillIcon}
+                      aria-hidden="true"
+                    />
+                    {profileLabel}
+                  </span>
+                  <span className={styles.asep} aria-hidden="true">
+                    ·
+                  </span>
+                </>
+              )}
               <span className={styles.amodel}>{model}</span>
               {branch && (
                 <>


### PR DESCRIPTION
## What

Renders the **routed specialist profile** as a small pill on each Sessions (Fleet) agent row — `Bot` icon + profile name, violet-tinted to read as distinct from the tool client chip to its left.

The data (`specialist_slug`, `specialist_rule_count`) already arrives on every agent in `TaskforceFleetAgentPublic`; the row just never displayed it. This is pure surfacing — no API, type, or backend change.

- Prefers the resolved `specialist_name`, falls back to a humanized slug (`jensen` → `Jensen`).
- Renders **nothing** when a session has no routed specialist, so real/non-demo rosters look unchanged.
- Tooltip shows the routing-rule count when present.
- Non-interactive `<span>` (not a link) to stay valid inside the row's `<button>`.

## Why

Demo prep for the live-fleet story (`EnderAI/docs/planning/taskforce-demo-fleet-story.md`, §6 — the cheap/high-payoff Act 1 polish): the board now reads in one glance — which specialist is steering each running agent.

## Validation

`biome check` clean on both files; `tsc -p tsconfig.build.json --noEmit` reports no errors in the changed files.

> Note: `tsc` surfaces one **pre-existing, unrelated** error on `main` — `src/routes/v2/fleet.$sessionId.tsx(46): 'Markdown' is declared but never read`. Not touched here (that page is under active edit elsewhere); flagging so it isn't mistaken for this PR.

## Revert

Two files only (`FleetPage.tsx`, `FleetPage.module.css`). `[DEMO WORK]` tagged — revert the merge to undo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)