### PR TITLE
Make detail-page back buttons return to where you came from

### DIFF
--- a/src/components/V2/BackLink.tsx
+++ b/src/components/V2/BackLink.tsx
@@ -1,0 +1,63 @@
+import { Link, useCanGoBack, useRouter } from "@tanstack/react-router"
+import type { ReactNode } from "react"
+
+type BackLinkProps = {
+  /**
+   * Canonical parent route, used only when there is no in-app history to step
+   * back through (deep link, refresh, or a freshly opened tab).
+   */
+  to: string
+  /** Label shown when falling back to the canonical parent (e.g. "Library"). */
+  fallbackLabel: ReactNode
+  /**
+   * Label shown when we step back to wherever the user actually came from.
+   * Kept generic ("Back") so it stays honest regardless of the origin page.
+   */
+  backLabel?: ReactNode
+  /** Optional leading icon, rendered in both the button and link variants. */
+  icon?: ReactNode
+  className?: string
+  "data-testid"?: string
+}
+
+/**
+ * Context-aware back affordance for detail pages.
+ *
+ * When the user reached this page via an in-app cross-link (e.g. a fleet agent
+ * → a document it wrote), "back" returns them to that origin via the router
+ * history instead of dumping them at the object's top-level list page. When
+ * there is no history to step back through, it degrades to a normal link to the
+ * canonical parent so deep links and refreshes still have a sensible target.
+ */
+export function BackLink({
+  to,
+  fallbackLabel,
+  backLabel = "Back",
+  icon,
+  className,
+  "data-testid": testId,
+}: BackLinkProps) {
+  const router = useRouter()
+  const canGoBack = useCanGoBack()
+
+  if (canGoBack) {
+    return (
+      <button
+        type="button"
+        onClick={() => router.history.back()}
+        className={className}
+        data-testid={testId}
+      >
+        {icon}
+        {backLabel}
+      </button>
+    )
+  }
+
+  return (
+    <Link to={to} className={className} data-testid={testId}>
+      {icon}
+      {fallbackLabel}
+    </Link>
+  )
+}

--- a/src/routes/v2/agents.$slug.tsx
+++ b/src/routes/v2/agents.$slug.tsx
@@ -37,6 +37,7 @@ import {
   formatCompactNumber,
   formatRelativeTime,
 } from "@/components/V2/Agents/formatters"
+import { BackLink } from "@/components/V2/BackLink"
 import { QueryErrorState } from "@/components/V2/QueryErrorState"
 import {
   V2_PAGE_BODY,
@@ -502,9 +503,11 @@ function AgentDetailPage() {
         >
           <div>
             <div className={AGENT_BREADCRUMB_CLASS}>
-              <Link to="/v2/agents" className="hover:text-foreground">
-                Profiles
-              </Link>
+              <BackLink
+                to="/v2/agents"
+                fallbackLabel="Profiles"
+                className="hover:text-foreground"
+              />
               <span className="px-2 text-muted-foreground/50">/</span>
               <span className="text-foreground">{agent.slug}</span>
             </div>

--- a/src/routes/v2/fleet.$sessionId.tsx
+++ b/src/routes/v2/fleet.$sessionId.tsx
@@ -14,6 +14,7 @@ import {
   type TaskforceSessionActivityEntry,
 } from "@/api/v2Taskforce"
 import { Button } from "@/components/ui/button"
+import { BackLink } from "@/components/V2/BackLink"
 import { ActivityProse } from "@/components/V2/Fleet/ActivityProse"
 import styles from "@/components/V2/Fleet/FleetPage.module.css"
 import { useFleetPulseSync } from "@/components/V2/Fleet/fleetPulseSync"
@@ -336,10 +337,12 @@ function FleetAgentDetailRoute() {
       >
         <div className={cn(styles.dtop, V2_STICKY_HEADER_CLASS, "border-b-0")}>
           <div className={styles.crumb}>
-            <Link to="/v2/fleet" className={styles.back}>
-              <ChevronLeft />
-              Sessions
-            </Link>
+            <BackLink
+              to="/v2/fleet"
+              fallbackLabel="Sessions"
+              icon={<ChevronLeft />}
+              className={styles.back}
+            />
             <span className={styles.sep}>/</span>
             <span>{fleetName}</span>
           </div>

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -69,6 +69,7 @@ import {
   formatCompactNumber,
   formatRelativeTime,
 } from "@/components/V2/Agents/formatters"
+import { BackLink } from "@/components/V2/BackLink"
 import {
   FolderCreateDialog,
   FolderPickerDropdown,
@@ -941,14 +942,13 @@ function TaskforceDocumentDetail() {
         >
           <div className="flex items-center justify-between gap-3 font-mono text-[0.66rem] tracking-[0.01em] text-muted-foreground">
             <div className="flex min-w-0 items-center gap-2">
-              <Link
+              <BackLink
                 to="/v2/library"
+                fallbackLabel="Library"
+                icon={<ArrowLeft className="size-3" />}
                 data-testid="v2-document-back-link"
                 className="inline-flex items-center gap-1 hover:text-foreground"
-              >
-                <ArrowLeft className="size-3" />
-                <span>Library</span>
-              </Link>
+              />
               <span className="text-border">/</span>
               <span className="truncate">
                 {document.folder_name ?? "Unfiled"}

--- a/src/routes/v2/metrics.methodology.tsx
+++ b/src/routes/v2/metrics.methodology.tsx
@@ -1,7 +1,8 @@
-import { createFileRoute, Link } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { ArrowLeft } from "lucide-react"
 import type { ReactNode } from "react"
 
+import { BackLink } from "@/components/V2/BackLink"
 import methodologyRaw from "@/components/V2/Metrics/methodology.md?raw"
 import { V2_PAGE_CONTENT } from "@/components/V2/v2PageShell"
 
@@ -20,13 +21,13 @@ function MetricsMethodology() {
   return (
     <div className={V2_PAGE_CONTENT}>
       <div className="mx-auto flex w-full min-w-0 max-w-3xl flex-col gap-6">
-        <Link
+        <BackLink
           to="/v2/metrics"
+          fallbackLabel="Back to Metrics"
+          backLabel="Back to Metrics"
+          icon={<ArrowLeft className="size-4" />}
           className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="size-4" />
-          Back to Metrics
-        </Link>
+        />
         <article className="pb-8 text-sm leading-6 text-foreground">
           <Markdown source={methodologyRaw} />
         </article>


### PR DESCRIPTION
## Problem

Clicking into an object from a cross-link and then hitting **back** dumps you at the object's top-level list page instead of where you came from. The reported case: a fleet agent writes a document → you click into the document → the back button takes you to the **Library**, not back to the **agent**. Cumbersome anywhere pages cross-link.

The four detail pages all hardcoded their back affordance to their canonical parent:

| Page | Back went to (always) |
|------|----------------------|
| `library/$documentId` | Library |
| `fleet/$sessionId` | Sessions |
| `agents/$slug` | Profiles |
| `metrics/methodology` | Metrics |

## Fix

New shared `BackLink` component (`src/components/V2/BackLink.tsx`):

- When there **is** in-app history to step back through (you arrived via a cross-link), it renders a button that calls `router.history.back()` and shows a generic **"Back"** label — so you return to the actual origin (the agent, a search, the ledger, wherever).
- When there **isn't** (deep link, refresh, freshly opened tab), it degrades to a normal `<Link>` to the canonical parent with the original label — so those entry points still have a sensible target.

Uses TanStack Router's `useCanGoBack()` to decide. Applied to all four detail pages so the behavior is consistent everywhere there are cross-links. No cross-link call sites had to change.

## Validation

- `tsc -p tsconfig.build.json --noEmit` — clean
- `biome check` on changed lines — clean
- production build (`vite build`) — succeeds

Note: the local Playwright harness has a pre-existing failure (unrelated empty-state assertion, reproduces identically on `origin/main`) and the env runs Node 18, so the full e2e suite wasn't run here. The existing `v2-document-back-link` test id is preserved on both render branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)