### PR TITLE
[DEMO WORK] Show routed specialist profile pill on fleet session rows

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -684,6 +684,33 @@
   color: var(--fl-faint);
 }
 
+/* profile pill — the specialist Taskforce routed to steer this session.
+   Violet tint keeps it distinct from the tool client chip to its left. */
+.profilePill {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 4px;
+  max-width: 160px;
+  overflow: hidden;
+  padding: 1px 7px 1px 5px;
+  border: 1px solid color-mix(in srgb, #8b5cf6 50%, var(--border));
+  background: color-mix(in srgb, #8b5cf6 14%, var(--background));
+  color: color-mix(in srgb, #8b5cf6 78%, var(--foreground));
+  font-size: calc(10.5px * var(--v2-scale, 1));
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.profilePillIcon {
+  width: calc(11px * var(--v2-scale, 1));
+  height: calc(11px * var(--v2-scale, 1));
+  flex-shrink: 0;
+}
+
 /* roster status */
 .status {
   min-width: 0;

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
 import {
   Archive,
+  Bot,
   ChevronDown,
   ChevronRight,
   GripVertical,
@@ -69,6 +70,8 @@ import {
   agentDisplayName,
   agentKind,
   agentModelName,
+  agentSpecialistName,
+  agentSpecialistRuleCount,
   agentStatus,
   compactPresence,
   type FleetStatus,
@@ -262,6 +265,19 @@ function AgentRow({
   const branch = agent.branch?.trim() || null
   const activity = agentActivityLine(agent)
   const [rowHovered, setRowHovered] = useState(false)
+  // The specialist profile steering this session, if Taskforce routed one.
+  // Prefer the resolved name; fall back to a humanized slug.
+  const specialistSlug = agent.specialist_slug?.trim() || null
+  const profileLabel =
+    agentSpecialistName(agent) ??
+    (specialistSlug
+      ? specialistSlug
+          .split(/[-_]/)
+          .filter(Boolean)
+          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+          .join(" ")
+      : null)
+  const profileRuleCount = agentSpecialistRuleCount(agent)
 
   const submitRename = (event: FormEvent) => {
     event.preventDefault()
@@ -320,6 +336,28 @@ function AgentRow({
               {sessionLabel}
             </div>
             <div className={styles.asub} data-testid="fleet-agent-sub">
+              {profileLabel && (
+                <>
+                  <span
+                    className={styles.profilePill}
+                    data-testid="fleet-agent-profile"
+                    title={
+                      profileRuleCount
+                        ? `Profile: ${profileLabel} · ${profileRuleCount} routing rules`
+                        : `Profile: ${profileLabel}`
+                    }
+                  >
+                    <Bot
+                      className={styles.profilePillIcon}
+                      aria-hidden="true"
+                    />
+                    {profileLabel}
+                  </span>
+                  <span className={styles.asep} aria-hidden="true">
+                    ·
+                  </span>
+                </>
+              )}
               <span className={styles.amodel}>{model}</span>
               {branch && (
                 <>


### PR DESCRIPTION
## Summary
- Adds a violet **profile pill** (Bot icon + specialist name) to each Sessions/Fleet agent row when Taskforce has routed a specialist to that session.
- Pill appears at the start of the sub-line (before model name), with tooltip showing rule count when available.
- Re-applies the intent of stale PR #340 fresh onto current `main` — no backend changes, pure surfacing of existing `specialist_slug` / `specialist_name` fields.

## Test plan
- [x] `npx biome check src/components/V2/Fleet/FleetPage.tsx src/components/V2/Fleet/FleetPage.module.css`
- [x] `npx tsc -p tsconfig.build.json --noEmit`
- [ ] With seeded demo fleet, each agent row shows profile pill (e.g. Jensen) when `specialist_slug` is set
- [ ] Rows without a routed specialist render unchanged (no pill)
- [ ] Pill tooltip shows `Profile: <name> · <n> routing rules` when rule count present

## Notes
- Ticket 2 (collision badge) skipped — requires backend `files_touched` field, out of scope.
- Supersedes PR #340 (stale branch with misleading CI failure).

Made with [Cursor](https://cursor.com)