### PR TITLE
Shorten unsupported Cursor agent reply note

### DIFF
--- a/src/routes/v2/sessions.$sessionId.tsx
+++ b/src/routes/v2/sessions.$sessionId.tsx
@@ -22,12 +22,14 @@ import {
   agentCapturePaused,
   agentDisplayName,
   agentFiles,
+  agentKind,
   agentPauseReason,
   agentQuestion,
   agentSpecialistName,
   agentSpecialistRuleCount,
   agentStartedAt,
   agentStatus,
+  AGENT_KIND_LABEL,
   cleanActivityPromptText,
   compactPresence,
   type FleetStatus,
@@ -167,8 +169,8 @@ function AgentReplyPanel({ agent }: { agent: TaskforceFleetAgent }) {
   if (!canReply) {
     return (
       <div className={styles.replyNote}>
-        Replying isn’t supported for {agent.agent_kind} agents yet — they have
-        no way to pick up a queued prompt.
+        Replying isn’t supported for {AGENT_KIND_LABEL[agentKind(agent)]} agents
+        yet.
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Show "Replying isn't supported for Cursor agents yet." without the queued-prompt explanation
- Use proper agent kind labels (Cursor, Claude, Codex)

## Test plan
- [ ] Open a Cursor agent session detail page and confirm the reply note copy

Made with [Cursor](https://cursor.com)