### PR TITLE
Type out hero terminal command, then reveal output

### DIFF
--- a/src/components/V2/Landing/Hero.tsx
+++ b/src/components/V2/Landing/Hero.tsx
@@ -36,8 +36,18 @@ const SCENES = [
   },
 ] as const
 
-const HERO_ROTATION_MS = 4400
-const HERO_CLICK_PAUSE_MS = 10_000
+const SCENE_COMMANDS = [
+  "tf sessions --live",
+  'tf route "stripe tax for new subscribers"',
+  'tf recall "annual-plan tax pattern"',
+  'tf ledger --ref "Stripe checkout wiring"',
+  "tf metrics --last 30d",
+] as const
+
+const HERO_ROTATION_MS = 5600
+const HERO_CLICK_PAUSE_MS = 12_000
+const TYPE_SPEED_MS = 30
+const OUTPUT_DELAY_MS = 220
 
 function usePrefersReducedMotion() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
@@ -219,7 +229,10 @@ export function LandingHero() {
               className={cn(styles.heroTerm, termReveal.className)}
               ref={termReveal.ref}
             >
-              <HeroTerminal sceneIndex={sceneIndex} />
+              <HeroTerminal
+                reducedMotion={reducedMotion}
+                sceneIndex={sceneIndex}
+              />
             </div>
           </div>
         </div>
@@ -240,7 +253,13 @@ export function LandingHero() {
   )
 }
 
-function HeroTerminal({ sceneIndex }: { sceneIndex: number }) {
+function HeroTerminal({
+  reducedMotion,
+  sceneIndex,
+}: {
+  reducedMotion: boolean
+  sceneIndex: number
+}) {
   const scenes = [
     <SessionsScene key="sessions" />,
     <ProfilesScene key="profiles" />,
@@ -248,6 +267,41 @@ function HeroTerminal({ sceneIndex }: { sceneIndex: number }) {
     <LedgerScene key="ledger" />,
     <MetricsScene key="metrics" />,
   ]
+
+  const command = SCENE_COMMANDS[sceneIndex]
+  const [typed, setTyped] = useState("")
+  const [showOutput, setShowOutput] = useState(false)
+
+  // Type the command character by character, then reveal the output below it.
+  useEffect(() => {
+    if (reducedMotion) {
+      setTyped(command)
+      setShowOutput(true)
+      return
+    }
+
+    setTyped("")
+    setShowOutput(false)
+
+    let index = 0
+    let outputTimer: number | undefined
+    const typeTimer = window.setInterval(() => {
+      index += 1
+      setTyped(command.slice(0, index))
+      if (index >= command.length) {
+        window.clearInterval(typeTimer)
+        outputTimer = window.setTimeout(
+          () => setShowOutput(true),
+          OUTPUT_DELAY_MS,
+        )
+      }
+    }, TYPE_SPEED_MS)
+
+    return () => {
+      window.clearInterval(typeTimer)
+      if (outputTimer) window.clearTimeout(outputTimer)
+    }
+  }, [command, reducedMotion])
 
   return (
     <div className={styles.term}>
@@ -260,17 +314,26 @@ function HeroTerminal({ sceneIndex }: { sceneIndex: number }) {
         </span>
       </div>
       <div className={styles.termBody}>
-        {scenes.map((scene, index) => (
-          <div
-            className={cn(
-              styles.terminalScene,
-              sceneIndex === index && styles.terminalSceneActive,
-            )}
-            key={scene.key}
-          >
-            {scene}
-          </div>
-        ))}
+        <div className={styles.cmd}>
+          <span className={styles.cmdSign}>$</span>
+          <span className={styles.cmdText}>{typed}</span>
+          <span className={cn(styles.caret, showOutput && styles.caretIdle)} />
+        </div>
+        <div className={styles.termScenes}>
+          {scenes.map((scene, index) => (
+            <div
+              className={cn(
+                styles.terminalScene,
+                sceneIndex === index &&
+                  showOutput &&
+                  styles.terminalSceneActive,
+              )}
+              key={scene.key}
+            >
+              {scene}
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )
@@ -279,7 +342,6 @@ function HeroTerminal({ sceneIndex }: { sceneIndex: number }) {
 function SessionsScene() {
   return (
     <>
-      <Command>tf sessions --live</Command>
       <SessionGroup count="3 agents" name="checkout-squad" />
       <SessionRow name="tax-refactor" state="running" tool="claude · vm-04" />
       <SessionRow name="checkout-e2e" state="14/20" tool="codex · term-2" />
@@ -309,7 +371,6 @@ function SessionsScene() {
 function ProfilesScene() {
   return (
     <>
-      <Command>tf route "stripe tax for new subscribers"</Command>
       <Field label="matched">
         <span className={styles.accent}>Jensen · Billing Reliability</span>
       </Field>
@@ -338,7 +399,6 @@ function ProfilesScene() {
 function LibraryScene() {
   return (
     <>
-      <Command>tf recall "annual-plan tax pattern"</Command>
       <Field label="reading">
         <span className={styles.accent}>Stripe checkout wiring</span> ·{" "}
         <span className={styles.accent}>tax-rates rollout</span>
@@ -369,7 +429,6 @@ function LibraryScene() {
 function LedgerScene() {
   return (
     <>
-      <Command>tf ledger --ref "Stripe checkout wiring"</Command>
       <div className={styles.ledgerHead}>
         <span>time</span>
         <span>session</span>
@@ -413,7 +472,6 @@ function LedgerScene() {
 function MetricsScene() {
   return (
     <>
-      <Command>tf metrics --last 30d</Command>
       <div className={styles.metricBig}>
         <span>73%</span>
         <span>rediscovery avoided · across 12 repos</span>
@@ -436,16 +494,6 @@ function MetricsScene() {
         ]}
       />
     </>
-  )
-}
-
-function Command({ children }: { children: ReactNode }) {
-  return (
-    <div className={styles.cmd}>
-      <span className={styles.cmdSign}>$</span>
-      <span className={styles.cmdText}>{children}</span>
-      <span className={styles.caret} />
-    </div>
   )
 }
 

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -217,9 +217,9 @@
   z-index: 1;
   display: grid;
   flex: 1 1 auto;
-  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  grid-template-columns: minmax(0, 1.06fr) minmax(0, 0.94fr);
   align-items: stretch;
-  gap: clamp(32px, 3.5vw, 52px);
+  gap: clamp(24px, 2.2vw, 36px);
 }
 
 .heroCopy {
@@ -463,14 +463,22 @@
 }
 
 .termBody {
-  position: relative;
-  min-height: 350px;
+  display: flex;
+  flex-direction: column;
+  min-height: 360px;
   padding: 18px;
+}
+
+.termScenes {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 298px;
+  margin-top: 11px;
 }
 
 .terminalScene {
   position: absolute;
-  inset: 18px;
+  inset: 0;
   display: flex;
   flex-direction: column;
   gap: 9px;
@@ -1351,7 +1359,8 @@
 
 .metricsBarFill {
   width: 100%;
-  border: 1px solid color-mix(in srgb, var(--landing-primary) 45%, var(--landing-border));
+  border: 1px solid
+    color-mix(in srgb, var(--landing-primary) 45%, var(--landing-border));
   background: color-mix(in srgb, var(--landing-primary) 18%, var(--landing-bg));
 }
 
@@ -1509,7 +1518,7 @@
     animation: cueBounce 1900ms ease-in-out infinite;
   }
 
-  .caret {
+  .caretIdle {
     animation: caretBlink 1100ms steps(1) infinite;
   }
 


### PR DESCRIPTION
## What

Follow-up polish on the landing hero terminal:

- **Typewriter command** — each scene types its `$ tf ...` command character by character (~30ms/char), then reveals the output beneath it once typing completes (~220ms pause), using the existing per-line print stagger. Caret is solid while typing, blinks when idle.
- **Restructured terminal body** — the prompt now sits in normal flow above a relative output area (`termScenes`) instead of the whole thing cross-fading as one block.
- **Longer dwell** so the type + reveal has room: rotation 4.4s → 5.6s, click-pause 10s → 12s.
- **Wider hero columns** — trim the split gap (`clamp(32–52px)` → `clamp(24–36px)`) and rebalance columns (`1.1/0.9` → `1.06/0.94`) to cut the middle spacing. Scoped to the hero's internal split; page-level `--landing-max` left alone.
- `prefers-reduced-motion`: command + output render instantly, no typing/stagger.

## Validation

- `tsc -p tsconfig.build.json` → clean
- `biome check` → no errors (only pre-existing CSS specificity warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)