### PR TITLE
Stop repeating agent name in Fleet reply UI

### DIFF
--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -191,7 +191,7 @@ function AgentReplyPanel({ agent }: { agent: TaskforceFleetAgent }) {
               submit()
             }
           }}
-          placeholder={`Reply to ${agentDisplayName(agent)}…`}
+          placeholder="Send a prompt…"
           aria-label="Reply to agent"
           disabled={enqueue.isPending}
         />
@@ -412,7 +412,7 @@ function FleetAgentDetailRoute() {
                 <div className={styles.question}>
                   <div className={styles.questionText}>
                     {question ??
-                      `${agentDisplayName(agent)} is idle. Send a prompt to pick up where it left off.`}
+                      "This agent is idle. Send a prompt to pick up where it left off."}
                   </div>
                   <AgentReplyPanel agent={agent} />
                 </div>


### PR DESCRIPTION
## Summary
- Use generic "Send a prompt…" placeholder instead of echoing the long display name
- Use generic idle copy so the session title only appears in the header

## Test plan
- [x] Manual: open `/v2/fleet/$sessionId` for a waiting agent and confirm placeholder/idle text are generic

Made with [Cursor](https://cursor.com)