### PR TITLE
[codex] Keep mobile landing carousel spacing stable

### DIFF
--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -1706,7 +1706,10 @@
 
   .heroCap {
     align-items: flex-start;
+    align-content: flex-start;
     flex-wrap: wrap;
+    min-height: 42px;
+    gap: 0 8px;
     font-size: 15px;
     line-height: 1.4;
     white-space: normal;

--- a/tests/landing-mobile.spec.ts
+++ b/tests/landing-mobile.spec.ts
@@ -41,6 +41,7 @@ for (const viewport of MOBILE_VIEWPORTS) {
     }
 
     const terminal = page.getByTestId("landing-terminal")
+    const terminalTopByCapability: number[] = []
     for (const capability of CAPABILITIES) {
       const tab = page.getByRole("tab", { name: capability })
       await expect(tab).toHaveCSS("min-height", "44px")
@@ -55,7 +56,16 @@ for (const viewport of MOBILE_VIEWPORTS) {
           (scene) => scene.scrollWidth <= scene.clientWidth + 1,
         ),
       ).toBe(true)
+      terminalTopByCapability.push(
+        await terminal.evaluate(
+          (element) => element.getBoundingClientRect().top,
+        ),
+      )
     }
+    expect(
+      Math.max(...terminalTopByCapability) -
+        Math.min(...terminalTopByCapability),
+    ).toBeLessThanOrEqual(1)
 
     for (const link of await page.locator("footer a").all()) {
       const box = await link.boundingBox()


### PR DESCRIPTION
## What changed

- reserve a consistent two-line height for the mobile capability label
- remove the flex row gap when the Library label wraps
- assert that the hero terminal keeps the same vertical position across all five carousel states on both target iPhone viewports

## Why

The “Library · Self-maintaining documents” label wraps to two lines on mobile. Other capability labels fit on one line, so switching to Library increased the label row height and pushed every element below it down.

## User impact

Cycling through the landing-page capabilities no longer causes the hero actions or terminal to jump vertically on mobile.

## Validation

- iPhone 15 Pro and iPhone 17 Pro mobile Chromium tests: 2 passed
- iPhone 15 Pro and iPhone 17 Pro mobile WebKit tests: 2 passed
- production build: `bun run build`
- Biome check on touched files (five pre-existing selector-order warnings remain in the landing stylesheet)
- `git diff --check`
