### PR TITLE
TF-255: Add harness sync action

### DIFF
--- a/src/api/v2Agents.ts
+++ b/src/api/v2Agents.ts
@@ -3,6 +3,8 @@ import { request } from "@/client/core/request"
 
 export type AgentSpecialistStatus = "active" | "draft" | "archived" | "proposed"
 export type AgentPermissionScope = "readonly" | "full"
+export type AgentHarnessTarget = "claude" | "codex" | "cursor"
+export type AgentHarnessTargetOption = AgentHarnessTarget | "all"
 
 export interface AgentSpecialistSummary {
   id: string
@@ -75,6 +77,18 @@ export interface AgentSpecialistStats {
   linked_docs_count: number
   tokens_saved: number
   usd_saved: string
+}
+
+export interface AgentHarnessSyncFile {
+  target: AgentHarnessTarget
+  path: string
+  content: string
+  sha256: string
+}
+
+export interface AgentHarnessSyncResponse {
+  priority: AgentHarnessTarget[]
+  files: AgentHarnessSyncFile[]
 }
 
 export interface AgentSpecialistDetail {
@@ -204,6 +218,23 @@ export function unlinkAgentDocument(
       document_id: documentId,
     },
     query: {
+      demo: options.demo || undefined,
+    },
+  })
+}
+
+export function syncAgentHarness(
+  slug: string,
+  options: { target?: AgentHarnessTargetOption; demo?: boolean } = {},
+): CancelablePromise<AgentHarnessSyncResponse> {
+  return request(OpenAPI, {
+    method: "POST",
+    url: "/api/v1/v2/agents/{slug}/sync-harness",
+    path: {
+      slug,
+    },
+    query: {
+      target: options.target || undefined,
       demo: options.demo || undefined,
     },
   })

--- a/src/routes/v2/profiles.$slug.tsx
+++ b/src/routes/v2/profiles.$slug.tsx
@@ -7,6 +7,7 @@ import {
   Pencil,
   Pin,
   Plus,
+  RefreshCw,
   Search,
   Trash2,
 } from "lucide-react"
@@ -19,6 +20,7 @@ import {
   deleteAgent,
   getAgent,
   linkAgentDocument,
+  syncAgentHarness,
   unlinkAgentDocument,
   updateAgent,
 } from "@/api/v2Agents"
@@ -659,6 +661,18 @@ function AgentDetailPage() {
       showErrorToast("Could not delete profile.")
     },
   })
+  const syncMutation = useMutation({
+    mutationFn: () => syncAgentHarness(slug, { demo: isDemoMode }),
+    onSuccess: (result) => {
+      const count = result.files.length
+      showSuccessToast(
+        `Harness sync prepared for ${count} file${count === 1 ? "" : "s"}.`,
+      )
+    },
+    onError: () => {
+      showErrorToast("Could not sync this profile to harness.")
+    },
+  })
   const addDocumentsMutation = useMutation({
     mutationFn: async (documentIds: string[]) => {
       const updates = await Promise.all(
@@ -867,6 +881,19 @@ function AgentDetailPage() {
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <AgentStatusBadge status={agent.status} className="h-8 px-3" />
+            <button
+              type="button"
+              onClick={() => syncMutation.mutate()}
+              disabled={syncMutation.isPending}
+              className="inline-flex h-8 items-center gap-2 rounded-md border border-black/10 px-3 text-xs font-medium text-foreground transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-white/12 dark:hover:bg-white/5"
+            >
+              {syncMutation.isPending ? (
+                <Loader2 className="size-3.5 animate-spin" aria-hidden />
+              ) : (
+                <RefreshCw className="size-3.5" aria-hidden />
+              )}
+              Sync to harness
+            </button>
             <button
               type="button"
               onClick={() => setEditOpen(true)}

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -235,6 +235,37 @@ async function mockAgentsShell(page: Page, options: { empty?: boolean } = {}) {
         return
       }
     }
+    if (
+      url.pathname === "/api/v1/v2/agents/jensen/sync-harness" &&
+      method === "POST"
+    ) {
+      await route.fulfill({
+        json: {
+          priority: ["claude", "codex", "cursor"],
+          files: [
+            {
+              target: "claude",
+              path: ".claude/agents/jensen.md",
+              content: "---\nname: jensen\n---\n",
+              sha256: "a".repeat(64),
+            },
+            {
+              target: "codex",
+              path: ".codex/agents/jensen.md",
+              content: "---\nname: jensen\n---\n",
+              sha256: "a".repeat(64),
+            },
+            {
+              target: "cursor",
+              path: ".cursor/agents/jensen.md",
+              content: "---\nname: jensen\n---\n",
+              sha256: "a".repeat(64),
+            },
+          ],
+        },
+      })
+      return
+    }
     const unlinkMatch = url.pathname.match(
       /^\/api\/v1\/v2\/agents\/jensen\/documents\/([^/]+)$/,
     )
@@ -571,6 +602,24 @@ test("profile documents can be pinned and removed", async ({ page }) => {
   await expect(
     page.getByRole("link", { name: "Refund idempotency notes" }),
   ).toHaveCount(0)
+})
+
+test("profile detail can prepare harness sync", async ({ page }) => {
+  await mockAgentsShell(page)
+
+  await page.goto("/v2/profiles/jensen")
+
+  const syncResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/v2/agents/jensen/sync-harness") &&
+      response.request().method() === "POST",
+  )
+  await page.getByRole("button", { name: "Sync to harness" }).click()
+  await syncResponse
+
+  await expect(
+    page.getByText("Harness sync prepared for 3 files."),
+  ).toBeVisible()
 })
 
 test("profiles grid shows empty state before profiles are seeded", async ({


### PR DESCRIPTION
## Summary
- Add typed frontend API support for `POST /v2/agents/{slug}/sync-harness`.
- Add a profile header "Sync to harness" action with pending state and toast feedback.
- Extend the mocked agents routing spec with the sync endpoint and button flow.

## Validation
- `npx biome check src/api/v2Agents.ts 'src/routes/v2/profiles.$slug.tsx' tests/agents-routing.spec.ts` passed.
- `npx -y -p node@20 -c 'node --version && npm run build'` passed with Node 20.20.2.
- `npm run build` under the default shell Node 18.19.1 is blocked because Vite requires Node 20.19+.
- `npm run test:mocked -- tests/agents-routing.spec.ts` is blocked locally: the mocked Vite shell leaves `#root` empty and broad baseline route tests fail before the new sync button can render.

Related: TF-255
