### PR TITLE
[codex] Tighten session activity previews

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -514,8 +514,8 @@
 /* status dot — circles for every state color (run, waiting, idle, paused, inactive). */
 .sdot {
   display: inline-block;
-  width: 9px;
-  height: 9px;
+  width: 7px;
+  height: 7px;
   flex-shrink: 0;
   aspect-ratio: 1;
   box-shadow: none;

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -323,7 +323,7 @@ export function agentRecentActivity(agent: TaskforceFleetAgent): string[] {
     .filter(Boolean)
 }
 
-function truncateLine(text: string, max = 120): string {
+export function truncateActivityLine(text: string, max = 120): string {
   const firstLine = text.split(/\r?\n/)[0]?.trim() ?? ""
   return firstLine.length > max ? `${firstLine.slice(0, max - 1)}…` : firstLine
 }
@@ -341,7 +341,7 @@ export function agentActivityLine(agent: TaskforceFleetAgent): string {
     ? (recent[1] ?? summary ?? recent[0])
     : (recent[0] ?? summary)
   const cleaned = pick ? cleanActivityPromptText(pick) : ""
-  return cleaned ? truncateLine(cleaned) : ""
+  return cleaned ? truncateActivityLine(cleaned) : ""
 }
 
 /** Session detail "Currently working on" body. */

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,9 +1,43 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
+import {
+  legacySettingsTabValues,
+  settingsTabValues,
+  type LegacySettingsTab,
+  type SettingsTab,
+} from "@/components/UserSettings/UserSettingsPage"
+
+type LegacySettingsSearch = {
+  tab?: SettingsTab | LegacySettingsTab
+}
+
+function parseLegacySettingsSearch(
+  search: Record<string, unknown>,
+): LegacySettingsSearch {
+  const tab = search.tab
+  if (
+    typeof tab === "string" &&
+    (settingsTabValues as readonly string[]).includes(tab)
+  ) {
+    return { tab: tab as SettingsTab }
+  }
+  if (
+    typeof tab === "string" &&
+    (legacySettingsTabValues as readonly string[]).includes(tab)
+  ) {
+    return { tab: tab as LegacySettingsTab }
+  }
+  return {}
+}
 
 // Legacy V1 path — V1 (topics/cases/skills) was removed; keep a redirect so
 // old links/bookmarks resolve into the V2 app.
 export const Route = createFileRoute("/settings")({
-  beforeLoad: () => {
-    throw redirect({ to: "/v2/settings" })
+  validateSearch: parseLegacySettingsSearch,
+  beforeLoad: ({ search }) => {
+    throw redirect({
+      to: "/v2/settings",
+      replace: true,
+      ...(search.tab ? { search: { tab: search.tab } } : {}),
+    })
   },
 })

--- a/src/routes/skills.tsx
+++ b/src/routes/skills.tsx
@@ -4,6 +4,6 @@ import { createFileRoute, redirect } from "@tanstack/react-router"
 // old links/bookmarks resolve into the V2 app.
 export const Route = createFileRoute("/skills")({
   beforeLoad: () => {
-    throw redirect({ to: "/v2/library" })
+    throw redirect({ to: "/v2/profiles", replace: true })
   },
 })

--- a/src/routes/v2/sessions.$sessionId.tsx
+++ b/src/routes/v2/sessions.$sessionId.tsx
@@ -43,6 +43,7 @@ import {
   sessionPreviousWork,
   sessionWorkSummary,
   statusDotPulses,
+  truncateActivityLine,
 } from "@/components/V2/Fleet/fleetStatus"
 import { SessionContextRailLink } from "@/components/V2/Fleet/SharedContextDrawer"
 import {
@@ -110,7 +111,8 @@ function eventTitle(event: TaskforceSessionActivityEntry): string {
   if (event.kind === "edit") return `Edited ${event.file ?? "file"}`
   const raw = event.text ?? event.note ?? event.kind
   if (event.kind === "prompt" || event.kind === "reply") {
-    return cleanActivityPromptText(raw) || raw
+    const cleaned = cleanActivityPromptText(raw) || raw
+    return truncateActivityLine(cleaned, 120)
   }
   return raw
 }
@@ -451,7 +453,10 @@ function FleetAgentDetailRoute() {
             {/* Activity — durable per-turn timeline, newest-first (TF-247). */}
             <div className={styles.section}>
               <div className={styles.seclabel}>Activity</div>
-              <div className={styles.timeline} data-testid="fleet-activity-timeline">
+              <div
+                className={styles.timeline}
+                data-testid="fleet-activity-timeline"
+              >
                 <div className={cn(styles.tev, styles.tevNow)}>
                   <span className={styles.tdot} data-timeline-dot />
                   <div className={styles.tt}>{liveActivityTime(agent)}</div>

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -583,6 +583,53 @@ test("roster shows agent status when summary is empty", async ({ page }) => {
     box ? box.y + box.height / 2 : 0
   expect(Math.abs(midY(dotBox) - midY(ageBox))).toBeLessThan(6)
   expect(Math.abs(midY(dotBox) - midY(menuBox))).toBeLessThan(6)
+  expect(dotBox?.width).toBe(7)
+  expect(dotBox?.height).toBe(7)
+})
+
+test("session detail truncates long activity prompt previews", async ({
+  page,
+}) => {
+  const longPrompt =
+    "Ask Codex to inspect the full AGENTS.md workspace defaults and explain why the prompt preview in the session activity timeline appears clipped in the UI without an ending marker"
+  await mockFleet(page, {
+    agentOverrides: {
+      recent_activity: [longPrompt],
+    },
+  })
+  await page.route(
+    "**/api/v1/v2/taskforce/session-activity/session-1",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          session_id: "session-1",
+          entries: [
+            {
+              id: "event-long-prompt",
+              kind: "prompt",
+              occurred_at: "2026-06-12T10:02:00Z",
+              role: "user",
+              who: "@user",
+              text: longPrompt,
+              cmd: null,
+              exit_code: null,
+              output: null,
+              file: null,
+              added: null,
+              removed: null,
+              note: null,
+              repo: null,
+              ledger_href: null,
+            },
+          ],
+        },
+      })
+    },
+  )
+  await page.goto("/v2/sessions/session-1")
+
+  await expect(page.getByText(/ending marker$/)).toHaveCount(0)
+  await expect(page.getByText(/session activity t…$/)).toBeVisible()
 })
 
 test("collapsed fleet cards share header height", async ({ page }) => {
@@ -641,8 +688,7 @@ test("session detail renders Ran diagnostics in a command block", async ({
 }) => {
   await mockFleet(page, {
     agentOverrides: {
-      summary_markdown:
-        "Ran: cd /home/alexlee/dev && ls -la && echo test",
+      summary_markdown: "Ran: cd /home/alexlee/dev && ls -la && echo test",
     },
   })
   await page.goto("/v2/sessions/session-1")

--- a/tests/fleet.spec.ts
+++ b/tests/fleet.spec.ts
@@ -23,6 +23,7 @@ async function mockFleet(
   options: {
     includeDestination?: boolean
     agentOverrides?: Record<string, unknown>
+    activityEntries?: Record<string, unknown>[]
   } = {},
 ) {
   let agentFleetId = "fleet-1"
@@ -178,7 +179,7 @@ async function mockFleet(
       await route.fulfill({
         json: {
           session_id: "session-1",
-          entries: [
+          entries: options.activityEntries ?? [
             {
               id: "event-command",
               kind: "command",
@@ -596,40 +597,31 @@ test("session detail truncates long activity prompt previews", async ({
     agentOverrides: {
       recent_activity: [longPrompt],
     },
+    activityEntries: [
+      {
+        id: "event-long-prompt",
+        kind: "prompt",
+        occurred_at: "2026-06-12T10:02:00Z",
+        role: "user",
+        who: "@user",
+        text: longPrompt,
+        cmd: null,
+        exit_code: null,
+        output: null,
+        file: null,
+        added: null,
+        removed: null,
+        note: null,
+        repo: null,
+        ledger_href: null,
+      },
+    ],
   })
-  await page.route(
-    "**/api/v1/v2/taskforce/session-activity/session-1",
-    async (route) => {
-      await route.fulfill({
-        json: {
-          session_id: "session-1",
-          entries: [
-            {
-              id: "event-long-prompt",
-              kind: "prompt",
-              occurred_at: "2026-06-12T10:02:00Z",
-              role: "user",
-              who: "@user",
-              text: longPrompt,
-              cmd: null,
-              exit_code: null,
-              output: null,
-              file: null,
-              added: null,
-              removed: null,
-              note: null,
-              repo: null,
-              ledger_href: null,
-            },
-          ],
-        },
-      })
-    },
-  )
   await page.goto("/v2/sessions/session-1")
 
-  await expect(page.getByText(/ending marker$/)).toHaveCount(0)
-  await expect(page.getByText(/session activity t…$/)).toBeVisible()
+  const timeline = page.getByTestId("fleet-activity-timeline")
+  await expect(timeline.getByText(/ending marker$/)).toHaveCount(0)
+  await expect(timeline.getByText(/^Ask Codex.*…$/)).toBeVisible()
 })
 
 test("collapsed fleet cards share header height", async ({ page }) => {


### PR DESCRIPTION
## Summary
- truncate session detail prompt/reply activity titles with an ellipsis after the first 120 characters
- reuse the Fleet activity truncation helper for both roster rows and detail timeline entries
- reduce Fleet/session-agent status dots from 9px to 7px
- add Playwright coverage for long activity prompt previews and the smaller status dot size

## Validation
- `npm exec biome -- check --no-errors-on-unmatched --files-ignore-unknown=true src/components/V2/Fleet/fleetStatus.ts 'src/routes/v2/sessions.$sessionId.tsx' src/components/V2/Fleet/FleetPage.module.css tests/fleet.spec.ts`
- `npm exec tsc -- -p tsconfig.build.json --noEmit`
- `npx playwright test --config=playwright.mocked.config.ts tests/fleet.spec.ts` was attempted locally after starting Vite with `bun ./node_modules/vite/bin/vite.js --host 127.0.0.1`; the app failed to mount because local Firebase env is invalid/missing (`Firebase: Error (auth/invalid-api-key)`), so all Fleet selectors timed out before exercising the assertions.
