### PR TITLE
Landing: Mission control framing (redesign is the homepage, Fleet visibility, ROI demoted)

### DIFF
--- a/src/components/Home/HomePage.tsx
+++ b/src/components/Home/HomePage.tsx
@@ -51,12 +51,12 @@ export function HomePage({ mode, signedIn = false, user }: HomePageProps) {
               <div className={styles.heroText}>
                 <p className={styles.greeting}>
                   {isPublic
-                    ? "Working memory for AI-assisted teams"
+                    ? "Mission control for your AI"
                     : `Welcome back, ${displayName}`}
                 </p>
                 <h1 className={styles.heroTitle}>
-                  Taskforce turns the collective knowledge of your company into
-                  reusable workflows for humans and AI.
+                  Taskforce remembers what your agents figure out — and brings
+                  it back to the next one, across every tool.
                 </h1>
                 <p className={styles.heroDescription}>
                   Knowledge that matters is scattered across support tickets,

--- a/src/components/V2/Landing/FeatureSection.tsx
+++ b/src/components/V2/Landing/FeatureSection.tsx
@@ -14,7 +14,7 @@ export function FeatureSection() {
           icon={Boxes}
           id="sessions"
           label="Sessions"
-          title="Orchestration"
+          title="Fleet visibility"
           visual={<SessionsPanel />}
           visualLeft
         />

--- a/src/components/V2/Landing/Hero.tsx
+++ b/src/components/V2/Landing/Hero.tsx
@@ -11,7 +11,7 @@ import styles from "./Landing.module.css"
 const SCENES = [
   {
     key: "Sessions",
-    name: "Orchestration",
+    name: "Fleet visibility",
     phrase: ["losing track", "of your agents."],
   },
   {

--- a/src/components/V2/Landing/ProvenRoi.tsx
+++ b/src/components/V2/Landing/ProvenRoi.tsx
@@ -25,9 +25,9 @@ export function ProvenRoi() {
             </div>
             <h2>Proven ROI</h2>
             <p>
-              Measure the tokens and engineering time your agents save with
-              Taskforce-powered shared context and knowledge. Use a transparent
-              methodology to understand what Taskforce returns across your work.
+              Every reuse is on the record, measured with a transparent
+              methodology — so the value your shared context returns is
+              auditable, not asserted.
             </p>
           </div>
           <div className={styles.visual}>

--- a/src/components/V2/TaskforceLandingPage.tsx
+++ b/src/components/V2/TaskforceLandingPage.tsx
@@ -50,7 +50,7 @@ export function TaskforceLandingPage() {
       <section className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 pb-14 pt-8 md:pt-16">
         <div className="max-w-3xl">
           <p className="mb-4 text-sm font-medium text-muted-foreground">
-            AI work memory for builders
+            Mission control for your AI
           </p>
           <h1 className="max-w-2xl text-5xl font-semibold leading-[1.05] md:text-6xl">
             Taskforce

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
-import { TaskforceLandingPage } from "@/components/V2/TaskforceLandingPage"
+import { LandingPage } from "@/components/V2/Landing/LandingPage"
 import { isLoggedIn } from "@/hooks/useAuth"
 import { getDefaultFrontendPath } from "@/lib/experimentalMode"
 
@@ -14,12 +14,12 @@ export const Route = createFileRoute("/")({
   head: () => ({
     meta: [
       {
-        title: "Taskforce | AI work memory",
+        title: "Taskforce | Mission control for your AI",
       },
     ],
   }),
 })
 
 function Landing() {
-  return <TaskforceLandingPage />
+  return <LandingPage />
 }

--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/landing")({
   head: () => ({
     meta: [
       {
-        title: "Taskforce | AI work memory",
+        title: "Taskforce | Mission control for your AI",
       },
     ],
   }),

--- a/tests/home-docs.spec.ts
+++ b/tests/home-docs.spec.ts
@@ -49,24 +49,12 @@ test("Landing page presents Taskforce V2 as the public product", async ({
 }) => {
   await page.goto("/")
 
-  await expect(page.getByTestId("taskforce-landing")).toBeVisible()
-  await expect(page.getByText("Search", { exact: true })).toHaveCount(0)
+  await expect(page.getByTestId("landing-redesign")).toBeVisible()
   await expect(
-    page.getByRole("heading", { name: "Taskforce", exact: true }),
-  ).toBeVisible()
-  await expect(page.getByText("AI work memory for builders")).toBeVisible()
-  await expect(
-    page.getByTestId("taskforce-landing-demo-disclosure"),
-  ).toContainText("Documents and activity below are example data.")
-  await expect(page.getByText("Library").first()).toBeVisible()
-  await expect(page.getByText("Profiles").first()).toBeVisible()
-  await expect(page.getByText("Metrics").first()).toBeVisible()
-  await expect(page.getByText(/rediscovery avoided/i)).toHaveCount(0)
-  await expect(
-    page.getByRole("link", { name: "Log in", exact: true }),
+    page.getByText("Works with Claude Code, Codex, and Cursor."),
   ).toBeVisible()
   await expect(
-    page.getByRole("link", { name: "Sign up", exact: true }),
+    page.getByRole("link", { name: /start free/i }).first(),
   ).toBeVisible()
   await expect(page.getByText("Browse Topics")).toHaveCount(0)
   await expect(page.getByText("Review Cases")).toHaveCount(0)

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -23,7 +23,7 @@ test("/landing renders the redesigned Taskforce landing page", async ({
   await expect(page.getByText("taskforce", { exact: true })).toBeVisible()
 
   for (const heading of [
-    "Orchestration",
+    "Fleet visibility",
     "Agent identities",
     "Self-maintaining documents",
     "Audit trail",


### PR DESCRIPTION
Updates the landing to the locked north-star framing (`taskforce-northstar.md`).

## Changes
- **`/` now renders the V2/Landing redesign** (was the old `TaskforceLandingPage`, which led with token-savings copy).
- **Tagline + page `<title>`**: "AI work memory" → **"Mission control for your AI"**.
- **"Orchestration" → "Fleet visibility"** (kernel line: we observe/steer, we don't run agents).
- **ROI section reframed** to lead with the record + transparent methodology, not $/tokens saved (anti-goal #3: ROI is proof, not the hero).
- **HomePage hero** off "reusable workflows" → remembers/brings-back framing.
- **e2e specs updated** (`home-docs`, `landing`) to assert the redesign at `/` and the renamed pillar.

Note: old `TaskforceLandingPage.tsx` is now unused (dead code) — safe to delete in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)