### PR TITLE
Capitalize Awaiting prompt in fleet eyebrow

### DIFF
--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -850,7 +850,7 @@ export function FleetPage() {
     `${activeAgents.length} ${activeAgents.length === 1 ? "agent" : "agents"}`,
     `${running} running`,
   ]
-  if (waiting) eyebrowParts.push(`${waiting} awaiting prompt`)
+  if (waiting) eyebrowParts.push(`${waiting} Awaiting prompt`)
 
   const openAgent = (agent: TaskforceFleetAgent) =>
     navigate({


### PR DESCRIPTION
## Summary
- Fleet page eyebrow now reads `2 Awaiting prompt` instead of `2 awaiting prompt`

## Test plan
- [ ] Sessions page eyebrow shows capitalized Awaiting prompt when agents are waiting

Made with [Cursor](https://cursor.com)