### PR TITLE
Fix fleet activity timeline dot alignment

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -1060,6 +1060,11 @@
   box-shadow: 0 0 0 3px var(--background);
 }
 
+/* tevLink inset hover padding shifts the positioning origin; keep dots on the spine. */
+.tev.tevLink .tdot {
+  left: -8px;
+}
+
 .tevRun .tdot,
 .tevNow .tdot {
   background: var(--primary);

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -439,7 +439,7 @@ function FleetAgentDetailRoute() {
             {/* Activity — durable per-turn timeline, newest-first (TF-247). */}
             <div className={styles.section}>
               <div className={styles.seclabel}>Activity</div>
-              <div className={styles.timeline}>
+              <div className={styles.timeline} data-testid="fleet-activity-timeline">
                 <div className={cn(styles.tev, styles.tevNow)}>
                   <span className={styles.tdot} />
                   <div className={styles.tt}>{liveActivityTime(agent)}</div>

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -509,6 +509,25 @@ test("activity timeline shows the full canonical event stream and exact Ledger l
   expect(href).toContain("/v2/ledger?")
   expect(href).toContain("session_id=session-1")
   expect(href).toContain("event_id=event-command")
+
+  const dotAlignment = await page.evaluate(() => {
+    const timeline = document.querySelector(
+      '[data-testid="fleet-activity-timeline"]',
+    )
+    if (!timeline) throw new Error("timeline missing")
+    const dots = [...timeline.children]
+      .map((entry) => entry.querySelector("span"))
+      .filter((dot): dot is HTMLSpanElement => Boolean(dot))
+    if (dots.length < 2) throw new Error("expected multiple timeline dots")
+    const centers = dots.map((dot) => {
+      const rect = dot.getBoundingClientRect()
+      return rect.left + rect.width / 2
+    })
+    const spread = Math.max(...centers) - Math.min(...centers)
+    return { dotCount: dots.length, spread }
+  })
+  expect(dotAlignment.dotCount).toBeGreaterThanOrEqual(2)
+  expect(dotAlignment.spread).toBeLessThan(2)
 })
 
 test("activity timeline live head shows running without summary", async ({


### PR DESCRIPTION
## Summary
- Re-center timeline dots on ledger-linked activity rows by offsetting `.tevLink` dot position for the row’s inset hover padding.
- Text positioning is unchanged; only the dot anchor moves.
- Add Playwright coverage that all timeline dots share the same horizontal center.

## Test plan
- [x] Extended `tests/fleet.spec.ts` activity timeline test with dot alignment assertion
- [ ] Open a session detail page and confirm gray dots sit on the vertical spine for linked entries

Made with [Cursor](https://cursor.com)