### PR TITLE
Keep session-agent status dots circular

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -511,12 +511,13 @@
   opacity: 1;
 }
 
-/* status dot */
+/* status dot — circles for every state color (run, waiting, idle, paused, inactive). */
 .sdot {
-  display: block;
+  display: inline-block;
   width: 9px;
   height: 9px;
   flex-shrink: 0;
+  aspect-ratio: 1;
   box-shadow: none;
   /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten status indicators. */
   border-radius: 50% !important;

--- a/src/components/V2/Fleet/FleetPage.tsx
+++ b/src/components/V2/Fleet/FleetPage.tsx
@@ -130,6 +130,7 @@ const STATE_CLASS: Record<FleetStatus, string> = {
 function StatusDot({ status }: { status: FleetStatus }) {
   return (
     <span
+      data-fleet-status-dot
       data-testid="fleet-status-dot"
       className={cn(
         styles.sdot,

--- a/src/index.css
+++ b/src/index.css
@@ -133,6 +133,14 @@
     border-radius: 9999px !important;
   }
 
+  /* Session roster/detail status dots — keep every state color circular. */
+  [data-fleet-status-dot] {
+    display: inline-block;
+    aspect-ratio: 1;
+    /* biome-ignore lint/complexity/noImportantStyles: override global square-corner reset for fleet status dots. */
+    border-radius: 50% !important;
+  }
+
   [data-mode-switch-track] {
     overflow: hidden;
   }

--- a/src/routes/v2/sessions.$sessionId.tsx
+++ b/src/routes/v2/sessions.$sessionId.tsx
@@ -343,6 +343,7 @@ function FleetAgentDetailRoute() {
 
           <div className={styles.dhead}>
             <span
+              data-fleet-status-dot
               data-testid="fleet-status-dot"
               className={cn(
                 styles.sdot,


### PR DESCRIPTION
## Summary
- Add `data-fleet-status-dot` with a global CSS override so the square-corner reset cannot flatten fleet status indicators
- Tighten `.sdot` sizing so roster and session-detail dots stay true circles for every state color (running, waiting, idle, paused, inactive)

## Test plan
- [x] `npx biome check` on touched CSS/TSX files
- [ ] Open `/v2/sessions` and confirm status dots are circles for running, waiting, idle, and inactive agents
- [ ] Open a session detail page and confirm the header status dot is circular


Made with [Cursor](https://cursor.com)