### PR TITLE
Rebuild metrics section as half-width bar chart panel

### DIFF
--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -1193,24 +1193,6 @@
   border-top: 1px solid var(--landing-hairline);
 }
 
-.proofRowStacked {
-  grid-template-columns: 1fr;
-  gap: 28px;
-}
-
-.proofRowStacked .featureCopy {
-  max-width: 40rem;
-}
-
-.proofRowStacked .visual {
-  width: 100%;
-}
-
-.proofRowStacked .metricsCard {
-  height: auto;
-  min-height: 0;
-}
-
 .features .proofRow:first-child {
   border-top: 1px solid var(--landing-hairline);
 }
@@ -1224,8 +1206,15 @@
 }
 
 .metricsCard {
-  justify-content: center;
-  padding: 18px;
+  justify-content: flex-start;
+}
+
+.metricsBody {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  padding: 14px;
 }
 
 .metricsHeroStat {
@@ -1237,7 +1226,7 @@
 
 .metricsHeroStat span {
   color: var(--landing-primary);
-  font-size: 38px;
+  font-size: 34px;
   font-weight: 600;
   line-height: 1;
   letter-spacing: -0.03em;
@@ -1250,65 +1239,65 @@
 }
 
 .metricsSub {
-  margin-bottom: 16px;
+  margin-bottom: 12px;
   color: var(--landing-faint);
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.04em;
 }
 
-.chart {
-  margin-right: -18px;
-  margin-bottom: 14px;
-  margin-left: -18px;
-  padding: 10px 12px 6px;
-  border-width: 1px 0;
-  border-style: solid;
-  border-color: var(--landing-hairline);
+.metricsBarChart {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: stretch;
+  gap: 8px;
+  min-height: 0;
+}
+
+.metricsBarCol {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  min-width: 0;
+}
+
+.metricsBarTrack {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: flex-end;
+  min-height: 112px;
+  padding: 8px 6px 0;
+  border: 1px solid var(--landing-hairline);
   background: var(--landing-bg);
 }
 
-.metricsChartSvg {
-  display: block;
-  overflow: visible;
+.metricsBarFill {
   width: 100%;
-  height: clamp(160px, 18vw, 240px);
+  border: 1px solid color-mix(in srgb, var(--landing-primary) 45%, var(--landing-border));
+  background: color-mix(in srgb, var(--landing-primary) 18%, var(--landing-bg));
 }
 
-.chartGrid line {
-  stroke: var(--landing-hairline);
-  stroke-width: 1;
+.metricsBarFillActive {
+  border-color: var(--landing-primary);
+  background: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--landing-primary) 28%, var(--landing-bg)),
+    var(--landing-primary)
+  );
 }
 
-.chartAxis line {
-  stroke: color-mix(in srgb, var(--landing-faint) 72%, var(--landing-border));
-  stroke-width: 1.2;
-}
-
-.chartLabels text {
-  fill: var(--landing-faint);
+.metricsBarLabel {
+  color: var(--landing-faint);
   font-family: var(--font-mono);
-  font-size: 3.2px;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-align: center;
 }
 
-.chartArea {
-  fill: url("#rediscovery-gradient");
-}
-
-.chartLine {
-  fill: none;
-  stroke: var(--landing-primary);
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: 2;
-  vector-effect: non-scaling-stroke;
-}
-
-.chartPoints circle {
-  fill: var(--landing-bg);
-  stroke: var(--landing-primary);
-  stroke-width: 2;
-  vector-effect: non-scaling-stroke;
+.metricsCard .metricsTiles {
+  margin-top: 12px;
 }
 
 .ctaBand {

--- a/src/components/V2/Landing/ProvenRoi.tsx
+++ b/src/components/V2/Landing/ProvenRoi.tsx
@@ -4,13 +4,18 @@ import { cn } from "@/lib/utils"
 
 import styles from "./Landing.module.css"
 
+const WEEKS = [
+  { label: "W1", value: 52 },
+  { label: "W2", value: 58 },
+  { label: "W3", value: 65 },
+  { label: "W4", value: 73 },
+] as const
+
 export function ProvenRoi() {
   return (
     <section className={styles.features} id="metrics">
       <div className={styles.wrap}>
-        <div
-          className={cn(styles.featureRow, styles.proofRow, styles.proofRowStacked)}
-        >
+        <div className={cn(styles.featureRow, styles.proofRow)}>
           <div className={styles.featureCopy}>
             <div className={styles.featureLabel}>
               <span className={styles.featureIcon}>
@@ -27,95 +32,47 @@ export function ProvenRoi() {
           </div>
           <div className={styles.visual}>
             <div className={cn(styles.panel, styles.metricsCard)}>
-              <div className={styles.metricsHeroStat}>
-                <span>73%</span>
-                <b>rediscovery avoided</b>
+              <div className={styles.panelHead}>
+                <span>metrics</span>
+                <span className={styles.spacer} />
+                <span className={styles.chip}>12 repos</span>
               </div>
-              <div className={styles.metricsSub}>
-                last 30 days - across 12 repos
-              </div>
-              <div className={styles.chart}>
-                <svg
-                  aria-hidden="true"
-                  className={styles.metricsChartSvg}
-                  preserveAspectRatio="none"
-                  viewBox="0 0 100 50"
-                >
-                  <defs>
-                    <linearGradient
-                      id="rediscovery-gradient"
-                      x1="0"
-                      x2="0"
-                      y1="0"
-                      y2="1"
-                    >
-                      <stop
-                        offset="0%"
-                        stopColor="var(--landing-primary)"
-                        stopOpacity="0.24"
-                      />
-                      <stop
-                        offset="100%"
-                        stopColor="var(--landing-primary)"
-                        stopOpacity="0"
-                      />
-                    </linearGradient>
-                  </defs>
-                  <g className={styles.chartGrid}>
-                    <line x1="7" x2="100" y1="12" y2="12" />
-                    <line x1="7" x2="100" y1="24" y2="24" />
-                    <line x1="7" x2="100" y1="36" y2="36" />
-                  </g>
-                  <g className={styles.chartAxis}>
-                    <line x1="7" x2="100" y1="42" y2="42" />
-                  </g>
-                  <g className={styles.chartLabels}>
-                    <text textAnchor="start" x="0" y="10.5">
-                      80%
-                    </text>
-                    <text textAnchor="start" x="0" y="22.5">
-                      60%
-                    </text>
-                    <text textAnchor="start" x="0" y="34.5">
-                      40%
-                    </text>
-                    <text textAnchor="start" x="7" y="47.5">
-                      W1
-                    </text>
-                    <text textAnchor="middle" x="38" y="47.5">
-                      W2
-                    </text>
-                    <text textAnchor="middle" x="69" y="47.5">
-                      W3
-                    </text>
-                    <text textAnchor="end" x="100" y="47.5">
-                      W4
-                    </text>
-                  </g>
-                  <path
-                    className={styles.chartArea}
-                    d="M7 33.2 L38 29.6 L69 25.2 L100 20.4 L100 42 L7 42 Z"
-                  />
-                  <path
-                    className={styles.chartLine}
-                    d="M7 33.2 L38 29.6 L69 25.2 L100 20.4"
-                  />
-                  <g className={styles.chartPoints}>
-                    <circle cx="7" cy="33.2" r="0.9" />
-                    <circle cx="38" cy="29.6" r="0.9" />
-                    <circle cx="69" cy="25.2" r="0.9" />
-                    <circle cx="100" cy="20.4" r="1.05" />
-                  </g>
-                </svg>
-              </div>
-              <div className={styles.metricsTiles}>
-                <div className={styles.statTile}>
-                  <div>2.4M</div>
-                  <span>Tokens saved / wk</span>
+              <div className={styles.metricsBody}>
+                <div className={styles.metricsHeroStat}>
+                  <span>73%</span>
+                  <b>rediscovery avoided</b>
                 </div>
-                <div className={styles.statTile}>
-                  <div>31 hrs</div>
-                  <span>Eng time / wk</span>
+                <div className={styles.metricsSub}>
+                  last 30 days - across 12 repos
+                </div>
+                <div aria-hidden className={styles.metricsBarChart}>
+                  {WEEKS.map((week, index) => (
+                    <div className={styles.metricsBarCol} key={week.label}>
+                      <div className={styles.metricsBarTrack}>
+                        <div
+                          className={cn(
+                            styles.metricsBarFill,
+                            index === WEEKS.length - 1 &&
+                              styles.metricsBarFillActive,
+                          )}
+                          style={{ height: `${(week.value / 80) * 100}%` }}
+                        />
+                      </div>
+                      <span className={styles.metricsBarLabel}>
+                        {week.label}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                <div className={styles.metricsTiles}>
+                  <div className={styles.statTile}>
+                    <div>2.4M</div>
+                    <span>Tokens saved / wk</span>
+                  </div>
+                  <div className={styles.statTile}>
+                    <div>31 hrs</div>
+                    <span>Eng time / wk</span>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Restore Proven ROI to the standard 50/50 feature row (copy left, panel right)
- Replace the stretched SVG line chart with a CSS bar chart that fits the terminal panel
- Match other landing panels with a proper panel header and stat tiles

## Test plan
- [ ] Metrics section shows copy and panel side by side on desktop
- [ ] Bar chart reads cleanly inside the half-width panel


Made with [Cursor](https://cursor.com)