### PR TITLE
Fix demo mode toggle pill shape

### DIFF
--- a/src/components/Sidebar/ModeSwitches.module.css
+++ b/src/components/Sidebar/ModeSwitches.module.css
@@ -1,5 +1,13 @@
-/* Global sharp-corner reset flattens rounded-full utilities; switches stay pill-shaped. */
+/* Redundant with index.css data-attribute rules; keeps switch styling co-located. */
 .track,
 .thumb {
-  border-radius: 999px !important;
+  border-radius: 9999px !important;
+}
+
+.track {
+  overflow: hidden;
+}
+
+.thumb {
+  flex-shrink: 0;
 }

--- a/src/components/Sidebar/ModeSwitches.tsx
+++ b/src/components/Sidebar/ModeSwitches.tsx
@@ -44,6 +44,7 @@ function ModeToggle({
         <span className="text-[calc(18px*0.85)]">{label}</span>
         <div
           aria-hidden="true"
+          data-mode-switch-track
           data-testid={`${testId}-track`}
           className={cn(
             styles.track,
@@ -52,10 +53,11 @@ function ModeToggle({
           )}
         >
           <div
+            data-mode-switch-thumb
             data-testid={`${testId}-thumb`}
             className={cn(
               styles.thumb,
-              "size-5 bg-background shadow-[0_1px_2px_rgb(0_0_0/0.14)] ring-1 ring-black/5 transition-transform duration-150 dark:ring-white/10",
+              "size-[1.125rem] bg-background shadow-[0_1px_2px_rgb(0_0_0/0.14)] ring-1 ring-black/5 transition-transform duration-150 dark:ring-white/10",
               isActive &&
                 "translate-x-5 bg-sidebar-primary-foreground ring-white/15",
             )}

--- a/src/index.css
+++ b/src/index.css
@@ -126,6 +126,17 @@
     scrollbar-width: none;
   }
 
+  /* Same layer + higher specificity than `*` — sidebar mode toggles stay pill-shaped. */
+  [data-mode-switch-track],
+  [data-mode-switch-thumb] {
+    /* biome-ignore lint/complexity/noImportantStyles: override global square-corner reset for sidebar toggles. */
+    border-radius: 9999px !important;
+  }
+
+  [data-mode-switch-track] {
+    overflow: hidden;
+  }
+
   *::-webkit-scrollbar {
     width: 0;
     height: 0;


### PR DESCRIPTION
## Summary
- Add `[data-mode-switch-track]` / `[data-mode-switch-thumb]` exceptions inside `@layer base` so they beat the global `* { border-radius: 0 !important }` reset
- Tag the demo toggle track/thumb with those data attributes and clip the track with `overflow: hidden`

## Test plan
- [ ] Open sidebar utilities drawer as superuser
- [ ] Confirm Demo mode switch track and thumb are pill-shaped, not square boxes


Made with [Cursor](https://cursor.com)