### PR TITLE
Polish Sessions idle copy, ROI layout, and library dividers

### DIFF
--- a/src/components/V2/Landing/ProvenRoi.tsx
+++ b/src/components/V2/Landing/ProvenRoi.tsx
@@ -15,7 +15,7 @@ export function ProvenRoi() {
   return (
     <section className={styles.features} id="metrics">
       <div className={styles.wrap}>
-        <div className={cn(styles.featureRow, styles.proofRow)}>
+        <div className={cn(styles.featureRow, styles.proofRow, styles.visualLeft)}>
           <div className={styles.featureCopy}>
             <div className={styles.featureLabel}>
               <span className={styles.featureIcon}>

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -936,10 +936,11 @@ function TaskforceDocumentDetail() {
         <div
           data-testid="v2-document-sticky-header"
           className={cn(
-            "sticky top-0 z-30 -mx-6 border-b bg-background px-6 pt-1 pb-3",
+            "sticky top-0 z-30 -mx-6 bg-background px-6 pt-1",
             isSplit && "md:shrink-0",
           )}
         >
+          <div className="border-b border-border pb-3">
           <div className="flex items-center justify-between gap-3 font-mono text-[0.66rem] tracking-[0.01em] text-muted-foreground">
             <div className="flex min-w-0 items-center gap-2">
               <BackLink
@@ -1089,6 +1090,7 @@ function TaskforceDocumentDetail() {
               </div>
             }
           />
+          </div>
         </div>
 
         <FolderCreateDialog

--- a/src/routes/v2/sessions.$sessionId.tsx
+++ b/src/routes/v2/sessions.$sessionId.tsx
@@ -415,7 +415,7 @@ function FleetAgentDetailRoute() {
                 <div className={styles.question}>
                   <div className={styles.questionText}>
                     {question ??
-                      "This agent is idle. Send a prompt to pick up where it left off."}
+                      "This agent is idle. Send a prompt to continue."}
                   </div>
                   <AgentReplyPanel agent={agent} />
                 </div>

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -393,7 +393,7 @@ test("clicking an agent row opens the session detail and back returns", async ({
     .first()
     .click()
 
-  await expect(page).toHaveURL(/\/v2\/fleet\/session-1$/)
+  await expect(page).toHaveURL(/\/v2\/sessions\/session-1$/)
   await expect(
     page.getByRole("heading", {
       name: "Wiring automatic tax on Stripe checkout",
@@ -414,7 +414,7 @@ test("clicking an agent row opens the session detail and back returns", async ({
 
   // Breadcrumb returns to the roster.
   await page.getByRole("link", { name: "Sessions" }).first().click()
-  await expect(page).toHaveURL(/\/v2\/fleet$/)
+  await expect(page).toHaveURL(/\/v2\/sessions$/)
   await expect(page.getByText("stripe-checkout", { exact: true })).toBeVisible()
 })
 
@@ -438,7 +438,9 @@ test("agent session can be renamed from the row menu", async ({ page }) => {
   expect((await renameRequest).postDataJSON()).toEqual({
     display_name: "Checkout tax rollout",
   })
-  await expect(page.getByText("Checkout tax rollout")).toBeVisible()
+  await expect(page.getByTestId("fleet-agent-name")).toHaveText(
+    "Checkout tax rollout",
+  )
 })
 
 test("agent session can be archived from the row menu", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Update the idle Sessions detail message to "Send a prompt to continue."
- Flip the Proven ROI landing section so the metrics terminal sits on the left for visual balance with Audit trail above it.
- Inset the library document sticky header divider so it matches the Sessions / Reused by strip width.

## Test plan
- [x] Frontend changes are copy/layout only
- [ ] Verify Sessions detail idle/waiting copy in the UI
- [ ] Verify landing Proven ROI section layout on desktop
- [ ] Verify library document header dividers align

Made with [Cursor](https://cursor.com)