### PR TITLE
Move Sessions archive action to inline row button

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -34,7 +34,7 @@
 }
 
 .fleet {
-  --fl-row-cols: 26px minmax(0, 1fr) max-content 2.75rem 40px;
+  --fl-row-cols: 26px minmax(0, 1fr) max-content 2.75rem max-content;
   --fl-row-gap: 18px;
   border: 1px solid var(--border);
   background: var(--fl-surface);
@@ -450,9 +450,17 @@
   cursor: pointer;
 }
 
-.arowMenu {
+.arowActions {
+  display: flex;
   grid-column: 5;
+  align-items: center;
+  gap: 2px;
   justify-self: end;
+}
+
+.arowArchive,
+.arowMenu {
+  flex-shrink: 0;
   color: var(--fl-faint);
 }
 
@@ -1477,7 +1485,7 @@
 
 @media (max-width: 760px) {
   .fleet {
-    --fl-row-cols: 26px minmax(0, 1fr) 7.5rem 40px;
+    --fl-row-cols: 26px minmax(0, 1fr) 7.5rem max-content;
     --fl-row-gap: 10px;
   }
 
@@ -1511,8 +1519,12 @@
     grid-column: 4;
   }
 
-  .arowMenu {
+  .arowActions {
     grid-column: 4;
+  }
+
+  .arowMenu {
+    grid-column: auto;
   }
 
   .arow {

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -370,40 +370,48 @@ function AgentRow({
 
       <div className={styles.age}>{age}</div>
 
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
+      <div className={styles.arowActions}>
+        {canArchive && (
           <Button
             type="button"
             variant="ghost"
             size="icon-sm"
-            aria-label={`${sessionLabel} actions`}
-            className={styles.arowMenu}
-            onClick={(event) => event.stopPropagation()}
-          >
-            <MoreHorizontal />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            onSelect={() => {
-              setRenameValue(agent.display_name ?? "")
-              setRenameOpen(true)
+            aria-label={`Archive ${sessionLabel}`}
+            className={styles.arowArchive}
+            onClick={(event) => {
+              event.stopPropagation()
+              onArchive(agent)
             }}
           >
-            <Pencil />
-            Rename
-          </DropdownMenuItem>
-          {canArchive && (
-            <>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onSelect={() => onArchive(agent)}>
-                <Archive />
-                Archive agent
-              </DropdownMenuItem>
-            </>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+            <Archive />
+          </Button>
+        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`${sessionLabel} actions`}
+              className={styles.arowMenu}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <MoreHorizontal />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onSelect={() => {
+                setRenameValue(agent.display_name ?? "")
+                setRenameOpen(true)
+              }}
+            >
+              <Pencil />
+              Rename
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
 
       <Dialog
         open={renameOpen}

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -443,21 +443,20 @@ test("agent session can be renamed from the row menu", async ({ page }) => {
   )
 })
 
-test("agent session can be archived from the row menu", async ({ page }) => {
+test("agent session can be archived from the row", async ({ page }) => {
   await mockFleet(page)
   await page.goto("/v2/sessions")
 
-  await page
-    .getByRole("button", {
-      name: "Wiring automatic tax on Stripe checkout actions",
-    })
-    .click()
   const archiveRequest = page.waitForRequest(
     (request) =>
       request.url().endsWith("/api/v1/v2/taskforce/session/session-1") &&
       request.method() === "PATCH",
   )
-  await page.getByRole("menuitem", { name: "Archive agent" }).click()
+  await page
+    .getByRole("button", {
+      name: "Archive Wiring automatic tax on Stripe checkout",
+    })
+    .click()
 
   expect((await archiveRequest).postDataJSON()).toEqual({
     fleet_session_id: "fleet-history",


### PR DESCRIPTION
## Summary
- Show archive as a ghost icon button directly in each Sessions row, to the left of the options menu.
- Remove archive from the row dropdown; rename remains the only menu action.

## Test plan
- [x] Updated `fleet.spec.ts` archive test for the inline button
- [ ] Confirm archive icon appears on active session rows and archives on click
- [ ] Confirm History rows still hide archive when archiving is disabled

Made with [Cursor](https://cursor.com)