### PR TITLE
Sessions: compact hover card + drop activity marquee

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -603,34 +603,113 @@
   color: var(--muted-foreground);
 }
 
+/* Live activity preview — truncated in the row; the full text lives in the
+   hover card (.hovercard) so the row stays terse and never animates. */
 .aactivity {
   overflow: hidden;
   flex: 1;
   min-width: 0;
-  padding-left: var(--activity-fade, 12px);
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
-.aactivityMarquee {
-  --activity-fade: 12px;
-  --activity-end-inset: calc(var(--activity-fade) + 4px);
-  mask-image: linear-gradient(
-    90deg,
-    transparent 0,
-    #000 var(--activity-fade),
-    #000 calc(100% - var(--activity-fade)),
-    transparent 100%
-  );
+/* ---------- agent hover card (compact) ---------- */
+/* Portaled to <body> and positioned at the cursor imperatively, so it is fixed
+   and laid out from the top-left corner via transform. */
+.hovercard {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 60;
+  pointer-events: none;
+  will-change: transform;
 }
 
-.aactivityTrack {
-  display: inline-block;
+.hcInner {
+  transform-origin: top left;
+  animation: hcIn 0.14s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes hcIn {
+  from {
+    opacity: 0;
+    transform: translateY(7px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.hcCard {
+  width: 256px;
+  border: 1px solid var(--border);
+  background: var(--popover);
+  color: var(--popover-foreground);
+  box-shadow:
+    0 18px 50px -18px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(0, 0, 0, 0.06);
+}
+
+.hcTop {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 13px 0;
+}
+
+.hcName {
+  flex: 1;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: calc(11px * var(--v2-scale, 1));
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
-.aactivityTrackScroll {
-  padding-right: var(--activity-end-inset, 16px);
-  transition: transform var(--activity-motion-duration, 0.25s) ease-in-out;
+.hcTitle {
+  padding: 8px 13px 0;
+  font-size: calc(13px * var(--v2-scale, 1));
+  font-weight: 500;
+  line-height: 1.35;
+  letter-spacing: -0.005em;
+}
+
+.hcAct {
+  display: flex;
+  gap: 6px;
+  margin: 10px 13px 0;
+  padding-top: 9px;
+  border-top: 1px solid var(--fl-hair);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: calc(11px * var(--v2-scale, 1));
+  line-height: 1.45;
+}
+
+.hcCaret {
+  flex-shrink: 0;
+  color: var(--primary);
+}
+
+.hcRows {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 12px;
+  padding: 9px 13px 12px;
+  font-family: var(--font-mono);
+  font-size: calc(11px * var(--v2-scale, 1));
+}
+
+.hcKey {
+  color: var(--fl-faint);
+}
+
+.hcVal {
+  overflow-wrap: anywhere;
+  color: var(--foreground);
+  text-align: right;
 }
 
 /* client chip — which coding tool drives the session. Fixed width so the chips
@@ -1517,11 +1596,9 @@
     animation: none;
   }
 
-  .aactivityTrackScroll {
+  .hovercard,
+  .hcInner {
+    animation: none;
     transition: none;
-  }
-
-  .aactivity {
-    text-overflow: ellipsis;
   }
 }

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -13,14 +13,15 @@ import {
   Trash2,
 } from "lucide-react"
 import {
-  type CSSProperties,
   type DragEvent,
   type FormEvent,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react"
+import { createPortal } from "react-dom"
 import {
   assignTaskforceFleetSession,
   createTaskforceFleetSession,
@@ -76,6 +77,7 @@ import {
   compactPresence,
   type FleetStatus,
   fleetTitle,
+  formatClockTime,
   rosterStatusLabel,
   runningCount,
   waitingCount,
@@ -158,79 +160,75 @@ function ClientChip({ kind }: { kind: AgentKind }) {
   )
 }
 
-function ActivityMarquee({
-  activity,
-  active,
+// Compact detail card shown while hovering an agent row. Rendered into a body
+// portal and positioned next to the cursor (see AgentRow.placeCard), so the row
+// itself can stay terse — the full activity line and meta live here instead of
+// scrolling inside the row.
+function AgentHoverCard({
+  agent,
+  fleetName,
+  cardRef,
 }: {
-  activity: string
-  active: boolean
+  agent: TaskforceFleetAgent
+  fleetName: string
+  cardRef: React.RefObject<HTMLDivElement | null>
 }) {
-  const containerRef = useRef<HTMLSpanElement>(null)
-  const trackRef = useRef<HTMLSpanElement>(null)
-  const [scrollDistance, setScrollDistance] = useState(0)
+  const status = agentStatus(agent)
+  const title = agentDisplayName(agent)
+  const model = agentModelName(agent)
+  const branch = agent.branch?.trim() || null
+  const activity = agentActivityLine(agent)
+  const started = agent.started_at ? formatClockTime(agent.started_at) : null
+  const presence = compactPresence(agent)
 
-  useEffect(() => {
-    const container = containerRef.current
-    const track = trackRef.current
-    if (!container || !track) return
-
-    const measure = () => {
-      const overflow = track.scrollWidth - container.clientWidth
-      setScrollDistance(overflow > 4 ? overflow : 0)
-    }
-
-    measure()
-    const observer = new ResizeObserver(measure)
-    observer.observe(container)
-    observer.observe(track)
-    return () => observer.disconnect()
-  }, [])
-
-  const scrolls = scrollDistance > 0
-  const forwardDuration = scrolls
-    ? Math.max(1.6, (scrollDistance / 32 + 2) / 2.5)
-    : 0
-  const rewindDuration = forwardDuration / 6
-
-  const marqueeStyle = scrolls
-    ? ({
-        "--activity-scroll": `${scrollDistance}px`,
-        "--activity-fade": "12px",
-      } as CSSProperties)
-    : undefined
-
-  const trackStyle = scrolls
-    ? ({
-        "--activity-motion-duration": `${active ? forwardDuration : rewindDuration}s`,
-        transform: active
-          ? "translateX(calc(-1 * var(--activity-scroll, 0px)))"
-          : "translateX(0)",
-      } as CSSProperties)
-    : undefined
-
-  return (
-    <span
-      ref={containerRef}
-      className={cn(styles.aactivity, scrolls && styles.aactivityMarquee)}
-      style={marqueeStyle}
-      title={activity}
-    >
-      <span
-        ref={trackRef}
-        className={cn(
-          styles.aactivityTrack,
-          scrolls && styles.aactivityTrackScroll,
-        )}
-        style={trackStyle}
-      >
-        {activity}
-      </span>
-    </span>
+  return createPortal(
+    <div ref={cardRef} className={styles.hovercard} role="tooltip">
+      <div className={styles.hcInner}>
+        <div className={styles.hcCard}>
+          <div className={styles.hcTop}>
+            <ClientChip kind={agentKind(agent)} />
+            <span className={styles.hcName}>{fleetName}</span>
+            <StatusDot status={status} />
+          </div>
+          <div className={styles.hcTitle}>{title}</div>
+          {activity && (
+            <div className={styles.hcAct}>
+              <span className={styles.hcCaret} aria-hidden="true">
+                ▸
+              </span>
+              <span>{activity}</span>
+            </div>
+          )}
+          <div className={styles.hcRows}>
+            <span className={styles.hcKey}>status</span>
+            <span className={styles.hcVal}>{rosterStatusLabel(agent)}</span>
+            <span className={styles.hcKey}>model</span>
+            <span className={styles.hcVal}>{model}</span>
+            {branch && (
+              <>
+                <span className={styles.hcKey}>branch</span>
+                <span className={styles.hcVal}>{branch}</span>
+              </>
+            )}
+            {started && (
+              <>
+                <span className={styles.hcKey}>started</span>
+                <span className={styles.hcVal}>{started}</span>
+              </>
+            )}
+            <span className={styles.hcKey}>active</span>
+            <span className={styles.hcVal}>{presence}</span>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
   )
 }
 
 function AgentRow({
   agent,
+  fleetName,
   onOpen,
   onRename,
   onArchive,
@@ -242,6 +240,7 @@ function AgentRow({
   draggable = true,
 }: {
   agent: TaskforceFleetAgent
+  fleetName: string
   onOpen: (agent: TaskforceFleetAgent) => void
   onRename: (agent: TaskforceFleetAgent, displayName: string) => void
   onArchive: (agent: TaskforceFleetAgent) => void
@@ -279,6 +278,44 @@ function AgentRow({
       : null)
   const profileRuleCount = agentSpecialistRuleCount(agent)
 
+  // Cursor-following hover card. We track the latest pointer position in a ref
+  // and reposition the portal element imperatively, so following the cursor
+  // never triggers a React re-render.
+  const hoverCardRef = useRef<HTMLDivElement>(null)
+  const lastPointer = useRef({ x: 0, y: 0 })
+
+  const placeCard = useCallback(() => {
+    const el = hoverCardRef.current
+    if (!el) return
+    const { x, y } = lastPointer.current
+    const margin = 10
+    const offset = 18
+    const width = el.offsetWidth
+    const height = el.offsetHeight
+    let nextX = x + offset
+    let nextY = y + offset
+    if (nextX + width > window.innerWidth - margin) nextX = x - width - offset
+    if (nextX < margin) nextX = margin
+    if (nextY + height > window.innerHeight - margin)
+      nextY = y - height - offset
+    if (nextY < margin) nextY = margin
+    el.style.transform = `translate(${nextX}px, ${nextY}px)`
+  }, [])
+
+  // Position before paint when the card mounts so it never flashes at (0,0).
+  useLayoutEffect(() => {
+    if (rowHovered) placeCard()
+  }, [rowHovered, placeCard])
+
+  // A fixed card detaches from the row on scroll, so dismiss it instead.
+  useEffect(() => {
+    if (!rowHovered) return
+    const dismiss = () => setRowHovered(false)
+    window.addEventListener("scroll", dismiss, { capture: true, passive: true })
+    return () =>
+      window.removeEventListener("scroll", dismiss, { capture: true })
+  }, [rowHovered])
+
   const submitRename = (event: FormEvent) => {
     event.preventDefault()
     const nextName = renameValue.trim()
@@ -302,7 +339,14 @@ function AgentRow({
       )}
       draggable={draggable && !isMoving}
       title={draggable ? undefined : "View this agent session"}
-      onMouseEnter={() => setRowHovered(true)}
+      onMouseEnter={(event) => {
+        lastPointer.current = { x: event.clientX, y: event.clientY }
+        setRowHovered(true)
+      }}
+      onMouseMove={(event) => {
+        lastPointer.current = { x: event.clientX, y: event.clientY }
+        if (rowHovered) placeCard()
+      }}
       onMouseLeave={() => setRowHovered(false)}
       onDragStart={(event) => {
         suppressClick.current = true
@@ -372,7 +416,9 @@ function AgentRow({
                   <span className={styles.asep} aria-hidden="true">
                     ·
                   </span>
-                  <ActivityMarquee activity={activity} active={rowHovered} />
+                  <span className={styles.aactivity} title={activity}>
+                    {activity}
+                  </span>
                 </>
               )}
             </div>
@@ -470,6 +516,14 @@ function AgentRow({
           </form>
         </DialogContent>
       </Dialog>
+
+      {rowHovered && !isDragging && !isMoving && (
+        <AgentHoverCard
+          agent={agent}
+          fleetName={fleetName}
+          cardRef={hoverCardRef}
+        />
+      )}
     </fieldset>
   )
 }
@@ -668,6 +722,7 @@ function FleetCard({
               <AgentRow
                 key={agent.session_id}
                 agent={agent}
+                fleetName={fleetTitle(fleet)}
                 onOpen={onOpenAgent}
                 onRename={onRenameAgent}
                 onArchive={onArchiveAgent}


### PR DESCRIPTION
## What

Implements the **compact** hover-card from the Sessions redesign mockup (`mockups/sessions/Sessions redesign.html`) on the Fleet/Sessions roster, and removes the scrolling activity marquee from the agent row.

- **Compact hover card** — hovering an agent row shows a small detail card that follows the cursor. It surfaces the harness chip, fleet/session name, status dot, agent title, the **full** live-activity line, and a `model / branch / started / active` meta grid. Rendered into a `<body>` portal, positioned imperatively (so cursor-follow never triggers a re-render), edge-flips near the viewport, and dismisses on scroll.
- **No view-switcher scaffolding** — only the compact variant, per the request (the mockup's Preview/Terminal toggle is omitted).
- **Drop the row marquee** — now that the full activity lives in the card, the in-row activity line no longer scrolls on hover. `ActivityMarquee` and its marquee CSS are replaced by a plain ellipsis-truncated span.

## Notes

- Styling uses the existing design tokens (`--popover`, `--border`, `--font-mono`, `--v2-scale`, …) so it tracks light/dark themes.
- Honors `prefers-reduced-motion`.

## Validation

- `tsc -p tsconfig.build.json` ✓
- `biome check` ✓
- `vite build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)