### PR TITLE
Polish Profiles and Pricing pages

### DIFF
--- a/src/api/v2Agents.ts
+++ b/src/api/v2Agents.ts
@@ -16,6 +16,7 @@ export interface AgentSpecialistSummary {
   invocations_count: number
   tokens_saved: number
   last_invoked_at: string | null
+  created_at: string | null
 }
 
 export interface AgentsListResponse {

--- a/src/data/membershipPlans.ts
+++ b/src/data/membershipPlans.ts
@@ -45,7 +45,7 @@ export const membershipPlans: MembershipPlan[] = [
     eyebrow: "The ultimate package",
     price: "$49.99",
     priceDetail: "/ month",
-    description: "For enterprise scale teams who can't waste a moment or token",
+    description: "For enterprise scale teams and organizations",
     benefits: [
       "Up to 1,000 agent profiles",
       "1 TB of library storage",

--- a/src/routes/v2/agents.tsx
+++ b/src/routes/v2/agents.tsx
@@ -10,7 +10,6 @@ import { useMemo, useState } from "react"
 
 import {
   type AgentSpecialistCreate,
-  type AgentSpecialistStatus,
   type AgentSpecialistSummary,
   createAgent,
   listAgents,
@@ -25,7 +24,6 @@ import {
 } from "@/components/V2/Agents/agentsTypography"
 import { CreateProfileDialog } from "@/components/V2/Agents/CreateProfileDialog"
 import { QueryErrorState } from "@/components/V2/QueryErrorState"
-import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
 import {
   V2_PAGE_BODY,
   V2_PAGE_FRAME,
@@ -35,38 +33,58 @@ import {
 import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
 
-type AgentScope = "all" | AgentSpecialistStatus
-
-const AGENT_SCOPES: { key: AgentScope; label: string }[] = [
-  { key: "all", label: "All" },
-  { key: "active", label: "Active" },
-  { key: "draft", label: "Draft" },
-  { key: "archived", label: "Archived" },
-]
-
-const AGENT_SORT_MODES = [
-  { key: "alphabetical", label: "A–Z" },
-  { key: "recent", label: "Recent" },
-] as const
-
-type AgentSortMode = (typeof AGENT_SORT_MODES)[number]["key"]
-
-function compareAgents(
-  a: AgentSpecialistSummary,
-  b: AgentSpecialistSummary,
-  sortMode: AgentSortMode,
-) {
-  if (sortMode === "alphabetical") {
+function sortAgentsByCreatedAt(agents: AgentSpecialistSummary[]) {
+  return [...agents].sort((a, b) => {
+    const aTime = a.created_at ? Date.parse(a.created_at) : 0
+    const bTime = b.created_at ? Date.parse(b.created_at) : 0
+    if (aTime !== bTime) return bTime - aTime
     return a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
-  }
-
-  const aTime = a.last_invoked_at ? Date.parse(a.last_invoked_at) : null
-  const bTime = b.last_invoked_at ? Date.parse(b.last_invoked_at) : null
-  if (aTime === null && bTime === null) return 0
-  if (aTime === null) return 1
-  if (bTime === null) return -1
-  return aTime - bTime
+  })
 }
+
+// TODO: Restore Profiles scope/sort filter bar (All/Active/Draft/Archived + A-Z/Recent).
+// import { ScopeFilterBar } from "@/components/V2/ScopeFilterBar"
+// import { type AgentSpecialistStatus } from "@/api/v2Agents"
+//
+// type AgentScope = "all" | AgentSpecialistStatus
+//
+// const AGENT_SCOPES: { key: AgentScope; label: string }[] = [
+//   { key: "all", label: "All" },
+//   { key: "active", label: "Active" },
+//   { key: "draft", label: "Draft" },
+//   { key: "archived", label: "Archived" },
+// ]
+//
+// const AGENT_SORT_MODES = [
+//   { key: "alphabetical", label: "A–Z" },
+//   { key: "recent", label: "Recent" },
+// ] as const
+//
+// type AgentSortMode = (typeof AGENT_SORT_MODES)[number]["key"]
+//
+// const [scope, setScope] = useState<AgentScope>("all")
+// const [sortMode, setSortMode] = useState<AgentSortMode>("recent")
+// const [sortDir, setSortDir] = useState<"desc" | "asc">("desc")
+//
+// <ScopeFilterBar
+//   items={AGENT_SCOPES.map((agentScope) => ({
+//     key: agentScope.key,
+//     label: agentScope.label,
+//     count:
+//       agentScope.key === "all"
+//         ? agents.length
+//         : agents.filter((agent) => agent.status === agentScope.key).length,
+//   }))}
+//   active={scope}
+//   onChange={setScope}
+//   sortModes={[...AGENT_SORT_MODES]}
+//   activeSortMode={sortMode}
+//   onSortModeChange={setSortMode}
+//   sortDir={sortDir}
+//   onSortDirToggle={() =>
+//     setSortDir((dir) => (dir === "desc" ? "asc" : "desc"))
+//   }
+// />
 
 export const Route = createFileRoute("/v2/agents")({
   component: TaskforceAgents,
@@ -128,9 +146,6 @@ function AgentsIndex() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
-  const [scope, setScope] = useState<AgentScope>("all")
-  const [sortMode, setSortMode] = useState<AgentSortMode>("recent")
-  const [sortDir, setSortDir] = useState<"desc" | "asc">("desc")
   const [createProfileOpen, setCreateProfileOpen] = useState(false)
   const agentsQuery = useQuery({
     queryKey: ["v2-agents", isDemoMode],
@@ -155,28 +170,7 @@ function AgentsIndex() {
     },
   })
 
-  const visible = useMemo(() => {
-    const filtered =
-      scope === "all"
-        ? agents
-        : agents.filter((agent) => agent.status === scope)
-    const sorted = [...filtered].sort((a, b) => {
-      if (sortMode === "recent") {
-        const aTime = a.last_invoked_at ? Date.parse(a.last_invoked_at) : null
-        const bTime = b.last_invoked_at ? Date.parse(b.last_invoked_at) : null
-        if (aTime === null && bTime === null) {
-          return a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
-        }
-        if (aTime === null) return 1
-        if (bTime === null) return -1
-        const comparison = aTime - bTime
-        return sortDir === "asc" ? comparison : -comparison
-      }
-      const comparison = compareAgents(a, b, sortMode)
-      return sortDir === "asc" ? comparison : -comparison
-    })
-    return sorted
-  }, [agents, scope, sortDir, sortMode])
+  const visible = useMemo(() => sortAgentsByCreatedAt(agents), [agents])
 
   return (
     <section
@@ -203,83 +197,59 @@ function AgentsIndex() {
               + Profile
             </Button>
           </header>
-          <ScopeFilterBar
-            items={AGENT_SCOPES.map((agentScope) => ({
-              key: agentScope.key,
-              label: agentScope.label,
-              count:
-                agentScope.key === "all"
-                  ? agents.length
-                  : agents.filter((agent) => agent.status === agentScope.key)
-                      .length,
-            }))}
-            active={scope}
-            onChange={setScope}
-            sortModes={[...AGENT_SORT_MODES]}
-            activeSortMode={sortMode}
-            onSortModeChange={setSortMode}
-            sortDir={sortDir}
-            onSortDirToggle={() =>
-              setSortDir((dir) => (dir === "desc" ? "asc" : "desc"))
-            }
-          />
         </div>
 
         <div className={V2_TAB_CONTENT_CLASS}>
-        <CreateProfileDialog
-          open={createProfileOpen}
-          onOpenChange={setCreateProfileOpen}
-          isCreating={createProfileMutation.isPending}
-          onSubmit={(values) => createProfileMutation.mutate(values)}
-        />
-
-        {agentsQuery.isError && !hasAgentsData ? (
-          <QueryErrorState
-            title="Could not load profiles"
-            description="Taskforce could not reach the profiles service. Try again without leaving this page."
-            onRetry={() => void agentsQuery.refetch()}
-            isRetrying={agentsQuery.isFetching}
-            testId="profiles-load-error"
+          <CreateProfileDialog
+            open={createProfileOpen}
+            onOpenChange={setCreateProfileOpen}
+            isCreating={createProfileMutation.isPending}
+            onSubmit={(values) => createProfileMutation.mutate(values)}
           />
-        ) : agentsQuery.isLoading ? (
-          <AgentsLoading />
-        ) : (
-          <>
-            {agentsQuery.isError && (
-              <QueryErrorState
-                title="Profiles may be out of date"
-                description="The latest profiles could not be loaded. The last available results are still shown."
-                onRetry={() => void agentsQuery.refetch()}
-                isRetrying={agentsQuery.isFetching}
-                compact
-                testId="profiles-refresh-error"
-              />
-            )}
-            {agents.length === 0 ? (
-              <EmptyAgents isDemoMode={isDemoMode} />
-            ) : visible.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                No profiles match this filter.
-              </p>
-            ) : (
-              <div
-                data-testid="agents-card-grid"
-                className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
-              >
-                {visible.map((agent) => (
-                  <AgentProfileCard key={agent.id} agent={agent} />
-                ))}
-              </div>
-            )}
-          </>
-        )}
 
-        {agentsQuery.isFetching && !agentsQuery.isLoading && (
-          <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="size-3 animate-spin" />
-            Refreshing profiles
-          </div>
-        )}
+          {agentsQuery.isError && !hasAgentsData ? (
+            <QueryErrorState
+              title="Could not load profiles"
+              description="Taskforce could not reach the profiles service. Try again without leaving this page."
+              onRetry={() => void agentsQuery.refetch()}
+              isRetrying={agentsQuery.isFetching}
+              testId="profiles-load-error"
+            />
+          ) : agentsQuery.isLoading ? (
+            <AgentsLoading />
+          ) : (
+            <>
+              {agentsQuery.isError && (
+                <QueryErrorState
+                  title="Profiles may be out of date"
+                  description="The latest profiles could not be loaded. The last available results are still shown."
+                  onRetry={() => void agentsQuery.refetch()}
+                  isRetrying={agentsQuery.isFetching}
+                  compact
+                  testId="profiles-refresh-error"
+                />
+              )}
+              {agents.length === 0 ? (
+                <EmptyAgents isDemoMode={isDemoMode} />
+              ) : (
+                <div
+                  data-testid="agents-card-grid"
+                  className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+                >
+                  {visible.map((agent) => (
+                    <AgentProfileCard key={agent.id} agent={agent} />
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+
+          {agentsQuery.isFetching && !agentsQuery.isLoading && (
+            <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-3 animate-spin" />
+              Refreshing profiles
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/src/routes/v2/pricing.tsx
+++ b/src/routes/v2/pricing.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/v2/pricing")({
   head: () => ({
     meta: [
       {
-        title: "Taskforce Membership",
+        title: "Taskforce | Pricing",
       },
     ],
   }),
@@ -61,17 +61,12 @@ function TaskforcePricing({ currentUser }: { currentUser: UserPublic }) {
   return (
     <section className="flex min-h-0 flex-1 overflow-y-auto">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 py-8">
-        <div className="space-y-3">
-          <p className="text-sm font-medium tracking-[0.01em] text-muted-foreground">
-            Taskforce Membership
-          </p>
-          <h1 className="text-2xl font-semibold tracking-tight md:whitespace-nowrap md:text-3xl">
-            Choose the <span className="text-[#8447ff]">Taskforce</span> tier
-            right for your team
-          </h1>
-        </div>
+        <h1 className="text-2xl font-semibold tracking-tight text-balance md:text-3xl">
+          Choose the <span className="text-[#8447ff]">Taskforce</span> tier right
+          for your team
+        </h1>
 
-        <div className="grid gap-4 lg:grid-cols-3">
+        <div className="grid gap-4 lg:grid-cols-3 lg:items-stretch">
           {membershipPlans.map((plan) => {
             const isCurrent = plan.tier === currentTier
             const isSelected = plan.tier === selectedTier
@@ -81,52 +76,52 @@ function TaskforcePricing({ currentUser }: { currentUser: UserPublic }) {
                 key={plan.tier}
                 data-testid={`membership-plan-${plan.tier}`}
                 className={cn(
-                  "relative flex cursor-pointer flex-col border bg-card transition hover:border-primary/60 hover:shadow-sm",
+                  "relative flex h-full cursor-pointer flex-col border bg-card transition hover:border-primary/60 hover:shadow-sm",
                   isSelected && "border-primary ring-2 ring-primary/20",
                   plan.highlighted && "bg-primary/[0.03]",
                 )}
                 onClick={() => setSelectedTier(plan.tier)}
               >
                 <CardHeader className="gap-3">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="space-y-1">
-                      <p className="text-xs font-medium tracking-[0.01em] text-muted-foreground">
-                        {plan.eyebrow}
-                      </p>
-                      <CardTitle className="text-2xl">{plan.name}</CardTitle>
-                    </div>
-                    <div className="flex flex-col items-end gap-2">
-                      {isCurrent && (
-                        <Badge variant="secondary">
-                          You already have this tier
-                        </Badge>
-                      )}
-                    </div>
+                  <div className="flex min-h-6 items-start justify-between gap-3">
+                    <p className="text-xs font-medium tracking-[0.01em] text-muted-foreground">
+                      {plan.eyebrow}
+                    </p>
+                    {isCurrent && (
+                      <Badge variant="secondary" className="shrink-0 text-right">
+                        You already have this tier
+                      </Badge>
+                    )}
                   </div>
-                  <CardDescription>{plan.description}</CardDescription>
+                  <CardTitle className="text-2xl">{plan.name}</CardTitle>
+                  <CardDescription className="min-h-10 text-pretty">
+                    {plan.description}
+                  </CardDescription>
                 </CardHeader>
 
                 <CardContent className="flex flex-1 flex-col gap-5">
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-4xl font-semibold">{plan.price}</span>
+                  <div className="flex min-h-14 flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <span className="text-4xl font-semibold leading-none">
+                      {plan.price}
+                    </span>
                     {plan.priceDetail && (
-                      <span className="text-sm text-muted-foreground">
+                      <span className="text-sm leading-snug text-muted-foreground">
                         {plan.priceDetail}
                       </span>
                     )}
                   </div>
 
-                  <ul className="grid gap-3 text-sm text-muted-foreground">
+                  <ul className="grid flex-1 gap-3 text-sm text-muted-foreground">
                     {plan.benefits.map((benefit) => (
                       <li key={benefit} className="flex items-start gap-3">
                         <Check className="mt-0.5 size-4 shrink-0 text-emerald-600" />
-                        <span>{benefit}</span>
+                        <span className="text-pretty">{benefit}</span>
                       </li>
                     ))}
                   </ul>
                 </CardContent>
 
-                <CardFooter className="flex flex-col items-stretch gap-2">
+                <CardFooter className="mt-auto flex flex-col items-stretch gap-2">
                   {(plan.tier === "pro" || plan.tier === "max") &&
                   !isCurrent ? (
                     <LoadingButton

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -28,6 +28,7 @@ const agents = [
     invocations_count: 12,
     tokens_saved: 42000,
     last_invoked_at: "2026-05-24T12:00:00Z",
+    created_at: "2026-05-20T12:00:00Z",
   },
   {
     id: "agent-2",
@@ -43,6 +44,7 @@ const agents = [
     invocations_count: 4,
     tokens_saved: 12000,
     last_invoked_at: null,
+    created_at: "2026-04-01T12:00:00Z",
   },
   {
     id: "agent-3",
@@ -57,6 +59,7 @@ const agents = [
     invocations_count: 8,
     tokens_saved: 8000,
     last_invoked_at: "2026-06-01T12:00:00Z",
+    created_at: "2026-06-01T12:00:00Z",
   },
 ]
 
@@ -205,7 +208,7 @@ test("hard refresh on /v2/agents/ keeps Profiles selected and renders content", 
   ).toBeVisible()
 })
 
-test("profiles grid sorts alphabetically and by recent use", async ({ page }) => {
+test("profiles grid sorts by creation date", async ({ page }) => {
   await mockAgentsShell(page)
   await page.goto("/v2/agents")
 
@@ -219,18 +222,6 @@ test("profiles grid sorts alphabetically and by recent use", async ({ page }) =>
     )
 
   await expect(grid).toBeVisible()
-  await expect.poll(profileOrder).toEqual(["Vega", "Jensen", "Mira"])
-
-  await page.getByRole("button", { name: "A–Z" }).click()
-  await expect.poll(profileOrder).toEqual(["Vega", "Mira", "Jensen"])
-
-  await page.getByRole("button", { name: "Sort descending" }).click()
-  await expect.poll(profileOrder).toEqual(["Jensen", "Mira", "Vega"])
-
-  await page.getByRole("button", { name: "Recent" }).click()
-  await expect.poll(profileOrder).toEqual(["Jensen", "Vega", "Mira"])
-
-  await page.getByRole("button", { name: "Sort ascending" }).click()
   await expect.poll(profileOrder).toEqual(["Vega", "Jensen", "Mira"])
 })
 
@@ -352,7 +343,7 @@ test("profiles grid links to detail and session metrics", async ({ page }) => {
   await expect(page).toHaveURL(/\/v2\/metrics\?session_id=session-1$/)
 })
 
-test("profile lifecycle updates detail and list filters", async ({ page }) => {
+test("profile lifecycle updates detail and list", async ({ page }) => {
   await mockAgentsShell(page)
 
   await page.goto("/v2/agents/jensen")
@@ -377,14 +368,14 @@ test("profile lifecycle updates detail and list filters", async ({ page }) => {
     .getByTestId("agent-detail-sticky-header")
     .getByRole("link", { name: "Profiles" })
     .click()
-  await page.getByRole("button", { name: /^Archived/ }).click()
   await expect(
     page.getByRole("link", { name: /open profile jensen/i }),
   ).toBeVisible()
-  await page.getByRole("button", { name: /^Active/ }).click()
   await expect(
-    page.getByRole("link", { name: /open profile jensen/i }),
-  ).toHaveCount(0)
+    page
+      .getByRole("link", { name: /open profile jensen/i })
+      .getByText("Archived", { exact: true }),
+  ).toBeVisible()
 })
 
 test("profiles grid shows empty state before profiles are seeded", async ({

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -374,7 +374,7 @@ test("profile lifecycle updates detail and list", async ({ page }) => {
   await expect(
     page
       .getByRole("link", { name: /open profile jensen/i })
-      .getByText("Archived", { exact: true }),
+      .getByTestId("agent-status-archived"),
   ).toBeVisible()
 })
 


### PR DESCRIPTION
## Summary
- Hide the Profiles scope/sort filter bar with a commented restore TODO; sort the grid by creation date (newest first).
- Remove the Pricing page eyebrow, align tier cards consistently, and update Max copy to "For enterprise scale teams and organizations".
- Add `created_at` to the frontend agent summary type for creation-date sorting.

## Test plan
- [x] Updated `agents-routing.spec.ts` for creation-date order and lifecycle without filter tabs
- [ ] Verify Profiles grid shows all agents without the filter bar
- [ ] Verify Pricing cards align across Free/Pro/Max

Made with [Cursor](https://cursor.com)