### PR TITLE
Remove Sessions agent row subline

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -556,18 +556,12 @@
   align-items: center;
   gap: 12px;
   min-width: 0;
-}
-
-.identity {
-  display: flex;
   flex: 1;
-  min-width: 0;
-  flex-direction: column;
-  gap: 3px;
 }
 
 .nm {
   overflow: hidden;
+  flex: 1;
   min-width: 0;
   color: var(--foreground);
   font-size: calc(14px * var(--v2-scale, 1));
@@ -577,40 +571,6 @@
   text-overflow: ellipsis;
   text-transform: none;
   white-space: nowrap;
-}
-
-/* second identity line — model · branch · live activity */
-.asub {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: 8px;
-  color: var(--fl-faint);
-  font-family: var(--font-mono);
-  font-size: calc(11px * var(--v2-scale, 1));
-  line-height: 1.35;
-  white-space: nowrap;
-}
-
-.asep {
-  flex-shrink: 0;
-  color: color-mix(in srgb, var(--fl-faint) 55%, var(--background));
-}
-
-.amodel,
-.abranch {
-  flex-shrink: 0;
-  color: var(--muted-foreground);
-}
-
-/* Live activity preview — truncated in the row; the full text lives in the
-   hover card (.hovercard) so the row stays terse and never animates. */
-.aactivity {
-  overflow: hidden;
-  flex: 1;
-  min-width: 0;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
 /* ---------- agent hover card (compact) ---------- */
@@ -775,33 +735,6 @@
   border-color: var(--border);
   background: transparent;
   color: var(--fl-faint);
-}
-
-/* profile pill — the specialist Taskforce routed to steer this session.
-   Violet tint keeps it distinct from the tool client chip to its left. */
-.profilePill {
-  display: inline-flex;
-  flex-shrink: 0;
-  align-items: center;
-  gap: 4px;
-  max-width: 160px;
-  overflow: hidden;
-  padding: 1px 7px 1px 5px;
-  border: 1px solid color-mix(in srgb, #8b5cf6 50%, var(--border));
-  background: color-mix(in srgb, #8b5cf6 14%, var(--background));
-  color: color-mix(in srgb, #8b5cf6 78%, var(--foreground));
-  font-size: calc(10.5px * var(--v2-scale, 1));
-  font-weight: 600;
-  line-height: 1.4;
-  letter-spacing: 0.01em;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.profilePillIcon {
-  width: calc(11px * var(--v2-scale, 1));
-  height: calc(11px * var(--v2-scale, 1));
-  flex-shrink: 0;
 }
 
 /* roster status */

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -2,7 +2,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
 import {
   Archive,
-  Bot,
   ChevronDown,
   ChevronRight,
   GripVertical,
@@ -71,8 +70,6 @@ import {
   agentDisplayName,
   agentKind,
   agentModelName,
-  agentSpecialistName,
-  agentSpecialistRuleCount,
   agentStatus,
   compactPresence,
   type FleetStatus,
@@ -260,23 +257,7 @@ function AgentRow({
   const status = agentStatus(agent)
   const age = compactPresence(agent)
   const sessionLabel = agentDisplayName(agent)
-  const model = agentModelName(agent)
-  const branch = agent.branch?.trim() || null
-  const activity = agentActivityLine(agent)
   const [rowHovered, setRowHovered] = useState(false)
-  // The specialist profile steering this session, if Taskforce routed one.
-  // Prefer the resolved name; fall back to a humanized slug.
-  const specialistSlug = agent.specialist_slug?.trim() || null
-  const profileLabel =
-    agentSpecialistName(agent) ??
-    (specialistSlug
-      ? specialistSlug
-          .split(/[-_]/)
-          .filter(Boolean)
-          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-          .join(" ")
-      : null)
-  const profileRuleCount = agentSpecialistRuleCount(agent)
 
   // Cursor-following hover card. We track the latest pointer position in a ref
   // and reposition the portal element imperatively, so following the cursor
@@ -375,53 +356,8 @@ function AgentRow({
         </span>
         <div className={styles.who}>
           <ClientChip kind={agentKind(agent)} />
-          <div className={styles.identity}>
-            <div className={styles.nm} data-testid="fleet-agent-name">
-              {sessionLabel}
-            </div>
-            <div className={styles.asub} data-testid="fleet-agent-sub">
-              {profileLabel && (
-                <>
-                  <span
-                    className={styles.profilePill}
-                    data-testid="fleet-agent-profile"
-                    title={
-                      profileRuleCount
-                        ? `Profile: ${profileLabel} · ${profileRuleCount} routing rules`
-                        : `Profile: ${profileLabel}`
-                    }
-                  >
-                    <Bot
-                      className={styles.profilePillIcon}
-                      aria-hidden="true"
-                    />
-                    {profileLabel}
-                  </span>
-                  <span className={styles.asep} aria-hidden="true">
-                    ·
-                  </span>
-                </>
-              )}
-              <span className={styles.amodel}>{model}</span>
-              {branch && (
-                <>
-                  <span className={styles.asep} aria-hidden="true">
-                    ·
-                  </span>
-                  <span className={styles.abranch}>{branch}</span>
-                </>
-              )}
-              {activity && (
-                <>
-                  <span className={styles.asep} aria-hidden="true">
-                    ·
-                  </span>
-                  <span className={styles.aactivity} title={activity}>
-                    {activity}
-                  </span>
-                </>
-              )}
-            </div>
+          <div className={styles.nm} data-testid="fleet-agent-name">
+            {sessionLabel}
           </div>
         </div>
         <div

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -369,7 +369,7 @@ test("Fleet renders the calm roster from live API data", async ({ page }) => {
     historyCard.getByText(/feature\/new-user-max-promo/),
   ).toHaveCount(0)
   await expect(page.getByTestId("fleet-card-fleet-1")).toContainText(
-    "feature/automatic-tax",
+    "Wiring automatic tax on Stripe checkout",
   )
 
   // New fleet creates a nameless fleet (no request body).


### PR DESCRIPTION
## Summary
- Drop the second line under each agent name (profile pill, model, branch, activity preview)
- Row is now client chip + display name + status; details stay in the hover card

## Test plan
- [x] Updated fleet e2e assertion to match row content

Made with [Cursor](https://cursor.com)