### PR TITLE
Polish fleet UI, profiles copy, sidebar toggles, and menus

### DIFF
--- a/src/components/Sidebar/ModeSwitches.module.css
+++ b/src/components/Sidebar/ModeSwitches.module.css
@@ -1,0 +1,5 @@
+/* Global sharp-corner reset flattens rounded-full utilities; switches stay pill-shaped. */
+.track,
+.thumb {
+  border-radius: 999px !important;
+}

--- a/src/components/Sidebar/ModeSwitches.tsx
+++ b/src/components/Sidebar/ModeSwitches.tsx
@@ -4,6 +4,8 @@ import { useDemoMode } from "@/components/demo-mode-provider"
 import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar"
 import { cn } from "@/lib/utils"
 
+import styles from "./ModeSwitches.module.css"
+
 type ModeToggleProps = {
   icon: LucideIcon
   isActive: boolean
@@ -44,16 +46,18 @@ function ModeToggle({
           aria-hidden="true"
           data-testid={`${testId}-track`}
           className={cn(
-            "ml-auto hidden h-7 w-12 items-center rounded-full border border-sidebar-border/70 bg-muted/70 p-1 shadow-inner transition-colors group-data-[collapsible=icon]:hidden md:flex",
-            isActive && "border-sidebar-primary/40 bg-sidebar-primary",
+            styles.track,
+            "ml-auto hidden h-6 w-11 shrink-0 items-center border border-sidebar-border/80 bg-muted/60 p-0.5 shadow-[inset_0_1px_2px_rgb(0_0_0/0.06)] transition-[background-color,border-color] duration-150 group-data-[collapsible=icon]:hidden md:flex",
+            isActive && "border-sidebar-primary/45 bg-sidebar-primary",
           )}
         >
           <div
             data-testid={`${testId}-thumb`}
             className={cn(
-              "size-5 rounded-full bg-background shadow-sm ring-1 ring-black/5 transition-transform",
+              styles.thumb,
+              "size-5 bg-background shadow-[0_1px_2px_rgb(0_0_0/0.14)] ring-1 ring-black/5 transition-transform duration-150 dark:ring-white/10",
               isActive &&
-                "translate-x-5 bg-sidebar-primary-foreground ring-white/20",
+                "translate-x-5 bg-sidebar-primary-foreground ring-white/15",
             )}
           />
         </div>

--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -592,12 +592,18 @@
 /* ---------- agent hover card (compact) ---------- */
 /* Portaled to <body> and positioned at the cursor imperatively, so it is fixed
    and laid out from the top-left corner via transform. */
+.hovercard,
+.hovercard * {
+  /* Children default to pointer-events: auto and would block row actions
+     when the cursor-following card overlaps archive/menu buttons. */
+  pointer-events: none;
+}
+
 .hovercard {
   position: fixed;
   top: 0;
   left: 0;
   z-index: 60;
-  pointer-events: none;
   will-change: transform;
 }
 

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -79,6 +79,7 @@ import {
   formatClockTime,
   rosterStatusLabel,
   runningCount,
+  statusDotPulses,
   waitingCount,
 } from "./fleetStatus"
 import { SharedContextDrawer } from "./SharedContextDrawer"
@@ -133,7 +134,7 @@ function StatusDot({ status }: { status: FleetStatus }) {
       className={cn(
         styles.sdot,
         styles[status],
-        status === "run" && styles.pulse,
+        statusDotPulses(status) && styles.pulse,
       )}
     />
   )
@@ -675,7 +676,7 @@ function FleetCard({
             <div className={styles.emptyRows}>
               {isHistory
                 ? "Drag a session here to archive it."
-                : "No active agents in this session group yet."}
+                : "No agents in this session."}
             </div>
           ) : (
             fleet.agents.map((agent) => (

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -82,6 +82,11 @@ export function agentStatus(agent: TaskforceFleetAgent): FleetStatus {
   return agent.status === "running" ? "run" : agent.status
 }
 
+/** Running (purple) and awaiting-prompt / "Agent idle" (red) roster dots pulse. */
+export function statusDotPulses(status: FleetStatus): boolean {
+  return status === "run" || status === "waiting"
+}
+
 export function isRunning(agent: TaskforceFleetAgent): boolean {
   return agentStatus(agent) === "run"
 }

--- a/src/components/V2/Landing/ClosingCta.tsx
+++ b/src/components/V2/Landing/ClosingCta.tsx
@@ -12,7 +12,8 @@ export function ClosingCta() {
     <section className={styles.ctaBand}>
       <div className={styles.ctaInner}>
         <h2>
-          Stop starting from <em>scratch</em>. Start using <em>Taskforce</em>.
+          Stop starting from <em className={styles.ctaScratch}>scratch</em>.
+          Start using <em>Taskforce</em>.
         </h2>
         <div className={cn(styles.heroCtas, styles.ctaActions)}>
           <Button asChild className={styles.solidButton}>

--- a/src/components/V2/Landing/Landing.module.css
+++ b/src/components/V2/Landing/Landing.module.css
@@ -1447,6 +1447,13 @@
   font-style: normal;
 }
 
+.ctaInner h2 em.ctaScratch {
+  display: inline-block;
+  padding: 0 0.12em;
+  background: var(--landing-primary);
+  color: #fff;
+}
+
 .footer {
   padding: 40px 0 56px;
 }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -92,7 +92,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -128,7 +128,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -211,7 +211,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
         className
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -107,7 +107,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}

--- a/src/routes/v2/profiles.tsx
+++ b/src/routes/v2/profiles.tsx
@@ -131,11 +131,11 @@ function EmptyAgents({ isDemoMode }: { isDemoMode: boolean }) {
       <div className="mx-auto grid size-12 place-items-center border border-border bg-muted text-primary">
         <Bot className="size-6" />
       </div>
-      <h2 className={cn("mt-5", AGENT_PAGE_TITLE_CLASS)}>No profiles yet</h2>
+      <h2 className={cn("mt-5", AGENT_PAGE_TITLE_CLASS)}>No profiles yet.</h2>
       <p className="mx-auto mt-2 max-w-lg text-sm leading-6 text-muted-foreground">
         {isDemoMode
           ? "Seeded demo profiles have not been created for this account yet."
-          : "Agents will appear here after Taskforce packages reusable profile knowledge from your work."}
+          : "Taskforce will create profiles automatically for you as you go."}
       </p>
     </div>
   )

--- a/src/routes/v2/sessions.$sessionId.tsx
+++ b/src/routes/v2/sessions.$sessionId.tsx
@@ -42,6 +42,7 @@ import {
   STATE_LABEL,
   sessionPreviousWork,
   sessionWorkSummary,
+  statusDotPulses,
 } from "@/components/V2/Fleet/fleetStatus"
 import { SessionContextRailLink } from "@/components/V2/Fleet/SharedContextDrawer"
 import {
@@ -346,7 +347,7 @@ function FleetAgentDetailRoute() {
               className={cn(
                 styles.sdot,
                 styles[status],
-                status === "run" && styles.pulse,
+                statusDotPulses(status) && styles.pulse,
               )}
             />
             <div className={styles.dtitle}>

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -403,11 +403,11 @@ test("profiles grid shows empty state before profiles are seeded", async ({
   await page.goto("/v2/profiles")
 
   await expect(
-    page.getByRole("heading", { name: "No profiles yet" }),
+    page.getByRole("heading", { name: "No profiles yet." }),
   ).toBeVisible()
   await expect(
     page.getByText(
-      "Agents will appear here after Taskforce packages reusable profile knowledge",
+      "Taskforce will create profiles automatically for you as you go.",
     ),
   ).toBeVisible()
 })
@@ -441,7 +441,7 @@ test("profiles list exposes a retry state instead of an empty state", async ({
 
   await expect(page.getByTestId("profiles-load-error")).toBeVisible()
   await expect(
-    page.getByRole("heading", { name: "No profiles yet" }),
+    page.getByRole("heading", { name: "No profiles yet." }),
   ).toHaveCount(0)
 
   await page.getByTestId("profiles-load-error").getByRole("button").click()


### PR DESCRIPTION
## Summary
- Fix session hover card blocking archive/menu button hovers by applying `pointer-events: none` to all hover-card descendants
- Pulse red awaiting-prompt status dots the same way as running (purple) agents
- Refresh empty-state copy on Profiles and empty session groups
- Restore pill-shaped Demo/Experimental mode toggles under the global sharp-corner reset
- Use pointer cursor on dropdown and select menu options app-wide
- Highlight "scratch" in the landing closing CTA

## Test plan
- [x] Rebased onto `origin/main`
- [ ] Hover fleet session row actions with hover card visible — archive/menu buttons highlight
- [ ] Confirm awaiting-prompt agents show pulsing red status dots
- [ ] Profiles empty state shows updated copy
- [ ] Demo mode toggle renders as a pill switch in sidebar utilities
- [ ] Fleet/session dropdown options show pointer cursor on hover


Made with [Cursor](https://cursor.com)