### PR TITLE
Polish session activity timeline layout and markers

### DIFF
--- a/src/components/V2/Fleet/FleetPage.module.css
+++ b/src/components/V2/Fleet/FleetPage.module.css
@@ -815,6 +815,9 @@
 
 .dtop {
   flex-shrink: 0;
+  /* Hairline ::after is the header bottom edge — no padding below it or the
+     rail border-left leaves a gap at the T-junction when scrolling. */
+  padding-bottom: 0;
 }
 
 .dtop::after {
@@ -1104,6 +1107,8 @@
 /* activity timeline */
 .timeline {
   position: relative;
+  --timeline-dot-size: calc(7px * 0.85);
+  --timeline-dot-line: calc(10.5px * var(--v2-scale, 1) * 1.3);
   padding-left: 20px;
 }
 
@@ -1128,19 +1133,47 @@
 
 .tdot {
   position: absolute;
-  top: 5px;
+  top: calc((var(--timeline-dot-line) - var(--timeline-dot-size)) / 2);
   left: -20px;
-  width: 7px;
-  height: 7px;
-  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten timeline dots. */
-  border-radius: 999px !important;
+  width: var(--timeline-dot-size);
+  height: var(--timeline-dot-size);
   background: var(--fl-faint);
-  box-shadow: 0 0 0 3px var(--background);
+  box-shadow: 0 0 0 calc(3px * 0.85) var(--background);
 }
 
-/* tevLink inset hover padding shifts the positioning origin; keep dots on the spine. */
-.tev.tevLink .tdot {
-  left: -8px;
+/* tevLink rows share the same layout as plain .tev so timeline dots, timestamps,
+   and command blocks stay aligned across link and non-link entries. */
+.tev.tevLink {
+  display: block;
+  padding: 0 0 18px;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.tev.tevLink:last-child {
+  padding-bottom: 0;
+}
+
+.tev.tevLink:hover,
+.tev.tevLink:focus-visible {
+  background: var(--fl-primary-softer);
+  box-shadow: inset 0 0 0 1px var(--fl-primary-line-soft);
+}
+
+.tev.tevLink:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
+.tx > .cmdBlock {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.tx .md > pre:first-child {
+  margin-top: 0;
 }
 
 .tevRun .tdot,
@@ -1190,30 +1223,6 @@
   line-height: 1.45;
 }
 
-.tev.tevLink {
-  display: block;
-  margin-inline: -12px;
-  padding: 8px 12px 18px;
-  color: inherit;
-  text-decoration: none;
-  cursor: pointer;
-  transition: background-color 120ms ease;
-}
-
-.tev.tevLink:last-child {
-  padding-bottom: 8px;
-}
-
-.tev.tevLink:hover,
-.tev.tevLink:focus-visible {
-  background: var(--fl-primary-softer);
-  box-shadow: inset 0 0 0 1px var(--fl-primary-line-soft);
-}
-
-.tev.tevLink:focus-visible {
-  outline: 2px solid var(--ring);
-  outline-offset: -2px;
-}
 
 /* rail blocks */
 .block {

--- a/src/components/V2/Fleet/fleetStatus.ts
+++ b/src/components/V2/Fleet/fleetStatus.ts
@@ -172,11 +172,15 @@ export function compactPresence(agent: TaskforceFleetAgent): string {
   return minutes ? `${hours}h ${minutes}m` : `${hours}h`
 }
 
-/** Clock time (HH:MM) for an activity event timestamp. */
+/** Clock time for activity timeline rows, e.g. "6:59 PM". */
 export function formatClockTime(iso: string): string {
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return ""
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+  return date.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  })
 }
 
 const USER_QUERY_RE = /^<user_query>\s*|\s*<\/user_query>\s*$/gim

--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -558,6 +558,8 @@
 /* Transcript timeline — mirrors Fleet agent detail activity formatting. */
 .transcriptTimeline {
   position: relative;
+  --timeline-dot-size: calc(7px * 0.85);
+  --timeline-dot-line: calc(10.5px * var(--v2-scale, 1) * 1.3);
   padding-left: 20px;
 }
 .transcriptTimeline::before {
@@ -578,14 +580,12 @@
 }
 .evDot {
   position: absolute;
-  top: 5px;
+  top: calc((var(--timeline-dot-line) - var(--timeline-dot-size)) / 2);
   left: -20px;
-  width: 7px;
-  height: 7px;
-  /* biome-ignore lint/complexity/noImportantStyles: global square-corner rule should not flatten timeline dots. */
-  border-radius: 999px !important;
+  width: var(--timeline-dot-size);
+  height: var(--timeline-dot-size);
   background: var(--ledger-detail-faint);
-  box-shadow: 0 0 0 3px var(--tf-bg);
+  box-shadow: 0 0 0 calc(3px * 0.85) var(--tf-bg);
 }
 .evPrompt .evDot,
 .evReply .evDot {

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -100,11 +100,15 @@ function pad(value: number): string {
   return String(value).padStart(2, "0")
 }
 
-/** "14:02" */
+/** "6:59 PM" — matches Fleet activity timeline formatting. */
 function formatClock(value: string | null | undefined): string {
   const date = dateFrom(value)
   if (!date) return "—"
-  return `${pad(date.getHours())}:${pad(date.getMinutes())}`
+  return date.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  })
 }
 
 /** "14:02:11" */
@@ -842,7 +846,7 @@ function EventShell({
       data-highlighted={highlighted ? "true" : undefined}
       ref={rootRef}
     >
-      <span className={styles.evDot} />
+      <span className={styles.evDot} data-timeline-dot />
       <div className={styles.evT}>
         {time}
         <span className={styles.evKind}>{kind}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -134,7 +134,8 @@
   }
 
   /* Session roster/detail status dots — keep every state color circular. */
-  [data-fleet-status-dot] {
+  [data-fleet-status-dot],
+  [data-timeline-dot] {
     display: inline-block;
     aspect-ratio: 1;
     /* biome-ignore lint/complexity/noImportantStyles: override global square-corner reset for fleet status dots. */

--- a/src/routes/v2/sessions.$sessionId.tsx
+++ b/src/routes/v2/sessions.$sessionId.tsx
@@ -329,7 +329,13 @@ function FleetAgentDetailRoute() {
         data-testid="fleet-agent-detail"
         ref={setPulseRoot}
       >
-        <div className={cn(styles.dtop, V2_STICKY_HEADER_CLASS, "border-b-0")}>
+        <div
+          className={cn(
+            styles.dtop,
+            V2_STICKY_HEADER_CLASS,
+            "border-b-0 pb-0",
+          )}
+        >
           <div className={styles.crumb}>
             <BackLink
               to="/v2/sessions"
@@ -447,7 +453,7 @@ function FleetAgentDetailRoute() {
               <div className={styles.seclabel}>Activity</div>
               <div className={styles.timeline} data-testid="fleet-activity-timeline">
                 <div className={cn(styles.tev, styles.tevNow)}>
-                  <span className={styles.tdot} />
+                  <span className={styles.tdot} data-timeline-dot />
                   <div className={styles.tt}>{liveActivityTime(agent)}</div>
                   <div className={styles.tx}>
                     <ActivityProse compact className={styles.txProse}>
@@ -462,7 +468,7 @@ function FleetAgentDetailRoute() {
                   const detail = eventDetail(entry)
                   const body = (
                     <>
-                      <span className={styles.tdot} />
+                      <span className={styles.tdot} data-timeline-dot />
                       <div className={styles.tt}>
                         {formatClockTime(entry.occurred_at)}
                         <span className={styles.tkind}>{entry.kind}</span>
@@ -481,7 +487,6 @@ function FleetAgentDetailRoute() {
                       to="/v2/ledger"
                       search={{ session_id: sessionId, event_id: entry.id }}
                       className={cn(styles.tev, styles.tevLink)}
-                      title="Open this event in Ledger"
                     >
                       {body}
                     </Link>
@@ -493,13 +498,13 @@ function FleetAgentDetailRoute() {
                 })}
                 {activityQuery.isLoading && (
                   <div className={styles.tev}>
-                    <span className={styles.tdot} />
+                    <span className={styles.tdot} data-timeline-dot />
                     <div className={styles.tx}>Loading session activity…</div>
                   </div>
                 )}
                 {!activityQuery.isLoading && activityEntries.length === 0 && (
                   <div className={styles.tev}>
-                    <span className={styles.tdot} />
+                    <span className={styles.tdot} data-timeline-dot />
                     <div className={styles.tx}>No activity captured yet.</div>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- Remove the gap between the session detail header hairline and right-rail vertical divider so scrolling stays flush.
- Align ledger-linked timeline rows with plain rows (no inset padding shift) and remove the native "Open this event in Ledger" hover title.
- Format activity timestamps as `6:59 PM` (no leading zero) in Sessions and Ledger.
- Render timeline markers as smaller circles (~15% reduction) centered vertically on the time row, with a global corner-reset exemption.

## Test plan
- [x] Verified session detail header/rail dividers meet without gap
- [x] Verified timeline link rows align with reply content and command blocks
- [x] Verified timestamps render as `6:59 PM`
- [x] Verified timeline dots are circular and centered on time labels

Made with [Cursor](https://cursor.com)