### PR TITLE
Fix bottom landing CTA button alignment

### DIFF
--- a/src/components/V2/Landing/ClosingCta.tsx
+++ b/src/components/V2/Landing/ClosingCta.tsx
@@ -3,6 +3,8 @@ import { ArrowRight } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 
+import { cn } from "@/lib/utils"
+
 import styles from "./Landing.module.css"
 
 export function ClosingCta() {
@@ -12,7 +14,7 @@ export function ClosingCta() {
         <h2>
           Stop starting from <em>scratch</em>. Start using <em>Taskforce</em>.
         </h2>
-        <div className={styles.heroCtas}>
+        <div className={cn(styles.heroCtas, styles.ctaActions)}>
           <Button asChild className={styles.solidButton}>
             <Link to="/signup">
               Start free

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -376,11 +376,38 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
   height: 46px;
+  min-height: 46px;
+  max-height: 46px;
   min-width: 0;
   padding: 0 18px;
+  border-radius: 0;
+  font-family: var(--font-mono);
   font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0.02em;
   white-space: nowrap;
+  gap: 8px;
+  box-shadow: none;
+}
+
+.heroCtas .solidButton {
+  border: 1px solid var(--landing-primary);
+  background: var(--landing-primary);
+  color: var(--landing-primary-fg);
+}
+
+.heroCtas .outlineButton {
+  border: 1px solid var(--landing-border);
+  background: transparent;
+  color: var(--landing-fg);
+}
+
+.heroCtas .solidButton svg {
+  width: 16px;
+  height: 16px;
 }
 
 .term {
@@ -1301,6 +1328,11 @@
     transparent 60%
   );
   content: "";
+}
+
+.ctaActions {
+  margin-inline: auto;
+  justify-content: center;
 }
 
 .ctaInner {


### PR DESCRIPTION
## Summary
- Center the closing CTA button row under the headline
- Match height, mono font, border radius, and padding on both buttons
- Override shadcn button defaults that caused mismatched sizes

## Test plan
- [ ] Bottom Start free and Open Taskforce buttons are same height and centered


Made with [Cursor](https://cursor.com)