### PR TITLE
Polish landing page layout, hero tabs, and copy

### DIFF
--- a/src/components/V2/Landing/FeatureSection.tsx
+++ b/src/components/V2/Landing/FeatureSection.tsx
@@ -23,7 +23,7 @@ export function FeatureSection() {
           icon={Bot}
           id="profiles"
           label="Profiles"
-          title="Agent profiles"
+          title="Agent identities"
           visual={<ProfilePanel />}
         />
         <FeatureRow
@@ -31,7 +31,7 @@ export function FeatureSection() {
           icon={BookOpenText}
           id="library"
           label="Library"
-          title="Self-updating documents"
+          title="Self-maintaining documents"
           visual={<LibraryPanel />}
           visualLeft
         />

--- a/src/components/V2/Landing/Hero.tsx
+++ b/src/components/V2/Landing/Hero.tsx
@@ -16,18 +16,18 @@ const SCENES = [
   },
   {
     key: "Profiles",
-    name: "Agent profiles",
+    name: "Agent identities",
     phrase: ["re-briefing", "every agent."],
   },
   {
     key: "Library",
-    name: "Self-updating documents",
+    name: "Self-maintaining documents",
     phrase: ["re-explaining", "your codebase."],
   },
   {
     key: "Ledger",
     name: "Audit trail",
-    phrase: ["guessing what", "agents did."],
+    phrase: ["guessing what", "your agents did."],
   },
   {
     key: "Metrics",
@@ -90,10 +90,13 @@ function useRevealClass() {
 export function LandingHero() {
   const [sceneIndex, setSceneIndex] = useState(0)
   const [isSwapping, setIsSwapping] = useState(false)
+  const [isPaused, setIsPaused] = useState(false)
+  const [pauseToken, setPauseToken] = useState(0)
   const reducedMotion = usePrefersReducedMotion()
   const copyReveal = useRevealClass()
   const termReveal = useRevealClass()
   const swapTimer = useRef<number | null>(null)
+  const pauseTimer = useRef<number | null>(null)
   const pauseUntilRef = useRef(0)
   const scene = SCENES[sceneIndex]
 
@@ -132,13 +135,44 @@ export function LandingHero() {
 
   const selectSceneFromDot = (nextIndex: number) => {
     pauseUntilRef.current = Date.now() + HERO_CLICK_PAUSE_MS
-    selectScene(nextIndex)
+    setPauseToken((token) => token + 1)
+    setIsPaused(true)
+    if (nextIndex !== sceneIndex) {
+      selectScene(nextIndex)
+    }
   }
+
+  useEffect(() => {
+    if (!isPaused) return
+
+    if (pauseTimer.current) {
+      window.clearTimeout(pauseTimer.current)
+    }
+
+    const remaining = pauseUntilRef.current - Date.now()
+    pauseTimer.current = window.setTimeout(
+      () => {
+        setIsPaused(false)
+        pauseTimer.current = null
+      },
+      Math.max(0, remaining),
+    )
+
+    return () => {
+      if (pauseTimer.current) {
+        window.clearTimeout(pauseTimer.current)
+        pauseTimer.current = null
+      }
+    }
+  }, [isPaused, pauseToken])
 
   useEffect(() => {
     return () => {
       if (swapTimer.current) {
         window.clearTimeout(swapTimer.current)
+      }
+      if (pauseTimer.current) {
+        window.clearTimeout(pauseTimer.current)
       }
     }
   }, [])
@@ -167,29 +201,53 @@ export function LandingHero() {
                 <span className={styles.lead}>Stop </span>
                 <span className={styles.phrase}>{phrase}</span>
               </h1>
-              <div
-                className={cn(styles.heroCap, isSwapping && styles.swapping)}
-              >
-                <span className={styles.capKey}>{scene.key}</span>
-                <span className={styles.capSep}>·</span>
-                <span>{scene.name}</span>
-              </div>
-              <div
-                aria-label="Capabilities"
-                className={styles.heroDots}
-                role="tablist"
-              >
-                {SCENES.map((item, index) => (
-                  <button
-                    aria-label={item.key}
-                    aria-selected={sceneIndex === index}
-                    className={cn(sceneIndex === index && styles.activeDot)}
-                    key={item.key}
-                    onClick={() => selectSceneFromDot(index)}
-                    role="tab"
-                    type="button"
-                  />
-                ))}
+              <div className={styles.heroSwitcher}>
+                <div
+                  className={cn(styles.heroCap, isSwapping && styles.swapping)}
+                >
+                  <span className={styles.capKey}>{scene.key}</span>
+                  <span className={styles.capSep}>·</span>
+                  <span>{scene.name}</span>
+                </div>
+                <div
+                  aria-label="Capabilities"
+                  className={styles.heroDots}
+                  role="tablist"
+                >
+                  {SCENES.map((item, index) => (
+                    <button
+                      aria-label={item.key}
+                      aria-selected={sceneIndex === index}
+                      className={cn(
+                        sceneIndex === index && styles.activeDot,
+                        sceneIndex === index &&
+                          isPaused &&
+                          !reducedMotion &&
+                          styles.pauseTimer,
+                      )}
+                      key={item.key}
+                      onClick={() => selectSceneFromDot(index)}
+                      role="tab"
+                      title={
+                        sceneIndex === index && isPaused
+                          ? "Auto-advancing soon"
+                          : undefined
+                      }
+                      type="button"
+                    >
+                      {sceneIndex === index && isPaused && !reducedMotion ? (
+                        <span aria-hidden className={styles.pauseClock} key={pauseToken}>
+                          <span
+                            className={styles.pauseClockHand}
+                            style={{
+                              animationDuration: `${HERO_CLICK_PAUSE_MS}ms`,
+                            }}
+                          />
+                        </span>
+                      ) : null}
+                    </button>
+                  ))}
+                </div>
               </div>
               <div className={styles.works}>
                 Works with Claude Code, Codex, and Cursor.
@@ -250,10 +308,6 @@ function HeroTerminal({ sceneIndex }: { sceneIndex: number }) {
       <div className={styles.termHead}>
         <span className={styles.termDot} />
         <span className={styles.termName}>taskforce</span>
-        <span className={styles.liveStatus}>
-          <span />
-          connected
-        </span>
       </div>
       <div className={styles.termBody}>
         {scenes.map((scene, index) => (
@@ -394,7 +448,6 @@ function LedgerScene() {
       <div className={styles.searchLine}>
         <span className={styles.termAccent}>search -</span> referenced:
         <span className={styles.termHighlight}>"Stripe checkout wiring"</span>
-        <span className={styles.termCursor} />
       </div>
       <div className={styles.ledgerHead}>
         <span>time</span>

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -1,5 +1,5 @@
 .page {
-  --landing-max: 1180px;
+  --landing-max: clamp(1180px, calc(100vw - 11vw), 1540px);
   --landing-bg: var(--background);
   --landing-fg: var(--foreground);
   --landing-muted: var(--muted-foreground);
@@ -205,15 +205,15 @@
 
 .hero::before {
   position: absolute;
-  top: -280px;
+  top: -360px;
   left: 50%;
   z-index: 0;
-  width: 820px;
-  height: 560px;
+  width: min(1240px, 96vw);
+  height: 820px;
   background: radial-gradient(
     ellipse at center,
-    color-mix(in srgb, var(--landing-primary) 24%, transparent),
-    transparent 66%
+    color-mix(in srgb, var(--landing-primary) 26%, transparent),
+    transparent 74%
   );
   content: "";
   pointer-events: none;
@@ -238,7 +238,7 @@
   flex: 1 1 auto;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   align-items: stretch;
-  gap: 46px;
+  gap: clamp(46px, 4vw, 64px);
 }
 
 .heroCopy {
@@ -289,11 +289,21 @@
   transform: translateY(7px);
 }
 
+.heroSwitcher {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: fit-content;
+  max-width: 100%;
+  gap: 10px;
+  margin-bottom: 26px;
+}
+
 .heroCap {
   display: flex;
   align-items: center;
   gap: 9px;
-  margin-bottom: 22px;
+  margin-bottom: 0;
   color: var(--landing-muted);
   font-family: var(--font-mono);
   font-size: 15px;
@@ -318,27 +328,81 @@
 .heroDots {
   display: flex;
   gap: 8px;
-  margin-bottom: 26px;
   width: 100%;
+  margin-bottom: 0;
 }
 
 .heroDots button {
+  position: relative;
   flex: 1 1 0;
-  height: 4.4px;
+  min-height: 28px;
   padding: 0;
   border: 0;
-  background: var(--landing-border);
+  background: transparent;
   appearance: none;
+  cursor: pointer;
+}
+
+.heroDots button::after {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  left: 0;
+  height: 8px;
+  background: var(--landing-border);
+  content: "";
+  transform: translateY(-50%);
   transition: background 250ms ease;
 }
 
-.heroDots button:hover {
+.heroDots button:hover::after {
   background: var(--landing-faint);
 }
 
-.heroDots .activeDot,
-.heroDots .activeDot:hover {
+.heroDots .activeDot::after,
+.heroDots .activeDot:hover::after {
   background: var(--landing-primary);
+}
+
+.heroDots .pauseTimer::after {
+  opacity: 0.28;
+}
+
+.pauseClock {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  border: 1.5px solid color-mix(in srgb, var(--landing-primary) 42%, var(--landing-border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--landing-bg) 92%, transparent);
+  transform: translate(-50%, -50%);
+}
+
+.pauseClockHand {
+  position: absolute;
+  top: 3px;
+  left: calc(50% - 0.75px);
+  width: 1.5px;
+  height: 5px;
+  transform-origin: 50% 100%;
+  border-radius: 999px;
+  animation: pauseClockHand linear forwards;
+  background: var(--landing-primary);
+}
+
+@keyframes pauseClockHand {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .works {
@@ -399,21 +463,6 @@
 
 .termName {
   color: oklch(0.84 0 0);
-}
-
-.liveStatus {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-left: auto;
-}
-
-.liveStatus span {
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  animation: pulse 2400ms ease-in-out infinite;
-  background: var(--landing-positive);
 }
 
 .termBody {
@@ -586,14 +635,6 @@
   gap: 6px;
   color: oklch(0.8 0 0);
   font-size: 11px;
-}
-
-.termCursor {
-  display: inline-block;
-  width: 7px;
-  height: 13px;
-  animation: blink 1100ms step-end infinite;
-  background: var(--landing-term-accent);
 }
 
 .metricBig {
@@ -1397,6 +1438,11 @@
   .page {
     scroll-behavior: auto;
   }
+
+  .pauseClockHand {
+    animation: none;
+    transform: rotate(45deg);
+  }
 }
 
 @keyframes revealUp {
@@ -1428,12 +1474,6 @@
   }
   50% {
     opacity: 0.35;
-  }
-}
-
-@keyframes blink {
-  50% {
-    opacity: 0;
   }
 }
 

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -24,8 +24,8 @@ test("/landing renders the redesigned Taskforce landing page", async ({
 
   for (const heading of [
     "Orchestration",
-    "Agent profiles",
-    "Self-updating documents",
+    "Agent identities",
+    "Self-maintaining documents",
     "Audit trail",
     "Proven ROI",
   ]) {


### PR DESCRIPTION
## Summary
- Widen landing page max width and enlarge the hero purple glow for a less cramped layout
- Refine hero capability tabs: fit under caption text, taller click targets, and a 10s pause countdown clock on click
- Remove terminal "connected" badge and ledger search cursor for a cleaner demo
- Update copy: Agent identities, Self-maintaining documents, and Ledger hero line ("Stop guessing what your agents did")

## Test plan
- [x] Verified landing page renders at `/landing`
- [ ] Hero tabs switch scenes and show pause clock on click
- [ ] Feature section headings match updated labels
- [ ] Playwright landing spec passes


Made with [Cursor](https://cursor.com)