### PR TITLE
[codex] Optimize landing page for iPhone viewports

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Chromium
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Build frontend
         run: npm run build

--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
     <meta name="theme-color" content="#8447ff" />
     <meta property="og:image" content="/assets/brand/og-mark.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>AI work memory for engineering teams</title>
   </head>
   <body>

--- a/playwright.mocked.config.ts
+++ b/playwright.mocked.config.ts
@@ -6,6 +6,7 @@ const mockedSpecs = [
   "fleet",
   "home-docs",
   "landing",
+  "landing-mobile",
   "ledger",
   "taskforce-external-links",
   "taskforce-routing",
@@ -34,7 +35,21 @@ export default defineConfig({
   projects: [
     {
       name: "mocked-chromium",
+      testIgnore: /landing-mobile\.spec\.ts$/,
       use: devices["Desktop Chrome"],
+    },
+    {
+      name: "mobile-chromium",
+      testMatch: /landing-mobile\.spec\.ts$/,
+      use: {
+        ...devices["iPhone 15 Pro"],
+        browserName: "chromium",
+      },
+    },
+    {
+      name: "mobile-webkit",
+      testMatch: /landing-mobile\.spec\.ts$/,
+      use: devices["iPhone 15 Pro"],
     },
   ],
   webServer: {

--- a/src/components/V2/Landing/Hero.tsx
+++ b/src/components/V2/Landing/Hero.tsx
@@ -194,9 +194,11 @@ export function LandingHero() {
                 >
                   {SCENES.map((item, index) => (
                     <button
+                      aria-controls={`landing-scene-${item.key.toLowerCase()}`}
                       aria-label={item.key}
                       aria-selected={sceneIndex === index}
                       className={cn(sceneIndex === index && styles.activeDot)}
+                      id={`landing-tab-${item.key.toLowerCase()}`}
                       key={item.key}
                       onClick={() => selectSceneFromDot(index)}
                       role="tab"
@@ -304,7 +306,7 @@ function HeroTerminal({
   }, [command, reducedMotion])
 
   return (
-    <div className={styles.term}>
+    <div className={styles.term} data-testid="landing-terminal">
       <div className={styles.termHead}>
         <span className={styles.termDot} />
         <span className={styles.termName}>tf · taskforce</span>
@@ -322,13 +324,17 @@ function HeroTerminal({
         <div className={styles.termScenes}>
           {scenes.map((scene, index) => (
             <div
+              aria-hidden={sceneIndex !== index || !showOutput}
+              aria-labelledby={`landing-tab-${SCENES[index].key.toLowerCase()}`}
               className={cn(
                 styles.terminalScene,
                 sceneIndex === index &&
                   showOutput &&
                   styles.terminalSceneActive,
               )}
+              id={`landing-scene-${SCENES[index].key.toLowerCase()}`}
               key={scene.key}
+              role="tabpanel"
             >
               {scene}
             </div>

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -1,6 +1,7 @@
 .page {
   --landing-max: clamp(1180px, calc(100vw - 11vw), 1540px);
-  --landing-nav-h: 77px;
+  --landing-safe-top: env(safe-area-inset-top, 0px);
+  --landing-nav-h: calc(77px + var(--landing-safe-top));
   --landing-bg: var(--background);
   --landing-fg: var(--foreground);
   --landing-muted: var(--muted-foreground);
@@ -72,7 +73,7 @@
   align-items: center;
   max-width: var(--landing-max);
   margin: 0 auto;
-  padding: 17.5px 32px;
+  padding: calc(17.5px + var(--landing-safe-top)) 32px 17.5px;
   gap: 35px;
 }
 
@@ -95,6 +96,7 @@
 
 .brand {
   gap: 11px;
+  min-height: 44px;
   font-size: 20px;
 }
 
@@ -217,6 +219,8 @@
   z-index: 1;
   display: grid;
   flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
   grid-template-columns: minmax(0, 1.06fr) minmax(0, 0.94fr);
   align-items: stretch;
   gap: clamp(24px, 2.2vw, 36px);
@@ -228,11 +232,13 @@
   flex-direction: column;
   align-items: stretch;
   width: 100%;
+  min-width: 0;
   margin-top: 7vh;
 }
 
 .heroTerm {
   align-self: end;
+  min-width: 0;
   margin-bottom: 7vh;
 }
 
@@ -288,6 +294,8 @@
   align-items: center;
   gap: 10px;
   margin-bottom: 0;
+  min-width: 0;
+  max-width: 100%;
   color: var(--landing-muted);
   font-family: var(--font-mono);
   font-size: 17px;
@@ -319,9 +327,9 @@
 
 .heroDots button {
   position: relative;
-  flex: 0 0 22px;
-  width: 22px;
-  min-height: 32px;
+  flex: 0 0 44px;
+  width: 44px;
+  min-height: 44px;
   padding: 0;
   border: 0;
   background: transparent;
@@ -332,8 +340,8 @@
 .heroDots button::after {
   position: absolute;
   top: 50%;
-  right: 0;
-  left: 0;
+  right: 8px;
+  left: 8px;
   height: 10px;
   background: var(--landing-border);
   content: "";
@@ -415,6 +423,8 @@
   display: flex;
   overflow: hidden;
   flex-direction: column;
+  width: 100%;
+  min-width: 0;
   border: 1px solid var(--landing-border);
   background: var(--landing-term-bg);
   box-shadow: var(--landing-shadow);
@@ -465,6 +475,7 @@
 .termBody {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   min-height: 360px;
   padding: 18px;
 }
@@ -472,6 +483,8 @@
 .termScenes {
   position: relative;
   flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
   min-height: 298px;
   margin-top: 11px;
 }
@@ -481,6 +494,8 @@
   inset: 0;
   display: flex;
   flex-direction: column;
+  width: 100%;
+  min-width: 0;
   gap: 9px;
   opacity: 0;
   pointer-events: none;
@@ -537,7 +552,7 @@
 
 .field {
   display: grid;
-  grid-template-columns: 80px 1fr;
+  grid-template-columns: 80px minmax(0, 1fr);
   align-items: baseline;
   gap: 12px;
   color: oklch(0.88 0 0);
@@ -1445,6 +1460,7 @@
 
 .footerBrand {
   gap: 11px;
+  min-height: 44px;
   font-size: 20px;
 }
 
@@ -1665,8 +1681,8 @@
 @media (max-width: 560px) {
   .wrap,
   .navInner {
-    padding-right: 20px;
-    padding-left: 20px;
+    padding-right: max(20px, env(safe-area-inset-right, 0px));
+    padding-left: max(20px, env(safe-area-inset-left, 0px));
   }
 
   .navInner {
@@ -1680,6 +1696,45 @@
   .heroCtas {
     flex-direction: column;
     align-items: stretch;
+    width: 100%;
+  }
+
+  .heroCtas .solidButton,
+  .heroCtas .outlineButton {
+    width: 100%;
+  }
+
+  .heroCap {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    font-size: 15px;
+    line-height: 1.4;
+    white-space: normal;
+  }
+
+  .heroDots {
+    gap: 0;
+  }
+
+  .termBody {
+    padding: 14px;
+  }
+
+  .field {
+    grid-template-columns: 68px minmax(0, 1fr);
+    gap: 9px;
+  }
+
+  .ledgerHead,
+  .ledgerRow {
+    grid-template-columns: 48px minmax(0, 0.8fr) minmax(0, 1fr) auto;
+    gap: 6px;
+  }
+
+  .ledgerHead,
+  .ledgerRow,
+  .sessionRow {
+    font-size: 11px;
   }
 
   .agentCards {
@@ -1707,5 +1762,40 @@
   .docSignal {
     grid-column: 2;
     text-align: left;
+  }
+
+  .scrollCue {
+    padding-right: max(20px, env(safe-area-inset-right, 0px));
+    padding-left: max(20px, env(safe-area-inset-left, 0px));
+  }
+
+  .ctaInner {
+    padding-right: max(20px, env(safe-area-inset-right, 0px));
+    padding-left: max(20px, env(safe-area-inset-left, 0px));
+  }
+
+  .footer {
+    padding-bottom: calc(56px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .footerInner {
+    align-items: flex-start;
+    gap: 20px;
+  }
+
+  .footerLinks {
+    flex-basis: 100%;
+    flex-wrap: wrap;
+    gap: 0 20px;
+  }
+
+  .footerLinks a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+  }
+
+  .copyright {
+    margin-left: 0;
   }
 }

--- a/tests/landing-mobile.spec.ts
+++ b/tests/landing-mobile.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test"
+
+const MOBILE_VIEWPORTS = [
+  { height: 852, name: "iPhone 15 Pro", width: 393 },
+  { height: 874, name: "iPhone 17 Pro", width: 402 },
+] as const
+
+const CAPABILITIES = ["Sessions", "Profiles", "Library", "Ledger", "Metrics"]
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test(`${viewport.name} keeps the landing page within the mobile viewport`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(viewport)
+    await page.emulateMedia({ reducedMotion: "reduce" })
+    await page.goto("/landing")
+
+    await expect(page.getByTestId("landing-redesign")).toBeVisible()
+
+    const pageSize = await page.evaluate(() => ({
+      documentWidth: document.documentElement.scrollWidth,
+      viewportWidth: window.innerWidth,
+    }))
+    expect(pageSize.documentWidth).toBeLessThanOrEqual(pageSize.viewportWidth)
+
+    const heroActions = page
+      .locator("section")
+      .first()
+      .getByRole("link", { name: /start free|open taskforce/i })
+
+    await expect(heroActions).toHaveCount(2)
+    for (const action of await heroActions.all()) {
+      const box = await action.boundingBox()
+      expect(box).not.toBeNull()
+      expect(box?.height).toBeGreaterThanOrEqual(44)
+      expect(box?.width).toBeGreaterThanOrEqual(viewport.width - 42)
+      expect(box?.x).toBeGreaterThanOrEqual(0)
+      expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(
+        viewport.width,
+      )
+    }
+
+    const terminal = page.getByTestId("landing-terminal")
+    for (const capability of CAPABILITIES) {
+      const tab = page.getByRole("tab", { name: capability })
+      await expect(tab).toHaveCSS("min-height", "44px")
+      await tab.click()
+
+      const activeScene = terminal.locator(
+        '[role="tabpanel"][aria-hidden="false"]',
+      )
+      await expect(activeScene).toBeVisible()
+      expect(
+        await activeScene.evaluate(
+          (scene) => scene.scrollWidth <= scene.clientWidth + 1,
+        ),
+      ).toBe(true)
+    }
+
+    for (const link of await page.locator("footer a").all()) {
+      const box = await link.boundingBox()
+      expect(box).not.toBeNull()
+      expect(box?.height).toBeGreaterThanOrEqual(44)
+    }
+  })
+}

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -20,7 +20,7 @@ test("/landing renders the redesigned Taskforce landing page", async ({
       name: /stop losing track.*of your agents/i,
     }),
   ).toBeVisible()
-  await expect(page.getByText("taskforce", { exact: true })).toBeVisible()
+  await expect(page.getByText("tf · taskforce", { exact: true })).toBeVisible()
 
   for (const heading of [
     "Fleet visibility",


### PR DESCRIPTION
## What changed

- constrain the landing hero and animated terminal so every capability scene stays inside 393px and 402px iPhone viewports
- make mobile CTAs full-width and expand capability tabs, brand links, and footer links to 44px touch targets
- add iOS safe-area handling with `viewport-fit=cover` and safe-area-aware navigation, content, CTA, and footer spacing
- connect capability tabs to accessible tab panels and hide inactive terminal scenes from assistive technology
- add dedicated iPhone 15 Pro (393×852) and iPhone 17 Pro (402×874) Playwright coverage in Chromium and WebKit
- install WebKit in frontend CI so Safari behavior remains covered

## Why

The generic mobile breakpoint clipped terminal content for several rotating scenes and allowed grid min-content sizing to extend beyond the viewport. Mobile actions and navigation targets also did not consistently meet a 44px touch target, and Safari safe areas were not explicitly handled.

## User impact

The public landing page now remains horizontally contained across every hero state on the target iPhones in Chrome and Safari/WebKit, with larger touch targets and safe spacing around device insets.

## Validation

- production build: `bun run build`
- targeted landing suite: 2 passed
- iPhone mobile Chromium suite: 2 passed
- iPhone mobile WebKit suite: 2 passed
- full mocked suite: 84 tests run; three unrelated Fleet/routing flakes passed on immediate isolated rerun
- Biome check on changed files (passes with the five pre-existing selector-order warnings in `Landing.module.css`)
- `git diff --check`
