### PR TITLE
Set Sessions hover card to 384px

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -602,8 +602,8 @@
 }
 
 .hcCard {
-  width: 512px;
-  max-width: min(512px, calc(100vw - 24px));
+  width: 384px;
+  max-width: min(384px, calc(100vw - 24px));
   overflow: hidden;
   border: 1px solid var(--border);
   background: var(--popover);


### PR DESCRIPTION
## Summary
- Reduce hover card width from 512px to 384px (25% narrower)

## Test plan
- [x] Hover a Sessions row and confirm card width feels balanced

Made with [Cursor](https://cursor.com)