### PR TITLE
Capitalize Awaiting prompt status label

### DIFF
--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -13,7 +13,7 @@ export type FleetStatus = "run" | "waiting" | "paused" | "idle" | "inactive"
 /** Quiet word shown next to a non-running status dot. */
 export const STATE_LABEL: Record<FleetStatus, string> = {
   run: "running",
-  waiting: "awaiting prompt",
+  waiting: "Awaiting prompt",
   paused: "capture paused",
   idle: "idle",
   inactive: "inactive",


### PR DESCRIPTION
## Summary
- Use "Awaiting prompt" in session detail state and fleet eyebrow copy

## Test plan
- [ ] Idle/waiting agent session detail shows "Awaiting prompt · 15m"

Made with [Cursor](https://cursor.com)