### PR TITLE
Make session status indicators circular

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -513,15 +513,20 @@
 
 /* status dot */
 .sdot {
-  width: 7px;
-  height: 7px;
+  display: block;
+  width: 9px;
+  height: 9px;
   flex-shrink: 0;
+  box-shadow: none;
   /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten status indicators. */
-  border-radius: 999px !important;
+  border-radius: 50% !important;
 }
 
 .run {
   background: var(--primary);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--primary) 18%, transparent),
+    0 0 12px color-mix(in srgb, var(--primary) 58%, transparent);
 }
 
 .pulse {
@@ -546,6 +551,9 @@
 
 .waiting {
   background: var(--fl-waiting);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--fl-waiting) 16%, transparent),
+    0 0 12px color-mix(in srgb, var(--fl-waiting) 52%, transparent);
 }
 
 @keyframes fleet-pulse {


### PR DESCRIPTION
## Summary
- Make fleet/session-agent status indicators true circles instead of box-like dots
- Add glow treatment for live running/purple and waiting/red states

## Validation
- npx biome check src/components/V2/Fleet/FleetPage.module.css
- PATH=/home/alexlee/.vscode-server/cli/servers/Stable-fcf604774b9f2674b473065736ee75077e256353/server:$PATH npm run build

## Notes
- Focused Playwright was attempted, but this local worktree setup times out in the existing Fleet status-dot test path as well, before this change-specific assertion; the production build passes.