### PR TITLE
Render ledger transcript timeline via shared ActivityProse

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -913,11 +913,13 @@
   letter-spacing: -0.005em;
 }
 
+/* ActivityProse is shared with the Ledger transcript, which is outside the
+   Fleet --fl-* scope; fall back to the global border token there. */
 .cmdBlock {
   margin: 0;
   padding: 9px 11px;
   overflow-x: auto;
-  border: 1px solid var(--fl-hair);
+  border: 1px solid var(--fl-hair, var(--border));
   background: color-mix(in srgb, var(--foreground) 6%, transparent);
   color: var(--foreground);
   font-family: var(--font-mono);

--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -613,15 +613,10 @@
   font-size: calc(13px * var(--v2-scale, 1));
   line-height: 1.45;
   text-wrap: pretty;
-  white-space: pre-wrap;
 }
 .evPrompt .evTitle,
 .evReply .evTitle {
   color: var(--tf-fg);
-}
-.evTitleMono {
-  font-family: var(--font-mono);
-  word-break: break-word;
 }
 .evSub {
   margin-top: 4px;

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/api/v2Ledger"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { formatCompactNumber } from "@/components/V2/Agents/formatters"
+import { ActivityProse } from "@/components/V2/Fleet/ActivityProse"
 import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
 import {
   V2_PAGE_BODY,
@@ -778,6 +779,15 @@ function LedgerDetail({
   )
 }
 
+// Dot/emphasis treatment per kind; commands and edits stay neutral and lean on
+// ActivityProse (command block / markdown) for their formatting.
+function eventModifier(kind: string): string | undefined {
+  if (kind === "prompt") return styles.evPrompt
+  if (kind === "reply") return styles.evReply
+  if (kind === "command" || kind === "edit") return undefined
+  return styles.evNote
+}
+
 function TranscriptEvent({
   anchorRef,
   detail,
@@ -794,60 +804,18 @@ function TranscriptEvent({
   const title = transcriptEventTitle(event)
   const eventDetail = transcriptEventDetail(event, detail)
 
-  if (event.kind === "prompt") {
-    return (
-      <EventShell
-        kind={event.kind}
-        modifier={styles.evPrompt}
-        time={time}
-        {...anchorProps}
-      >
-        <div className={styles.evTitle}>{title}</div>
-        {eventDetail ? <div className={styles.evSub}>{eventDetail}</div> : null}
-      </EventShell>
-    )
-  }
-
-  if (event.kind === "reply") {
-    return (
-      <EventShell
-        kind={event.kind}
-        modifier={styles.evReply}
-        time={time}
-        {...anchorProps}
-      >
-        <div className={styles.evTitle}>{title}</div>
-        {eventDetail ? <div className={styles.evSub}>{eventDetail}</div> : null}
-      </EventShell>
-    )
-  }
-
-  if (event.kind === "command") {
-    return (
-      <EventShell kind={event.kind} time={time} {...anchorProps}>
-        <div className={cn(styles.evTitle, styles.evTitleMono)}>{title}</div>
-        {eventDetail ? <div className={styles.evSub}>{eventDetail}</div> : null}
-      </EventShell>
-    )
-  }
-
-  if (event.kind === "edit") {
-    return (
-      <EventShell kind={event.kind} time={time} {...anchorProps}>
-        <div className={styles.evTitle}>{title}</div>
-        {eventDetail ? <div className={styles.evSub}>{eventDetail}</div> : null}
-      </EventShell>
-    )
-  }
-
+  // Mirrors the Fleet agent-detail activity timeline: prose text renders as
+  // compact markdown and command-like text ("$ …") renders as a command block.
   return (
     <EventShell
       kind={event.kind}
-      modifier={styles.evNote}
+      modifier={eventModifier(event.kind)}
       time={time}
       {...anchorProps}
     >
-      <div className={styles.evTitle}>{title}</div>
+      <div className={styles.evTitle}>
+        <ActivityProse compact>{title}</ActivityProse>
+      </div>
       {eventDetail ? <div className={styles.evSub}>{eventDetail}</div> : null}
     </EventShell>
   )


### PR DESCRIPTION
## Problem
The ledger transcript timeline was in rough shape: it dumped raw text into a `<div>` with `white-space: pre-wrap`, so markdown showed up as literal `*`/backtick characters, commands were plain mono text, and raw whitespace was preserved. The session-agent (Fleet) activity timeline renders the same kind of content much more cleanly.

## Change
Render each ledger transcript entry through the **same `ActivityProse` component** the Fleet agent-detail timeline uses:
- Prose text renders as compact GitHub-flavored markdown.
- Command-like text (`$ …`) renders as a proper command block.

Also collapses the five duplicated per-kind branches in `TranscriptEvent` into one, with a small `eventModifier()` helper for the dot/emphasis treatment.

`ActivityProse`'s command block referenced `--fl-hair` (scoped to the Fleet CSS module). Since the component is now shared with the ledger, it gets a global fallback: `var(--fl-hair, var(--border))` — a no-op inside Fleet, correct border in the ledger.

Net: −54 / +19 lines; the two timelines now share one renderer so they won't drift again.

## Validation
- `tsc -p tsconfig.build.json --noEmit` → clean
- `biome check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)