### PR TITLE
TF-251: Agent profile edit context UI

### DIFF
--- a/src/api/v2Agents.ts
+++ b/src/api/v2Agents.ts
@@ -1,7 +1,8 @@
 import { type CancelablePromise, OpenAPI } from "@/client"
 import { request } from "@/client/core/request"
 
-export type AgentSpecialistStatus = "active" | "draft" | "archived"
+export type AgentSpecialistStatus = "active" | "draft" | "archived" | "proposed"
+export type AgentPermissionScope = "readonly" | "full"
 
 export interface AgentSpecialistSummary {
   id: string
@@ -36,6 +37,11 @@ export interface AgentSpecialistUpdate {
   short_description?: string
   domain_tags?: string[]
   status?: AgentSpecialistStatus
+  model_hint?: string
+  permission_scope?: AgentPermissionScope
+  instructions?: string[]
+  routing_triggers?: string[]
+  negative_triggers?: string[]
 }
 
 export interface AgentSpecialistLinkedDoc {
@@ -75,6 +81,8 @@ export interface AgentSpecialistDetail {
   short_description: string
   description: string
   created_from: string
+  model_hint: string
+  permission_scope: AgentPermissionScope
   domain_tags: string[]
   routing_triggers: string[]
   negative_triggers: string[]

--- a/src/components/V2/Agents/AgentStatusBadge.tsx
+++ b/src/components/V2/Agents/AgentStatusBadge.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils"
 const STATUS_STYLES: Record<AgentSpecialistStatus, string> = {
   active: "border-emerald-500/30 text-emerald-700 dark:text-emerald-400",
   draft: "border-amber-500/30 text-amber-700 dark:text-amber-400",
+  proposed: "border-sky-500/30 text-sky-700 dark:text-sky-400",
   archived: "border-border text-muted-foreground",
 }
 
@@ -28,6 +29,7 @@ export function AgentStatusBadge({
           "size-1.5 rounded-full",
           status === "active" && "bg-emerald-500",
           status === "draft" && "bg-amber-500",
+          status === "proposed" && "bg-sky-500",
           status === "archived" && "bg-muted-foreground/60",
         )}
       />

--- a/src/components/V2/Agents/EditProfileDialog.tsx
+++ b/src/components/V2/Agents/EditProfileDialog.tsx
@@ -125,7 +125,7 @@ export function EditProfileDialog({
 
   return (
     <Dialog open={open} onOpenChange={(next) => !busy && onOpenChange(next)}>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Edit profile</DialogTitle>
           <DialogDescription>

--- a/src/components/V2/Agents/EditProfileDialog.tsx
+++ b/src/components/V2/Agents/EditProfileDialog.tsx
@@ -2,6 +2,7 @@ import { Save, Trash2 } from "lucide-react"
 import { type FormEvent, useEffect, useState } from "react"
 
 import type {
+  AgentPermissionScope,
   AgentSpecialistDetail,
   AgentSpecialistStatus,
   AgentSpecialistUpdate,
@@ -37,6 +38,17 @@ function parseTags(raw: string): string[] {
   )
 }
 
+function parseLines(raw: string): string[] {
+  return Array.from(
+    new Set(
+      raw
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean),
+    ),
+  )
+}
+
 export function EditProfileDialog({
   open,
   onOpenChange,
@@ -59,6 +71,19 @@ export function EditProfileDialog({
   const [description, setDescription] = useState(agent.short_description)
   const [tags, setTags] = useState(agent.domain_tags.join(", "))
   const [status, setStatus] = useState<AgentSpecialistStatus>(agent.status)
+  const [modelHint, setModelHint] = useState(agent.model_hint)
+  const [permissionScope, setPermissionScope] = useState<AgentPermissionScope>(
+    agent.permission_scope,
+  )
+  const [routingTriggers, setRoutingTriggers] = useState(
+    agent.routing_triggers.join("\n"),
+  )
+  const [negativeTriggers, setNegativeTriggers] = useState(
+    agent.negative_triggers.join("\n"),
+  )
+  const [instructions, setInstructions] = useState(
+    agent.instructions.join("\n"),
+  )
   const [confirmingDelete, setConfirmingDelete] = useState(false)
 
   // Re-seed the form from the current profile each time the dialog opens.
@@ -69,6 +94,11 @@ export function EditProfileDialog({
       setDescription(agent.short_description)
       setTags(agent.domain_tags.join(", "))
       setStatus(agent.status)
+      setModelHint(agent.model_hint)
+      setPermissionScope(agent.permission_scope)
+      setRoutingTriggers(agent.routing_triggers.join("\n"))
+      setNegativeTriggers(agent.negative_triggers.join("\n"))
+      setInstructions(agent.instructions.join("\n"))
       setConfirmingDelete(false)
     }
   }, [open, agent])
@@ -85,12 +115,17 @@ export function EditProfileDialog({
       short_description: description.trim(),
       domain_tags: parseTags(tags),
       status,
+      model_hint: modelHint.trim() || "inherit",
+      permission_scope: permissionScope,
+      routing_triggers: parseLines(routingTriggers),
+      negative_triggers: parseLines(negativeTriggers),
+      instructions: parseLines(instructions),
     })
   }
 
   return (
     <Dialog open={open} onOpenChange={(next) => !busy && onOpenChange(next)}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Edit profile</DialogTitle>
           <DialogDescription>
@@ -142,6 +177,7 @@ export function EditProfileDialog({
               <SelectContent>
                 <SelectItem value="active">Active</SelectItem>
                 <SelectItem value="draft">Draft</SelectItem>
+                <SelectItem value="proposed">Proposed</SelectItem>
                 <SelectItem value="archived">Archived</SelectItem>
               </SelectContent>
             </Select>
@@ -160,6 +196,69 @@ export function EditProfileDialog({
             <p className="text-xs text-muted-foreground">
               Comma-separated. Used for routing and filtering.
             </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="edit-profile-model">Model</Label>
+              <Input
+                id="edit-profile-model"
+                value={modelHint}
+                onChange={(event) => setModelHint(event.target.value)}
+                placeholder="inherit"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-profile-permission">Permission scope</Label>
+              <Select
+                value={permissionScope}
+                onValueChange={(value) =>
+                  setPermissionScope(value as AgentPermissionScope)
+                }
+                disabled={busy}
+              >
+                <SelectTrigger id="edit-profile-permission" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="readonly">Read-only</SelectItem>
+                  <SelectItem value="full">Full</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-profile-routing-triggers">
+              Routing triggers
+            </Label>
+            <Textarea
+              id="edit-profile-routing-triggers"
+              value={routingTriggers}
+              onChange={(event) => setRoutingTriggers(event.target.value)}
+              placeholder={"stripe\nwebhook\nsubscription"}
+              rows={4}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-profile-negative-triggers">
+              Negative triggers
+            </Label>
+            <Textarea
+              id="edit-profile-negative-triggers"
+              value={negativeTriggers}
+              onChange={(event) => setNegativeTriggers(event.target.value)}
+              placeholder={"pricing page copy\nfrontend billing UI"}
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-profile-instructions">Instructions</Label>
+            <Textarea
+              id="edit-profile-instructions"
+              value={instructions}
+              onChange={(event) => setInstructions(event.target.value)}
+              placeholder="Check webhook idempotency before changing fulfillment logic."
+              rows={5}
+            />
           </div>
           <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-between">
             {confirmingDelete ? (

--- a/src/components/V2/Agents/agentDetailPlaceholder.ts
+++ b/src/components/V2/Agents/agentDetailPlaceholder.ts
@@ -16,6 +16,8 @@ export function agentSummaryToDetailPlaceholder(
     short_description: summary.short_description,
     description: summary.short_description,
     created_from: summary.created_from,
+    model_hint: "inherit",
+    permission_scope: "readonly",
     domain_tags: summary.domain_tags,
     routing_triggers: summary.domain_tags,
     negative_triggers: [],

--- a/src/routes/v2/profiles.$slug.tsx
+++ b/src/routes/v2/profiles.$slug.tsx
@@ -160,7 +160,7 @@ function Instructions({ instructions }: { instructions: string[] }) {
   const [expanded, setExpanded] = useState(false)
 
   return (
-    <section className="pt-5">
+    <section className="pt-5" data-testid="agent-instructions">
       <SectionHeader
         title="Operating instructions"
         meta={`${instructions.length} rules`}
@@ -200,7 +200,7 @@ function Instructions({ instructions }: { instructions: string[] }) {
 
 function ContextSection({ agent }: { agent: AgentSpecialistDetail }) {
   return (
-    <section className="pt-5">
+    <section className="pt-5" data-testid="agent-context">
       <SectionHeader title="Harness context" meta="export-ready" />
       <div className="mt-3 grid gap-3 lg:grid-cols-2">
         <div className="border border-black/10 p-3 dark:border-white/12">

--- a/src/routes/v2/profiles.$slug.tsx
+++ b/src/routes/v2/profiles.$slug.tsx
@@ -205,13 +205,19 @@ function ContextSection({ agent }: { agent: AgentSpecialistDetail }) {
       <div className="mt-3 grid gap-3 lg:grid-cols-2">
         <div className="border border-black/10 p-3 dark:border-white/12">
           <div className={AGENT_STAT_LABEL_CLASS}>Model</div>
-          <div className="mt-1 font-mono text-sm text-zinc-950 dark:text-white">
+          <div
+            className="mt-1 font-mono text-sm text-zinc-950 dark:text-white"
+            data-testid="agent-model-hint"
+          >
             {agent.model_hint || "inherit"}
           </div>
         </div>
         <div className="border border-black/10 p-3 dark:border-white/12">
           <div className={AGENT_STAT_LABEL_CLASS}>Permission scope</div>
-          <div className="mt-1 font-mono text-sm capitalize text-zinc-950 dark:text-white">
+          <div
+            className="mt-1 font-mono text-sm capitalize text-zinc-950 dark:text-white"
+            data-testid="agent-permission-scope"
+          >
             {agent.permission_scope}
           </div>
         </div>

--- a/src/routes/v2/profiles.$slug.tsx
+++ b/src/routes/v2/profiles.$slug.tsx
@@ -198,6 +198,49 @@ function Instructions({ instructions }: { instructions: string[] }) {
   )
 }
 
+function ContextSection({ agent }: { agent: AgentSpecialistDetail }) {
+  return (
+    <section className="pt-5">
+      <SectionHeader title="Harness context" meta="export-ready" />
+      <div className="mt-3 grid gap-3 lg:grid-cols-2">
+        <div className="border border-black/10 p-3 dark:border-white/12">
+          <div className={AGENT_STAT_LABEL_CLASS}>Model</div>
+          <div className="mt-1 font-mono text-sm text-zinc-950 dark:text-white">
+            {agent.model_hint || "inherit"}
+          </div>
+        </div>
+        <div className="border border-black/10 p-3 dark:border-white/12">
+          <div className={AGENT_STAT_LABEL_CLASS}>Permission scope</div>
+          <div className="mt-1 font-mono text-sm capitalize text-zinc-950 dark:text-white">
+            {agent.permission_scope}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-4 lg:grid-cols-2">
+        <div>
+          <SectionHeader
+            title="Use when"
+            meta={`${agent.routing_triggers.length} triggers`}
+          />
+          <div className="py-3">
+            <Chips values={agent.routing_triggers} />
+          </div>
+        </div>
+        <div>
+          <SectionHeader
+            title="Do not use when"
+            meta={`${agent.negative_triggers.length} triggers`}
+          />
+          <div className="py-3">
+            <Chips values={agent.negative_triggers} />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
 function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
   return (
     <section className="pt-5">
@@ -550,40 +593,41 @@ function AgentDetailPage() {
         />
 
         <div className={V2_TAB_CONTENT_CLASS}>
-        {agent.description ? (
-          <p className={cn("max-w-3xl", AGENT_DESCRIPTION_CLASS)}>
-            {agent.description}
-          </p>
-        ) : null}
+          {agent.description ? (
+            <p className={cn("max-w-3xl", AGENT_DESCRIPTION_CLASS)}>
+              {agent.description}
+            </p>
+          ) : null}
 
-        {isHydratingDetail ? (
-          <AgentDetailSkeleton
-            shellClassName={AGENTS_DETAIL_SHELL}
-            hideHeader
-          />
-        ) : (
-          <>
-            <StatLine agent={agent} />
+          {isHydratingDetail ? (
+            <AgentDetailSkeleton
+              shellClassName={AGENTS_DETAIL_SHELL}
+              hideHeader
+            />
+          ) : (
+            <>
+              <StatLine agent={agent} />
 
-            <section className="pt-2">
-              <SectionHeader title="Tags" />
-              <div className="py-3">
-                <Chips values={agent.routing_triggers} />
-              </div>
-            </section>
+              <section className="pt-2">
+                <SectionHeader title="Tags" />
+                <div className="py-3">
+                  <Chips values={agent.domain_tags} />
+                </div>
+              </section>
 
-            <Instructions instructions={agent.instructions} />
-            <LinkedKnowledge agent={agent} />
-            <RecentInvocations agent={agent} />
-          </>
-        )}
+              <ContextSection agent={agent} />
+              <Instructions instructions={agent.instructions} />
+              <LinkedKnowledge agent={agent} />
+              <RecentInvocations agent={agent} />
+            </>
+          )}
 
-        {agentQuery.isFetching && !isHydratingDetail && (
-          <div className="mt-5 inline-flex items-center gap-2 text-sm text-zinc-400 dark:text-zinc-500">
-            <Loader2 className="size-4 animate-spin" />
-            Refreshing profile
-          </div>
-        )}
+          {agentQuery.isFetching && !isHydratingDetail && (
+            <div className="mt-5 inline-flex items-center gap-2 text-sm text-zinc-400 dark:text-zinc-500">
+              <Loader2 className="size-4 animate-spin" />
+              Refreshing profile
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -74,6 +74,8 @@ const jensenDetail = {
   created_from: "earned",
   description:
     "Helps debug Stripe billing, subscription upgrades, webhook retries, idempotency, duplicate invoices, and customer double-charge incidents.",
+  model_hint: "inherit",
+  permission_scope: "readonly",
   domain_tags: ["Stripe", "Billing", "Webhooks", "Reliability"],
   routing_triggers: ["stripe", "webhook", "subscription", "plan upgrade"],
   negative_triggers: ["pricing page copy", "frontend billing UI"],
@@ -369,6 +371,14 @@ test("profile lifecycle updates detail and list", async ({ page }) => {
   await page.getByRole("button", { name: "Edit" }).click()
   await page.getByLabel("Status").click()
   await page.getByRole("option", { name: "Archived" }).click()
+  await page.getByLabel("Model").fill("sonnet")
+  await page.getByLabel("Permission scope").click()
+  await page.getByRole("option", { name: "Full" }).click()
+  await page.getByLabel("Routing triggers").fill("stripe\nwebhook\nrefunds")
+  await page.getByLabel("Negative triggers").fill("pricing page copy")
+  await page
+    .getByLabel("Instructions")
+    .fill("Verify webhook signatures.\nNever trust unverified events.")
 
   const updateResponse = page.waitForResponse(
     (response) =>
@@ -378,8 +388,22 @@ test("profile lifecycle updates detail and list", async ({ page }) => {
   await page.getByRole("button", { name: "Save" }).click()
   expect(
     await updateResponse.then((response) => response.request().postDataJSON()),
-  ).toMatchObject({ status: "archived" })
+  ).toMatchObject({
+    status: "archived",
+    model_hint: "sonnet",
+    permission_scope: "full",
+    routing_triggers: ["stripe", "webhook", "refunds"],
+    negative_triggers: ["pricing page copy"],
+    instructions: [
+      "Verify webhook signatures.",
+      "Never trust unverified events.",
+    ],
+  })
   await expect(page.getByTestId("agent-status-archived")).toBeVisible()
+  await expect(page.getByText("sonnet")).toBeVisible()
+  await expect(page.getByText("full")).toBeVisible()
+  await expect(page.getByText("refunds")).toBeVisible()
+  await expect(page.getByText("Never trust unverified events.")).toBeVisible()
 
   await page
     .getByTestId("agent-detail-sticky-header")

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -402,8 +402,14 @@ test("profile lifecycle updates detail and list", async ({ page }) => {
   await expect(page.getByTestId("agent-status-archived")).toBeVisible()
   await expect(page.getByTestId("agent-model-hint")).toHaveText("sonnet")
   await expect(page.getByTestId("agent-permission-scope")).toHaveText("full")
-  await expect(page.getByText("refunds")).toBeVisible()
-  await expect(page.getByText("Never trust unverified events.")).toBeVisible()
+  await expect(
+    page.getByTestId("agent-context").getByText("refunds"),
+  ).toBeVisible()
+  await expect(
+    page
+      .getByTestId("agent-instructions")
+      .getByText("Never trust unverified events."),
+  ).toBeVisible()
 
   await page
     .getByTestId("agent-detail-sticky-header")

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -400,8 +400,8 @@ test("profile lifecycle updates detail and list", async ({ page }) => {
     ],
   })
   await expect(page.getByTestId("agent-status-archived")).toBeVisible()
-  await expect(page.getByText("sonnet")).toBeVisible()
-  await expect(page.getByText("full")).toBeVisible()
+  await expect(page.getByTestId("agent-model-hint")).toHaveText("sonnet")
+  await expect(page.getByTestId("agent-permission-scope")).toHaveText("full")
   await expect(page.getByText("refunds")).toBeVisible()
   await expect(page.getByText("Never trust unverified events.")).toBeVisible()
 


### PR DESCRIPTION
Jira: https://alexlee4190.atlassian.net/browse/TF-251

## Scope
- Mirrors TF-250 agent context fields in the frontend API types: `model_hint`, `permission_scope`, `instructions`, `routing_triggers`, and `negative_triggers`.
- Expands the profile edit dialog so users can edit model, permission scope, routing triggers, negative triggers, and instructions.
- Adds harness context readback on the profile detail page and keeps tags tied to `domain_tags`.
- Covers the edit PATCH payload and resulting detail UI in the mocked profile lifecycle spec.

## Validation
- `npx biome check --write --unsafe --files-ignore-unknown=true src/api/v2Agents.ts src/components/V2/Agents/EditProfileDialog.tsx src/components/V2/Agents/AgentStatusBadge.tsx 'src/routes/v2/profiles.$slug.tsx' src/components/V2/Agents/agentDetailPlaceholder.ts tests/agents-routing.spec.ts`
- `npx tsc -p tsconfig.build.json --noEmit`
- `npx playwright test --config=playwright.mocked.config.ts tests/agents-routing.spec.ts` was attempted locally but the Vite web server could not start under the local Node 18.19.1 environment because Tailwind's optional native binding was missing. CI should run with the repo's supported Node runtime.