### PR TITLE
TF-253: Agent document assignment UI

### DIFF
--- a/src/api/v2Agents.ts
+++ b/src/api/v2Agents.ts
@@ -44,6 +44,11 @@ export interface AgentSpecialistUpdate {
   negative_triggers?: string[]
 }
 
+export interface AgentSpecialistDocumentLinkCreate {
+  document_id: string
+  reason?: string
+}
+
 export interface AgentSpecialistLinkedDoc {
   document_id: string
   title: string
@@ -161,6 +166,42 @@ export function deleteAgent(
     url: "/api/v1/v2/agents/{slug}",
     path: {
       slug,
+    },
+    query: {
+      demo: options.demo || undefined,
+    },
+  })
+}
+
+export function linkAgentDocument(
+  slug: string,
+  body: AgentSpecialistDocumentLinkCreate,
+  options: { demo?: boolean } = {},
+): CancelablePromise<AgentSpecialistDetail> {
+  return request(OpenAPI, {
+    method: "POST",
+    url: "/api/v1/v2/agents/{slug}/documents",
+    path: {
+      slug,
+    },
+    query: {
+      demo: options.demo || undefined,
+    },
+    body,
+  })
+}
+
+export function unlinkAgentDocument(
+  slug: string,
+  documentId: string,
+  options: { demo?: boolean } = {},
+): CancelablePromise<AgentSpecialistDetail> {
+  return request(OpenAPI, {
+    method: "DELETE",
+    url: "/api/v1/v2/agents/{slug}/documents/{document_id}",
+    path: {
+      slug,
+      document_id: documentId,
     },
     query: {
       demo: options.demo || undefined,

--- a/src/routes/v2/library.$documentId.tsx
+++ b/src/routes/v2/library.$documentId.tsx
@@ -11,8 +11,10 @@ import {
   Heading2,
   Heading3,
   Italic,
+  Loader2,
   Pencil,
   Pilcrow,
+  Plus,
   ReceiptText,
   Search,
   Share2,
@@ -25,6 +27,11 @@ import {
   type OrganizationMemberPublic,
   readMyOrganization,
 } from "@/api/organizations"
+import {
+  type AgentSpecialistSummary,
+  linkAgentDocument,
+  listAgents,
+} from "@/api/v2Agents"
 import {
   favoriteV2Document,
   readV2Document,
@@ -50,6 +57,14 @@ import { useDemoMode } from "@/components/demo-mode-provider"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -79,6 +94,7 @@ export const Route = createFileRoute("/v2/library/$documentId")({
 })
 
 type ViewMode = "summary" | "details"
+const MAX_LINKS_PER_SPECIALIST = 25
 
 type EditableDoc = {
   title: string
@@ -496,6 +512,7 @@ function TaskforceDocumentDetail() {
   const [accessOpen, setAccessOpen] = useState(false)
   const [shareDraft, setShareDraft] = useState<ShareDraft>({})
   const [createFolderOpen, setCreateFolderOpen] = useState(false)
+  const [addToAgentOpen, setAddToAgentOpen] = useState(false)
 
   const documentQuery = useQuery({
     queryKey: ["v2-document", documentId, { demo: isDemoMode }],
@@ -540,6 +557,11 @@ function TaskforceDocumentDetail() {
     queryFn: () => readV2DocumentShares(documentId),
     enabled: canManageDocument,
     retry: false,
+  })
+  const agentsQuery = useQuery({
+    queryKey: ["v2-agents", isDemoMode],
+    queryFn: () => listAgents({ demo: isDemoMode }),
+    enabled: addToAgentOpen,
   })
 
   const updateMutation = useMutation({
@@ -627,6 +649,23 @@ function TaskforceDocumentDetail() {
     },
     onError: () => {
       showErrorToast("Could not update sharing.")
+    },
+  })
+  const addToAgentMutation = useMutation({
+    mutationFn: (agentSlug: string) =>
+      linkAgentDocument(
+        agentSlug,
+        { document_id: documentId },
+        { demo: isDemoMode },
+      ),
+    onSuccess: (updated, agentSlug) => {
+      queryClient.setQueryData(["v2-agent", agentSlug, isDemoMode], updated)
+      queryClient.invalidateQueries({ queryKey: ["v2-agents", isDemoMode] })
+      setAddToAgentOpen(false)
+      showSuccessToast("Document added to agent.")
+    },
+    onError: () => {
+      showErrorToast("Could not add document to agent.")
     },
   })
 
@@ -858,6 +897,17 @@ function TaskforceDocumentDetail() {
               viewSwitcher={
                 <div className="flex items-center gap-2">
                   {documentViewToggle}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setAddToAgentOpen(true)}
+                    data-testid="document-add-to-agent"
+                    className="h-7 px-2.5 font-mono text-[0.65rem]"
+                  >
+                    <Plus className="size-4" />
+                    Add to agent
+                  </Button>
                   {!editing && canEditDocument && (
                     <Button
                       type="button"
@@ -883,6 +933,14 @@ function TaskforceDocumentDetail() {
           demo={isDemoMode}
           folders={foldersQuery.data?.data ?? []}
           onCreated={(folder) => moveDocumentToFolder(folder.id)}
+        />
+        <AddToAgentDialog
+          open={addToAgentOpen}
+          onOpenChange={setAddToAgentOpen}
+          agents={agentsQuery.data?.items ?? []}
+          isLoading={agentsQuery.isLoading}
+          isAdding={addToAgentMutation.isPending}
+          onAdd={(agentSlug) => addToAgentMutation.mutate(agentSlug)}
         />
 
         <DocumentProvenanceStrip
@@ -993,6 +1051,146 @@ function DocumentProvenanceStrip({
         </div>
       ) : null}
     </section>
+  )
+}
+
+function AddToAgentDialog({
+  open,
+  onOpenChange,
+  agents,
+  isLoading,
+  isAdding,
+  onAdd,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  agents: AgentSpecialistSummary[]
+  isLoading: boolean
+  isAdding: boolean
+  onAdd: (agentSlug: string) => void
+}) {
+  const [query, setQuery] = useState("")
+  const [selectedSlug, setSelectedSlug] = useState("")
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("")
+      setSelectedSlug("")
+    }
+  }, [open])
+
+  const filteredAgents = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    if (!needle) return agents
+    return agents.filter((agent) =>
+      [agent.name, agent.role, agent.short_description, ...agent.domain_tags]
+        .filter(Boolean)
+        .some((value) => value.toLowerCase().includes(needle)),
+    )
+  }, [agents, query])
+
+  const close = (nextOpen: boolean) => {
+    onOpenChange(nextOpen)
+    if (!nextOpen) {
+      setQuery("")
+      setSelectedSlug("")
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !isAdding && close(next)}>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add to agent</DialogTitle>
+          <DialogDescription>
+            Pin this document to an agent profile.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="relative">
+          <Search className="-translate-y-1/2 pointer-events-none absolute left-3 top-1/2 size-4 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search agents"
+            className="pl-9"
+            aria-label="Search agents"
+          />
+        </div>
+
+        <div className="max-h-72 overflow-y-auto border border-border">
+          {isLoading ? (
+            <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Loading agents
+            </div>
+          ) : filteredAgents.length === 0 ? (
+            <div className="p-4 text-sm text-muted-foreground">
+              No agents match this search.
+            </div>
+          ) : (
+            filteredAgents.map((agent) => {
+              const selected = selectedSlug === agent.slug
+              return (
+                <button
+                  key={agent.id}
+                  type="button"
+                  onClick={() => setSelectedSlug(agent.slug)}
+                  disabled={agent.linked_docs_count >= MAX_LINKS_PER_SPECIALIST}
+                  aria-pressed={selected}
+                  className={cn(
+                    "flex w-full items-start gap-3 border-b border-border p-3 text-left last:border-b-0 hover:bg-muted/50",
+                    selected && "bg-[#8447ff]/10",
+                    agent.linked_docs_count >= MAX_LINKS_PER_SPECIALIST &&
+                      "cursor-not-allowed opacity-50",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "mt-1 size-4 shrink-0 rounded-full border border-border",
+                      selected && "border-[#8447ff] bg-[#8447ff]",
+                    )}
+                    aria-hidden
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-medium text-foreground">
+                      {agent.name}
+                    </span>
+                    <span className="mt-1 line-clamp-2 block text-sm text-muted-foreground">
+                      {agent.short_description}
+                    </span>
+                    <span className="mt-2 block text-xs text-muted-foreground">
+                      {agent.linked_docs_count} documents
+                      {agent.linked_docs_count >= MAX_LINKS_PER_SPECIALIST
+                        ? " · full"
+                        : ""}
+                    </span>
+                  </span>
+                </button>
+              )
+            })
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => close(false)}
+            disabled={isAdding}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => onAdd(selectedSlug)}
+            disabled={!selectedSlug || isAdding}
+          >
+            {isAdding ? "Adding..." : "Add to agent"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/src/routes/v2/profiles.$slug.tsx
+++ b/src/routes/v2/profiles.$slug.tsx
@@ -1,7 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
-import { ChevronDown, ChevronUp, Loader2, Pencil } from "lucide-react"
-import { useState } from "react"
+import {
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  Pencil,
+  Pin,
+  Plus,
+  Search,
+  Trash2,
+} from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
 
 import {
   type AgentSpecialistDetail,
@@ -9,11 +18,23 @@ import {
   type AgentsListResponse,
   deleteAgent,
   getAgent,
+  linkAgentDocument,
+  unlinkAgentDocument,
   updateAgent,
 } from "@/api/v2Agents"
+import { readV2Documents, type V2DocumentPublic } from "@/api/v2Documents"
 import { ApiError } from "@/client"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
 import { AgentDetailSkeleton } from "@/components/V2/Agents/AgentDetailSkeleton"
 import { AgentStatusBadge } from "@/components/V2/Agents/AgentStatusBadge"
 import {
@@ -61,6 +82,7 @@ export const Route = createFileRoute("/v2/profiles/$slug")({
 })
 
 const AGENTS_DETAIL_SHELL = V2_PAGE_BODY
+const MAX_LINKS_PER_SPECIALIST = 25
 
 function initials(name: string) {
   return name
@@ -247,65 +269,233 @@ function ContextSection({ agent }: { agent: AgentSpecialistDetail }) {
   )
 }
 
-function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
+function AddDocumentsDialog({
+  open,
+  onOpenChange,
+  agent,
+  documents,
+  folders,
+  isLoading,
+  isAdding,
+  onAdd,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  agent: AgentSpecialistDetail
+  documents: V2DocumentPublic[]
+  folders: string[]
+  isLoading: boolean
+  isAdding: boolean
+  onAdd: (documentIds: string[]) => void
+}) {
+  const [query, setQuery] = useState("")
+  const [folder, setFolder] = useState("all")
+  const [favoritesOnly, setFavoritesOnly] = useState(false)
+  const [selectedIds, setSelectedIds] = useState<string[]>([])
+  const remainingSlots = Math.max(
+    0,
+    MAX_LINKS_PER_SPECIALIST - agent.linked_knowledge.length,
+  )
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("")
+      setFolder("all")
+      setFavoritesOnly(false)
+      setSelectedIds([])
+    }
+  }, [open])
+
+  const linkedIds = useMemo(
+    () =>
+      new Set(agent.linked_knowledge.map((document) => document.document_id)),
+    [agent.linked_knowledge],
+  )
+  const filteredDocuments = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return documents.filter((document) => {
+      if (linkedIds.has(document.id)) return false
+      if (favoritesOnly && !document.is_favorite) return false
+      if (folder !== "all" && (document.folder_name ?? "Unfiled") !== folder) {
+        return false
+      }
+      if (!needle) return true
+      return [document.title, document.description, document.human_summary]
+        .filter(Boolean)
+        .some((value) => value.toLowerCase().includes(needle))
+    })
+  }, [documents, favoritesOnly, folder, linkedIds, query])
+
+  const toggleSelected = (documentId: string) => {
+    setSelectedIds((current) =>
+      current.includes(documentId)
+        ? current.filter((id) => id !== documentId)
+        : current.length >= remainingSlots
+          ? current
+          : [...current, documentId],
+    )
+  }
+
+  const close = (nextOpen: boolean) => {
+    onOpenChange(nextOpen)
+    if (!nextOpen) {
+      setQuery("")
+      setFolder("all")
+      setFavoritesOnly(false)
+      setSelectedIds([])
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !isAdding && close(next)}>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Add documents</DialogTitle>
+          <DialogDescription>
+            Pin library documents to this profile for harness injection.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
+          <div className="relative">
+            <Search className="-translate-y-1/2 pointer-events-none absolute left-3 top-1/2 size-4 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search title or description"
+              className="pl-9"
+              aria-label="Search documents"
+            />
+          </div>
+          <select
+            value={folder}
+            onChange={(event) => setFolder(event.target.value)}
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+            aria-label="Filter by folder"
+          >
+            <option value="all">All folders</option>
+            {folders.map((folderName) => (
+              <option key={folderName} value={folderName}>
+                {folderName}
+              </option>
+            ))}
+          </select>
+          <Button
+            type="button"
+            variant={favoritesOnly ? "default" : "outline"}
+            onClick={() => setFavoritesOnly((value) => !value)}
+          >
+            Favorites
+          </Button>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {remainingSlots} document slot{remainingSlots === 1 ? "" : "s"}{" "}
+          available.
+        </div>
+
+        <div className="max-h-80 overflow-y-auto border border-border">
+          {isLoading ? (
+            <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Loading documents
+            </div>
+          ) : filteredDocuments.length === 0 ? (
+            <div className="p-4 text-sm text-muted-foreground">
+              No available documents match these filters.
+            </div>
+          ) : (
+            filteredDocuments.map((document) => {
+              const selected = selectedIds.includes(document.id)
+              return (
+                <button
+                  key={document.id}
+                  type="button"
+                  onClick={() => toggleSelected(document.id)}
+                  aria-pressed={selected}
+                  className={cn(
+                    "flex w-full items-start gap-3 border-b border-border p-3 text-left last:border-b-0 hover:bg-muted/50",
+                    selected && "bg-[#8447ff]/10",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "mt-1 size-4 shrink-0 border border-border",
+                      selected && "border-[#8447ff] bg-[#8447ff]",
+                    )}
+                    aria-hidden
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-medium text-foreground">
+                      {document.title}
+                    </span>
+                    <span className="mt-1 line-clamp-2 block text-sm text-muted-foreground">
+                      {document.description || document.human_summary}
+                    </span>
+                    <span className="mt-2 block text-xs text-muted-foreground">
+                      {document.folder_name ?? "Unfiled"}
+                      {document.is_favorite ? " · favorite" : ""}
+                    </span>
+                  </span>
+                </button>
+              )
+            })
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => close(false)}
+            disabled={isAdding}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => onAdd(selectedIds)}
+            disabled={
+              selectedIds.length === 0 ||
+              selectedIds.length > remainingSlots ||
+              isAdding
+            }
+          >
+            {isAdding ? "Adding..." : `Add ${selectedIds.length || ""}`.trim()}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DocumentsSection({
+  agent,
+  onAddDocuments,
+  onRemoveDocument,
+  isRemovingDocumentId,
+}: {
+  agent: AgentSpecialistDetail
+  onAddDocuments: () => void
+  onRemoveDocument: (documentId: string) => void
+  isRemovingDocumentId: string | null
+}) {
   return (
     <section className="pt-5">
       <SectionHeader
-        title="Sessions & documents"
-        meta={`${agent.recent_invocations.length} sessions · ${agent.linked_knowledge.length} documents`}
+        title="Documents"
+        meta={`${agent.linked_knowledge.length} pinned`}
       />
-
-      <div className="mt-2 overflow-x-auto">
-        <table className="w-full min-w-[42rem] border-collapse text-sm">
-          <thead>
-            <tr className="border-b border-black/10 text-xs tracking-[0.01em] text-zinc-400 dark:border-white/12 dark:text-zinc-500">
-              <th className="py-2 pr-3 text-left font-medium">Session</th>
-              <th className="px-3 text-left font-medium">Repo</th>
-              <th className="px-3 text-right font-medium">Saved</th>
-              <th className="py-2 pl-3 text-right font-medium">When</th>
-            </tr>
-          </thead>
-          <tbody>
-            {agent.recent_invocations.length === 0 ? (
-              <tr className="border-b border-black/5 dark:border-white/10">
-                <td
-                  colSpan={4}
-                  className="py-3 text-sm text-zinc-500 dark:text-zinc-400"
-                >
-                  No sessions yet.
-                </td>
-              </tr>
-            ) : (
-              agent.recent_invocations.map((invocation) => (
-                <tr
-                  key={invocation.id}
-                  className="group relative cursor-pointer border-b border-black/5 transition-colors hover:bg-zinc-50 dark:border-white/10 dark:hover:bg-white/5"
-                >
-                  <td className="py-3 pr-3 align-top text-sm text-zinc-950 dark:text-white">
-                    {invocation.session_id && (
-                      <Link
-                        to="/v2/ledger"
-                        search={{ session_id: invocation.session_id }}
-                        aria-label={`Open session "${invocation.prompt}"`}
-                        className="absolute inset-0 z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
-                      />
-                    )}
-                    <div className="font-semibold">"{invocation.prompt}"</div>
-                  </td>
-                  <td className="px-3 py-3 align-top text-sm text-zinc-500 dark:text-zinc-400">
-                    {invocation.repo ?? "Taskforce"}
-                  </td>
-                  <td className="px-3 py-3 text-right align-top text-sm font-semibold text-[#8447ff]">
-                    +{formatCompactNumber(invocation.tokens_saved)}
-                  </td>
-                  <td className="py-3 pl-3 text-right align-top text-xs text-zinc-400 dark:text-zinc-500">
-                    {formatRelativeTime(invocation.created_at)}
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+      <div className="mt-3 flex justify-end">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onAddDocuments}
+          disabled={agent.linked_knowledge.length >= MAX_LINKS_PER_SPECIALIST}
+        >
+          <Plus className="size-4" />
+          Add documents
+        </Button>
       </div>
 
       <div className="mt-2 overflow-x-auto">
@@ -314,37 +504,65 @@ function LinkedKnowledge({ agent }: { agent: AgentSpecialistDetail }) {
             <tr className="border-b border-black/10 text-xs tracking-[0.01em] text-zinc-400 dark:border-white/12 dark:text-zinc-500">
               <th className="py-2 pr-3 text-left font-medium">Document</th>
               <th className="px-3 text-left font-medium">Anchor</th>
-              <th className="py-2 px-3 text-right font-medium">Reason</th>
+              <th className="px-3 text-left font-medium">Pin</th>
+              <th className="py-2 pl-3 text-right font-medium">Action</th>
             </tr>
           </thead>
           <tbody>
-            {agent.linked_knowledge.map((document) => (
-              <tr
-                key={`${document.document_id}-${document.anchor_id ?? "summary"}`}
-                className="group relative cursor-pointer border-b border-black/5 transition-colors hover:bg-zinc-50 dark:border-white/10 dark:hover:bg-white/5"
-              >
-                <td className="py-3 pr-3 align-top">
-                  <a
-                    href={document.href}
-                    className="absolute inset-0 z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
-                  >
-                    <span className="sr-only">Open {document.title}</span>
-                  </a>
-                  <div className="text-base font-semibold text-zinc-950 dark:text-white">
-                    {document.title}
-                  </div>
-                  <div className="mt-1 line-clamp-1 text-xs text-zinc-500 dark:text-zinc-400">
-                    {document.description}
-                  </div>
-                </td>
-                <td className="px-3 py-3 align-top text-sm text-zinc-500 dark:text-zinc-400">
-                  {document.anchor_id ?? "summary"}
-                </td>
-                <td className="px-3 py-3 text-right align-top text-xs text-zinc-500 dark:text-zinc-400">
-                  {document.reason ?? "Pinned knowledge"}
+            {agent.linked_knowledge.length === 0 ? (
+              <tr className="border-b border-black/5 dark:border-white/10">
+                <td
+                  colSpan={4}
+                  className="py-3 text-sm text-zinc-500 dark:text-zinc-400"
+                >
+                  No documents pinned yet.
                 </td>
               </tr>
-            ))}
+            ) : (
+              agent.linked_knowledge.map((document) => (
+                <tr
+                  key={`${document.document_id}-${document.anchor_id ?? "summary"}`}
+                  className="border-b border-black/5 transition-colors hover:bg-zinc-50 dark:border-white/10 dark:hover:bg-white/5"
+                >
+                  <td className="py-3 pr-3 align-top">
+                    <a
+                      href={document.href}
+                      className="text-base font-semibold text-zinc-950 underline-offset-4 hover:underline dark:text-white"
+                    >
+                      {document.title}
+                    </a>
+                    <div className="mt-1 line-clamp-1 text-xs text-zinc-500 dark:text-zinc-400">
+                      {document.description}
+                    </div>
+                  </td>
+                  <td className="px-3 py-3 align-top text-sm text-zinc-500 dark:text-zinc-400">
+                    {document.anchor_id ?? "summary"}
+                  </td>
+                  <td className="px-3 py-3 align-top text-xs text-zinc-500 dark:text-zinc-400">
+                    <span className="inline-flex items-center gap-1">
+                      <Pin className="size-3" />
+                      {document.reason ?? "Pinned"}
+                    </span>
+                  </td>
+                  <td className="py-3 pl-3 text-right align-top">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onRemoveDocument(document.document_id)}
+                      disabled={isRemovingDocumentId === document.document_id}
+                    >
+                      {isRemovingDocumentId === document.document_id ? (
+                        <Loader2 className="size-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="size-4" />
+                      )}
+                      Remove
+                    </Button>
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>
@@ -411,6 +629,10 @@ function AgentDetailPage() {
   const navigate = useNavigate()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const [editOpen, setEditOpen] = useState(false)
+  const [addDocumentsOpen, setAddDocumentsOpen] = useState(false)
+  const [removingDocumentId, setRemovingDocumentId] = useState<string | null>(
+    null,
+  )
   const updateMutation = useMutation({
     mutationFn: (values: AgentSpecialistUpdate) =>
       updateAgent(slug, values, { demo: isDemoMode }),
@@ -437,6 +659,57 @@ function AgentDetailPage() {
       showErrorToast("Could not delete profile.")
     },
   })
+  const addDocumentsMutation = useMutation({
+    mutationFn: async (documentIds: string[]) => {
+      const updates = await Promise.all(
+        documentIds.map((documentId) =>
+          linkAgentDocument(
+            slug,
+            { document_id: documentId },
+            { demo: isDemoMode },
+          ),
+        ),
+      )
+      return updates[updates.length - 1]
+    },
+    onSuccess: (updated, documentIds) => {
+      if (updated) {
+        queryClient.setQueryData(["v2-agent", slug, isDemoMode], updated)
+      }
+      queryClient.invalidateQueries({
+        queryKey: ["v2-agent", slug, isDemoMode],
+      })
+      queryClient.invalidateQueries({ queryKey: ["v2-agents", isDemoMode] })
+      setAddDocumentsOpen(false)
+      showSuccessToast(
+        `${documentIds.length} document${documentIds.length === 1 ? "" : "s"} added.`,
+      )
+    },
+    onError: () => {
+      showErrorToast("Could not add documents.")
+    },
+  })
+  const removeDocumentMutation = useMutation({
+    mutationFn: (documentId: string) =>
+      unlinkAgentDocument(slug, documentId, { demo: isDemoMode }),
+    onMutate: (documentId) => {
+      setRemovingDocumentId(documentId)
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["v2-agent", slug, isDemoMode], updated)
+      queryClient.invalidateQueries({
+        queryKey: ["v2-agent", slug, isDemoMode],
+      })
+      queryClient.invalidateQueries({ queryKey: ["v2-agents", isDemoMode] })
+      showSuccessToast("Document removed.")
+    },
+    onError: () => {
+      showErrorToast("Could not remove document.")
+    },
+    onSettled: () => {
+      setRemovingDocumentId(null)
+    },
+  })
   const agentQuery = useQuery({
     queryKey: ["v2-agent", slug, isDemoMode],
     queryFn: () => getAgent(slug, { demo: isDemoMode }),
@@ -459,7 +732,24 @@ function AgentDetailPage() {
     },
     retry: false,
   })
+  const documentsQuery = useQuery({
+    queryKey: ["v2-documents", { demo: isDemoMode }],
+    queryFn: () => readV2Documents({ demo: isDemoMode }),
+    enabled: addDocumentsOpen,
+  })
   const agent = agentQuery.data
+  const availableDocuments = documentsQuery.data?.data ?? []
+  const documentFolders = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          availableDocuments.map(
+            (document) => document.folder_name ?? "Unfiled",
+          ),
+        ),
+      ).sort((a, b) => a.localeCompare(b)),
+    [availableDocuments],
+  )
   const isAgentError = agentQuery.isError
   const isAgentFetched = agentQuery.isFetched
   const isAgentFetching = agentQuery.isFetching
@@ -597,6 +887,16 @@ function AgentDetailPage() {
           onSubmit={(values) => updateMutation.mutate(values)}
           onDelete={() => deleteMutation.mutate()}
         />
+        <AddDocumentsDialog
+          open={addDocumentsOpen}
+          onOpenChange={setAddDocumentsOpen}
+          agent={agent}
+          documents={availableDocuments}
+          folders={documentFolders}
+          isLoading={documentsQuery.isLoading}
+          isAdding={addDocumentsMutation.isPending}
+          onAdd={(documentIds) => addDocumentsMutation.mutate(documentIds)}
+        />
 
         <div className={V2_TAB_CONTENT_CLASS}>
           {agent.description ? (
@@ -623,7 +923,14 @@ function AgentDetailPage() {
 
               <ContextSection agent={agent} />
               <Instructions instructions={agent.instructions} />
-              <LinkedKnowledge agent={agent} />
+              <DocumentsSection
+                agent={agent}
+                onAddDocuments={() => setAddDocumentsOpen(true)}
+                onRemoveDocument={(documentId) =>
+                  removeDocumentMutation.mutate(documentId)
+                }
+                isRemovingDocumentId={removingDocumentId}
+              />
               <RecentInvocations agent={agent} />
             </>
           )}

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -446,11 +446,13 @@ test("profiles grid links to detail and session metrics", async ({ page }) => {
     page.getByRole("heading", { name: "Jensen", level: 1 }),
   ).toBeVisible()
   await expect(page.getByText("Operating instructions")).toBeVisible()
-  await expect(
-    page.getByRole("link", {
-      name: /open session "stripe is double-charging some users/i,
-    }),
-  ).toHaveAttribute("href", "/v2/ledger?session_id=session-1")
+  const metricsLink = page.getByRole("link", {
+    name: /open metrics for "stripe is double-charging some users/i,
+  })
+  await expect(metricsLink).toHaveAttribute(
+    "href",
+    "/v2/metrics?session_id=session-1",
+  )
 
   const linkedKnowledge = page.getByRole("link", {
     name: /Stripe webhook idempotency strategy/,
@@ -460,11 +462,7 @@ test("profiles grid links to detail and session metrics", async ({ page }) => {
     "/v2/library/doc-1#decision-wal-table",
   )
 
-  await page
-    .getByRole("link", {
-      name: /open metrics for "stripe is double-charging some users/i,
-    })
-    .click()
+  await metricsLink.click()
   await expect(page).toHaveURL(/\/v2\/metrics\?session_id=session-1$/)
 })
 
@@ -541,15 +539,18 @@ test("profile documents can be pinned and removed", async ({ page }) => {
   ).toBeVisible()
 
   await page.getByRole("button", { name: "Add documents" }).click()
-  await page.getByLabel("Search documents").fill("refund")
-  await page.getByRole("button", { name: /Refund idempotency notes/ }).click()
+  const addDialog = page.getByRole("dialog", { name: "Add documents" })
+  await addDialog.getByLabel("Search documents").fill("refund")
+  await addDialog
+    .getByRole("button", { name: /Refund idempotency notes/ })
+    .click()
 
   const addResponse = page.waitForResponse(
     (response) =>
       response.url().endsWith("/api/v1/v2/agents/jensen/documents") &&
       response.request().method() === "POST",
   )
-  await page.getByRole("button", { name: "Add 1" }).click()
+  await addDialog.getByRole("button", { name: "Add 1" }).click()
   expect(
     await addResponse.then((response) => response.request().postDataJSON()),
   ).toMatchObject({ document_id: "doc-2" })

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -1,7 +1,5 @@
 import { expect, type Page, test } from "@playwright/test"
 
-import { mockV2Documents } from "./fixtures/v2-documents"
-
 const currentUser = {
   id: "user-1",
   email: "alex@example.com",
@@ -114,6 +112,53 @@ const jensenDetail = {
   },
 }
 
+const pickerDocuments = [
+  {
+    id: "doc-1",
+    owner_id: "user-1",
+    organization_id: null,
+    folder_id: null,
+    folder_name: "Billing",
+    visibility: "private",
+    user_access: "owner",
+    is_favorite: true,
+    title: "Stripe webhook idempotency strategy",
+    description: "Decision record for route-boundary WAL dedupe.",
+    human_summary: "Use route-boundary WAL dedupe for webhook retries.",
+    ai_generated_summary: "Webhook idempotency strategy.",
+    collaborators: ["Alex Lee"],
+    shared_with: [],
+    main_body: [{ segments: [{ text: "Use route-boundary WAL dedupe." }] }],
+    details_file_name: "stripe-webhook-idempotency-strategy.details.md",
+    details_markdown_sections: [],
+    is_demo: false,
+    created_at: "2026-05-20T12:00:00Z",
+    updated_at: "2026-05-20T12:00:00Z",
+  },
+  {
+    id: "doc-2",
+    owner_id: "user-1",
+    organization_id: null,
+    folder_id: null,
+    folder_name: "Billing",
+    visibility: "private",
+    user_access: "owner",
+    is_favorite: true,
+    title: "Refund idempotency notes",
+    description: "Manual refund retry contract for billing agents.",
+    human_summary: "Key refunds by charge_id so retries no-op.",
+    ai_generated_summary: "Refund idempotency details.",
+    collaborators: ["Alex Lee"],
+    shared_with: [],
+    main_body: [{ segments: [{ text: "Key refunds by charge_id." }] }],
+    details_file_name: "refund-idempotency-notes.details.md",
+    details_markdown_sections: [],
+    is_demo: false,
+    created_at: "2026-05-21T12:00:00Z",
+    updated_at: "2026-05-21T12:00:00Z",
+  },
+]
+
 test.use({
   storageState: {
     cookies: [],
@@ -148,10 +193,59 @@ async function mockAgentsShell(page: Page, options: { empty?: boolean } = {}) {
 
   await page.route("**/api/v1/v2/agents**", async (route) => {
     const url = new URL(route.request().url())
+    const method = route.request().method()
     if (url.pathname === "/api/v1/v2/agents") {
       await route.fulfill({
         json: { items: options.empty ? [] : agentItems },
       })
+      return
+    }
+    if (url.pathname === "/api/v1/v2/agents/jensen/documents") {
+      if (method === "POST") {
+        const body = route.request().postDataJSON()
+        const document = pickerDocuments.find(
+          (item) => item.id === body.document_id,
+        )
+        if (document) {
+          const linked = detail.linked_knowledge.some(
+            (item) => item.document_id === document.id,
+          )
+          if (!linked) {
+            detail = {
+              ...detail,
+              linked_knowledge: [
+                ...detail.linked_knowledge,
+                {
+                  document_id: document.id,
+                  title: document.title,
+                  description: document.description,
+                  anchor_id: null,
+                  href: `/v2/library/${document.id}`,
+                  reason: "added by Alex Lee",
+                },
+              ],
+              stats: {
+                ...detail.stats,
+                linked_docs_count: detail.linked_knowledge.length + 1,
+              },
+            }
+          }
+        }
+        await route.fulfill({ json: detail })
+        return
+      }
+    }
+    const unlinkMatch = url.pathname.match(
+      /^\/api\/v1\/v2\/agents\/jensen\/documents\/([^/]+)$/,
+    )
+    if (unlinkMatch && method === "DELETE") {
+      detail = {
+        ...detail,
+        linked_knowledge: detail.linked_knowledge.filter(
+          (item) => item.document_id !== unlinkMatch[1],
+        ),
+      }
+      await route.fulfill({ json: detail })
       return
     }
     if (url.pathname === "/api/v1/v2/agents/jensen") {
@@ -172,7 +266,19 @@ async function mockAgentsShell(page: Page, options: { empty?: boolean } = {}) {
     await route.fulfill({ json: { metrics: {} } })
   })
 
-  await mockV2Documents(page)
+  await page.route("**/api/v1/v2/documents/**", async (route) => {
+    const url = new URL(route.request().url())
+    if (
+      url.pathname === "/api/v1/v2/documents/" &&
+      route.request().method() === "GET"
+    ) {
+      await route.fulfill({
+        json: { data: pickerDocuments, count: pickerDocuments.length },
+      })
+      return
+    }
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
 }
 
 test("direct specialist URL renders detail instead of the agents grid", async ({
@@ -423,6 +529,47 @@ test("profile lifecycle updates detail and list", async ({ page }) => {
       .getByRole("link", { name: /open profile jensen/i })
       .getByTestId("agent-status-archived"),
   ).toBeVisible()
+})
+
+test("profile documents can be pinned and removed", async ({ page }) => {
+  await mockAgentsShell(page)
+
+  await page.goto("/v2/profiles/jensen")
+  await expect(page.getByRole("heading", { name: "Documents" })).toBeVisible()
+  await expect(
+    page.getByRole("link", { name: "Stripe webhook idempotency strategy" }),
+  ).toBeVisible()
+
+  await page.getByRole("button", { name: "Add documents" }).click()
+  await page.getByLabel("Search documents").fill("refund")
+  await page.getByRole("button", { name: /Refund idempotency notes/ }).click()
+
+  const addResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/v2/agents/jensen/documents") &&
+      response.request().method() === "POST",
+  )
+  await page.getByRole("button", { name: "Add 1" }).click()
+  expect(
+    await addResponse.then((response) => response.request().postDataJSON()),
+  ).toMatchObject({ document_id: "doc-2" })
+  await expect(
+    page.getByRole("link", { name: "Refund idempotency notes" }),
+  ).toBeVisible()
+
+  const removeResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/v2/agents/jensen/documents/doc-2") &&
+      response.request().method() === "DELETE",
+  )
+  await page
+    .getByRole("row", { name: /Refund idempotency notes/ })
+    .getByRole("button", { name: "Remove" })
+    .click()
+  await removeResponse
+  await expect(
+    page.getByRole("link", { name: "Refund idempotency notes" }),
+  ).toHaveCount(0)
 })
 
 test("profiles grid shows empty state before profiles are seeded", async ({

--- a/tests/v2-document-hash.spec.ts
+++ b/tests/v2-document-hash.spec.ts
@@ -54,6 +54,71 @@ async function mockTaskforceDocumentPage(page: Page) {
     await route.fulfill({ json: { data: [], count: 0 } })
   })
 
+  await page.route("**/api/v1/v2/agents**", async (route) => {
+    const url = new URL(route.request().url())
+    const method = route.request().method()
+
+    if (url.pathname === "/api/v1/v2/agents" && method === "GET") {
+      await route.fulfill({
+        json: {
+          items: [
+            {
+              id: "agent-1",
+              slug: "jensen",
+              name: "Jensen",
+              role: "Billing Reliability Specialist",
+              short_description: "Stripe webhooks and billing retries.",
+              domain_tags: ["Stripe", "Billing"],
+              status: "active",
+              created_from: "earned",
+              linked_docs_count: 1,
+              invocations_count: 12,
+              tokens_saved: 42000,
+              last_invoked_at: "2026-05-24T12:00:00Z",
+              created_at: "2026-05-20T12:00:00Z",
+            },
+          ],
+        },
+      })
+      return
+    }
+
+    if (
+      url.pathname === "/api/v1/v2/agents/jensen/documents" &&
+      method === "POST"
+    ) {
+      await route.fulfill({
+        json: {
+          id: "agent-1",
+          slug: "jensen",
+          name: "Jensen",
+          role: "Billing Reliability Specialist",
+          status: "active",
+          short_description: "Stripe webhooks and billing retries.",
+          description: "Stripe webhooks and billing retries.",
+          created_from: "earned",
+          model_hint: "inherit",
+          permission_scope: "readonly",
+          domain_tags: ["Stripe", "Billing"],
+          routing_triggers: ["stripe"],
+          negative_triggers: [],
+          instructions: [],
+          linked_knowledge: [],
+          recent_invocations: [],
+          stats: {
+            invocations_count: 12,
+            linked_docs_count: 2,
+            tokens_saved: 42000,
+            usd_saved: "0.630000",
+          },
+        },
+      })
+      return
+    }
+
+    await route.fulfill({ status: 404, json: { detail: "Not found" } })
+  })
+
   await mockV2Documents(page)
 }
 
@@ -139,4 +204,26 @@ test("V2 document viewer ignores unknown URL hash anchors", async ({
       ),
     )
     .toEqual([])
+})
+
+test("V2 document can be added to an agent", async ({ page }) => {
+  await mockTaskforceDocumentPage(page)
+
+  await page.goto(`/v2/library/${bridgeDocumentId}`)
+  await page.getByRole("button", { name: "Add to agent" }).click()
+  await page.getByLabel("Search agents").fill("jensen")
+  await page.getByRole("button", { name: /Jensen/ }).click()
+
+  const addResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/v2/agents/jensen/documents?demo=true") &&
+      response.request().method() === "POST",
+  )
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "Add to agent" })
+    .click()
+  expect(
+    await addResponse.then((response) => response.request().postDataJSON()),
+  ).toMatchObject({ document_id: bridgeDocumentId })
 })


### PR DESCRIPTION
Jira: https://alexlee4190.atlassian.net/browse/TF-253

## Scope
- Adds frontend API helpers for `POST /v2/agents/{slug}/documents` and `DELETE /v2/agents/{slug}/documents/{document_id}`.
- Replaces the read-only profile linked-knowledge table with an editable `Documents` section.
- Adds an agent-page `Add documents` picker with search, folder filter, favorites filter, multi-select, remove actions, and the 25-link cap guardrail.
- Adds a library document `Add to agent` dialog that uses the same link endpoint and disables full agents.
- Extends mocked browser coverage for both assignment directions.

## Validation
- `npx biome check --write --unsafe --files-ignore-unknown=true src/api/v2Agents.ts 'src/routes/v2/profiles.$slug.tsx' 'src/routes/v2/library.$documentId.tsx' tests/agents-routing.spec.ts tests/v2-document-hash.spec.ts`
- `npx tsc -p tsconfig.build.json --noEmit`
- `npx playwright test --config=playwright.mocked.config.ts tests/agents-routing.spec.ts tests/v2-document-hash.spec.ts` was attempted locally, but the Vite web server could not start under local Node 18.19.1 because Tailwind's optional native binding was missing. CI should run on the repo-supported Node runtime.