### PR TITLE
TF-269/TF-270: Profiles auto-evolve toggle and candidate approval

### DIFF
--- a/src/api/v2Agents.ts
+++ b/src/api/v2Agents.ts
@@ -1,7 +1,11 @@
 import { type CancelablePromise, OpenAPI } from "@/client"
 import { request } from "@/client/core/request"
 
-export type AgentSpecialistStatus = "active" | "draft" | "archived" | "proposed"
+export type AgentSpecialistStatus =
+  | "active"
+  | "draft"
+  | "archived"
+  | "proposed"
 export type AgentPermissionScope = "readonly" | "full"
 export type AgentHarnessTarget = "claude" | "codex" | "cursor"
 export type AgentHarnessTargetOption = AgentHarnessTarget | "all"

--- a/src/components/V2/Agents/AgentStatusBadge.tsx
+++ b/src/components/V2/Agents/AgentStatusBadge.tsx
@@ -1,6 +1,13 @@
 import type { AgentSpecialistStatus } from "@/api/v2Agents"
 import { cn } from "@/lib/utils"
 
+const STATUS_LABELS: Record<AgentSpecialistStatus, string> = {
+  active: "Active",
+  draft: "Draft",
+  proposed: "Candidate",
+  archived: "Archived",
+}
+
 const STATUS_STYLES: Record<AgentSpecialistStatus, string> = {
   active: "border-emerald-500/30 text-emerald-700 dark:text-emerald-400",
   draft: "border-amber-500/30 text-amber-700 dark:text-amber-400",
@@ -33,7 +40,7 @@ export function AgentStatusBadge({
           status === "archived" && "bg-muted-foreground/60",
         )}
       />
-      {status}
+      {STATUS_LABELS[status]}
     </span>
   )
 }

--- a/src/components/V2/Agents/AutoEvolveToggle.tsx
+++ b/src/components/V2/Agents/AutoEvolveToggle.tsx
@@ -1,0 +1,71 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { Sparkles } from "lucide-react"
+
+import { readMyOrganization, updateMyOrganization } from "@/api/organizations"
+import { Button } from "@/components/ui/button"
+import useCustomToast from "@/hooks/useCustomToast"
+import { cn } from "@/lib/utils"
+
+export const organizationQueryKey = ["my-organization"]
+
+export function AutoEvolveToggle({ className }: { className?: string }) {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  const organizationQuery = useQuery({
+    queryKey: organizationQueryKey,
+    queryFn: readMyOrganization,
+  })
+
+  const autoEvolveMutation = useMutation({
+    mutationFn: (autoEvolveEnabled: boolean) =>
+      updateMyOrganization({ auto_evolve_enabled: autoEvolveEnabled }),
+    onSuccess: (updatedOrganization) => {
+      showSuccessToast(
+        updatedOrganization.auto_evolve_enabled
+          ? "Auto-evolve enabled"
+          : "Auto-evolve disabled — humans-only mode",
+      )
+      void queryClient.invalidateQueries({ queryKey: organizationQueryKey })
+    },
+    onError: () => {
+      showErrorToast("Could not update auto-evolve setting.")
+    },
+  })
+
+  const organization = organizationQuery.data
+  const isAdmin = organization?.organization_role === "admin"
+
+  if (!isAdmin || organizationQuery.isLoading || !organization) {
+    return null
+  }
+
+  const enabled = organization.auto_evolve_enabled
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-2 rounded-lg border border-border bg-muted/40 p-1 pl-2.5",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Sparkles className="size-3.5 text-primary" aria-hidden />
+        <span className="whitespace-nowrap font-medium text-foreground">
+          Auto-evolve
+        </span>
+      </div>
+      <Button
+        type="button"
+        size="sm"
+        variant={enabled ? "default" : "outline"}
+        className="h-7 min-w-12 px-2.5"
+        data-testid="profiles-auto-evolve-toggle"
+        disabled={autoEvolveMutation.isPending}
+        onClick={() => autoEvolveMutation.mutate(!enabled)}
+      >
+        {enabled ? "On" : "Off"}
+      </Button>
+    </div>
+  )
+}

--- a/src/components/V2/Agents/CandidateProfileCard.tsx
+++ b/src/components/V2/Agents/CandidateProfileCard.tsx
@@ -1,0 +1,148 @@
+import { Link } from "@tanstack/react-router"
+import { Hash, Loader2 } from "lucide-react"
+
+import type { AgentSpecialistSummary } from "@/api/v2Agents"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+import { AgentStatusBadge } from "./AgentStatusBadge"
+import { formatCompactNumber, formatRelativeTime } from "./formatters"
+
+function initialsOf(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return "?"
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[1][0]).toUpperCase()
+}
+
+export function CandidateProfileCard({
+  agent,
+  isApproving,
+  isDismissing,
+  onApprove,
+  onDismiss,
+}: {
+  agent: AgentSpecialistSummary
+  isApproving: boolean
+  isDismissing: boolean
+  onApprove: () => void
+  onDismiss: () => void
+}) {
+  const topTag = agent.domain_tags[0]
+  const busy = isApproving || isDismissing
+
+  return (
+    <article
+      data-testid={`candidate-profile-${agent.slug}`}
+      className="flex min-h-[168px] flex-col border border-dashed border-sky-500/40 bg-card px-4 pt-[15px] text-card-foreground"
+    >
+      <div className="flex items-center gap-[11px]">
+        <div className="grid size-[38px] shrink-0 place-items-center bg-sky-500/10 font-mono text-[13px] font-semibold text-sky-700 outline outline-1 outline-sky-500/20 dark:text-sky-400">
+          {initialsOf(agent.name)}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <Link
+              to="/v2/profiles/$slug"
+              params={{ slug: agent.slug }}
+              className="truncate text-sm font-semibold tracking-[-0.01em] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+            >
+              {agent.name}
+            </Link>
+            <AgentStatusBadge status={agent.status} className="h-6 shrink-0" />
+          </div>
+          <div className="mt-[3px] font-mono text-[10px] tracking-[0.01em] text-foreground/70">
+            {agent.role}
+          </div>
+        </div>
+      </div>
+
+      {agent.short_description && (
+        <p className="mt-3 line-clamp-2 text-[12px] leading-[1.45] text-foreground/80">
+          {agent.short_description}
+        </p>
+      )}
+
+      <div className="mt-3 grid grid-cols-3 border-t border-border/60">
+        <div className="py-[11px]">
+          <div className="font-mono text-[15px] font-semibold tabular-nums tracking-[-0.01em] text-sky-700 dark:text-sky-400">
+            {agent.invocations_count.toLocaleString()}
+          </div>
+          <div className="mt-[3px] font-mono text-[9.5px] tracking-[0.01em] text-foreground/70">
+            Invocations
+          </div>
+        </div>
+        <div className="border-l border-border/60 py-[11px] pl-3">
+          <div className="font-mono text-[15px] font-semibold tabular-nums tracking-[-0.01em] text-foreground">
+            {agent.linked_docs_count.toLocaleString()}
+          </div>
+          <div className="mt-[3px] font-mono text-[9.5px] tracking-[0.01em] text-foreground/70">
+            Docs
+          </div>
+        </div>
+        <div className="border-l border-border/60 py-[11px] pl-3">
+          <div className="font-mono text-[15px] font-semibold tabular-nums tracking-[-0.01em] text-foreground">
+            {formatCompactNumber(agent.tokens_saved)}
+          </div>
+          <div className="mt-[3px] font-mono text-[9.5px] tracking-[0.01em] text-foreground/70">
+            Saved
+          </div>
+        </div>
+      </div>
+
+      <div className="-mx-4 flex flex-wrap items-center justify-between gap-2 border-t border-border/60 px-4 py-[9px]">
+        <div className="flex min-w-0 items-center gap-1.5 font-mono text-[10.5px] tracking-[0.03em] text-muted-foreground/90">
+          <span className="size-1.5 shrink-0 bg-sky-500" />
+          Proposed {formatRelativeTime(agent.created_at)}
+        </div>
+        {topTag && (
+          <div className="flex min-w-0 items-center gap-1 whitespace-nowrap font-mono text-[10.5px] tracking-[0.03em] text-muted-foreground">
+            <Hash
+              className="size-[11px] shrink-0 text-muted-foreground/70"
+              aria-hidden
+            />
+            <span className="truncate">{topTag.toLowerCase()}</span>
+          </div>
+        )}
+      </div>
+
+      <div className="-mx-4 mt-auto flex items-center gap-2 border-t border-border/60 px-4 py-3">
+        <Button
+          type="button"
+          size="sm"
+          className="flex-1"
+          disabled={busy}
+          data-testid={`candidate-approve-${agent.slug}`}
+          onClick={onApprove}
+        >
+          {isApproving ? (
+            <>
+              <Loader2 className="size-3.5 animate-spin" />
+              Approving
+            </>
+          ) : (
+            "Approve"
+          )}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className={cn("flex-1", isDismissing && "text-muted-foreground")}
+          disabled={busy}
+          data-testid={`candidate-dismiss-${agent.slug}`}
+          onClick={onDismiss}
+        >
+          {isDismissing ? (
+            <>
+              <Loader2 className="size-3.5 animate-spin" />
+              Dismissing
+            </>
+          ) : (
+            "Dismiss"
+          )}
+        </Button>
+      </div>
+    </article>
+  )
+}

--- a/src/routes/v2/profiles.tsx
+++ b/src/routes/v2/profiles.tsx
@@ -13,11 +13,14 @@ import {
   type AgentSpecialistSummary,
   createAgent,
   listAgents,
+  updateAgent,
 } from "@/api/v2Agents"
 import { useDemoMode } from "@/components/demo-mode-provider"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AgentProfileCard } from "@/components/V2/Agents/AgentProfileCard"
+import { AutoEvolveToggle } from "@/components/V2/Agents/AutoEvolveToggle"
+import { CandidateProfileCard } from "@/components/V2/Agents/CandidateProfileCard"
 import {
   AGENT_EYEBROW_CLASS,
   AGENT_PAGE_TITLE_CLASS,
@@ -147,6 +150,10 @@ function AgentsIndex() {
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const [createProfileOpen, setCreateProfileOpen] = useState(false)
+  const [reviewingSlug, setReviewingSlug] = useState<{
+    slug: string
+    action: "approve" | "dismiss"
+  } | null>(null)
   const agentsQuery = useQuery({
     queryKey: ["v2-agents", isDemoMode],
     queryFn: () => listAgents({ demo: isDemoMode }),
@@ -170,7 +177,51 @@ function AgentsIndex() {
     },
   })
 
-  const visible = useMemo(() => sortAgentsByCreatedAt(agents), [agents])
+  const reviewCandidateMutation = useMutation({
+    mutationFn: ({
+      slug,
+      action,
+    }: {
+      slug: string
+      action: "approve" | "dismiss"
+    }) =>
+      updateAgent(
+        slug,
+        { status: action === "approve" ? "active" : "archived" },
+        { demo: isDemoMode },
+      ),
+    onMutate: ({ slug, action }) => {
+      setReviewingSlug({ slug, action })
+    },
+    onSuccess: (_agent, { action }) => {
+      queryClient.invalidateQueries({ queryKey: ["v2-agents", isDemoMode] })
+      showSuccessToast(
+        action === "approve" ? "Profile approved." : "Profile dismissed.",
+      )
+    },
+    onError: (_error, { action }) => {
+      showErrorToast(
+        action === "approve"
+          ? "Could not approve profile."
+          : "Could not dismiss profile.",
+      )
+    },
+    onSettled: () => {
+      setReviewingSlug(null)
+    },
+  })
+
+  const candidateProfiles = useMemo(
+    () => sortAgentsByCreatedAt(agents.filter((agent) => agent.status === "proposed")),
+    [agents],
+  )
+  const approvedProfiles = useMemo(
+    () =>
+      sortAgentsByCreatedAt(
+        agents.filter((agent) => agent.status !== "proposed"),
+      ),
+    [agents],
+  )
 
   return (
     <section
@@ -188,14 +239,17 @@ function AgentsIndex() {
               </div>
               <h1 className={cn("mt-1", AGENT_PAGE_TITLE_CLASS)}>Profiles</h1>
             </div>
-            <Button
-              type="button"
-              size="sm"
-              className="w-fit"
-              onClick={() => setCreateProfileOpen(true)}
-            >
-              + Profile
-            </Button>
+            <div className="flex flex-wrap items-center gap-2">
+              <AutoEvolveToggle />
+              <Button
+                type="button"
+                size="sm"
+                className="w-fit"
+                onClick={() => setCreateProfileOpen(true)}
+              >
+                + Profile
+              </Button>
+            </div>
           </header>
         </div>
 
@@ -232,13 +286,69 @@ function AgentsIndex() {
               {agents.length === 0 ? (
                 <EmptyAgents isDemoMode={isDemoMode} />
               ) : (
-                <div
-                  data-testid="agents-card-grid"
-                  className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
-                >
-                  {visible.map((agent) => (
-                    <AgentProfileCard key={agent.id} agent={agent} />
-                  ))}
+                <div className="space-y-8">
+                  {candidateProfiles.length > 0 && (
+                    <section data-testid="candidate-profiles-section">
+                      <div className="mb-3">
+                        <h2 className="text-sm font-semibold tracking-tight">
+                          Candidate profiles
+                        </h2>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          Taskforce proposed these profiles from recent work.
+                          Approve to activate routing, or dismiss to archive.
+                        </p>
+                      </div>
+                      <div
+                        data-testid="candidate-profiles-grid"
+                        className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+                      >
+                        {candidateProfiles.map((agent) => (
+                          <CandidateProfileCard
+                            key={agent.id}
+                            agent={agent}
+                            isApproving={
+                              reviewingSlug?.slug === agent.slug &&
+                              reviewingSlug.action === "approve"
+                            }
+                            isDismissing={
+                              reviewingSlug?.slug === agent.slug &&
+                              reviewingSlug.action === "dismiss"
+                            }
+                            onApprove={() =>
+                              reviewCandidateMutation.mutate({
+                                slug: agent.slug,
+                                action: "approve",
+                              })
+                            }
+                            onDismiss={() =>
+                              reviewCandidateMutation.mutate({
+                                slug: agent.slug,
+                                action: "dismiss",
+                              })
+                            }
+                          />
+                        ))}
+                      </div>
+                    </section>
+                  )}
+
+                  {approvedProfiles.length > 0 ? (
+                    <section>
+                      {candidateProfiles.length > 0 && (
+                        <h2 className="mb-3 text-sm font-semibold tracking-tight">
+                          Approved profiles
+                        </h2>
+                      )}
+                      <div
+                        data-testid="agents-card-grid"
+                        className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+                      >
+                        {approvedProfiles.map((agent) => (
+                          <AgentProfileCard key={agent.id} agent={agent} />
+                        ))}
+                      </div>
+                    </section>
+                  ) : null}
                 </div>
               )}
             </>

--- a/tests/agents-routing.spec.ts
+++ b/tests/agents-routing.spec.ts
@@ -11,6 +11,24 @@ const currentUser = {
   subscription_tier: "free",
 }
 
+const organization = {
+  id: "org-1",
+  name: "Taskforce Labs",
+  auto_evolve_enabled: true,
+  created_at: "2026-03-24T00:00:00Z",
+  updated_at: "2026-03-24T00:00:00Z",
+  organization_role: "admin",
+  members: [
+    {
+      id: "user-1",
+      email: "alex@example.com",
+      full_name: "Alex Lee",
+      organization_role: "admin",
+    },
+  ],
+  invitations: [],
+}
+
 const agents = [
   {
     id: "agent-1",
@@ -58,6 +76,21 @@ const agents = [
     tokens_saved: 8000,
     last_invoked_at: "2026-06-01T12:00:00Z",
     created_at: "2026-06-01T12:00:00Z",
+  },
+  {
+    id: "agent-4",
+    slug: "orion",
+    name: "Orion",
+    role: "Observability Specialist",
+    short_description: "Metrics drift, alert noise, and dashboard hygiene.",
+    domain_tags: ["Metrics", "Observability"],
+    status: "proposed",
+    created_from: "earned",
+    linked_docs_count: 0,
+    invocations_count: 0,
+    tokens_saved: 0,
+    last_invoked_at: null,
+    created_at: "2026-06-15T12:00:00Z",
   },
 ]
 
@@ -169,6 +202,7 @@ test.use({
 async function mockAgentsShell(page: Page, options: { empty?: boolean } = {}) {
   let agentItems = agents.map((agent) => ({ ...agent }))
   let detail = { ...jensenDetail }
+  let organizationState = { ...organization }
 
   await page.addInitScript(() => {
     window.localStorage.setItem("access_token", "test-token")
@@ -189,6 +223,14 @@ async function mockAgentsShell(page: Page, options: { empty?: boolean } = {}) {
 
   await page.route("**/api/v1/organizations/invitations", async (route) => {
     await route.fulfill({ json: { data: [], count: 0 } })
+  })
+
+  await page.route("**/api/v1/organizations/me", async (route) => {
+    if (route.request().method() === "PATCH") {
+      const body = route.request().postDataJSON()
+      organizationState = { ...organizationState, ...body }
+    }
+    await route.fulfill({ json: organizationState })
   })
 
   await page.route("**/api/v1/v2/agents**", async (route) => {
@@ -288,6 +330,29 @@ async function mockAgentsShell(page: Page, options: { empty?: boolean } = {}) {
         )
       }
       await route.fulfill({ json: detail })
+      return
+    }
+    const agentSlugMatch = url.pathname.match(
+      /^\/api\/v1\/v2\/agents\/([^/]+)$/,
+    )
+    if (agentSlugMatch) {
+      const slug = agentSlugMatch[1]
+      const agent = agentItems.find((item) => item.slug === slug)
+      if (!agent) {
+        await route.fulfill({ status: 404, json: { detail: "Not found" } })
+        return
+      }
+      if (method === "PATCH") {
+        const body = route.request().postDataJSON()
+        agentItems = agentItems.map((item) =>
+          item.slug === slug ? { ...item, ...body } : item,
+        )
+        await route.fulfill({
+          json: { ...jensenDetail, ...agent, ...body, slug },
+        })
+        return
+      }
+      await route.fulfill({ json: { ...jensenDetail, ...agent, slug } })
       return
     }
     await route.fulfill({ status: 404, json: { detail: "Not found" } })
@@ -466,6 +531,8 @@ test("profiles grid links to detail and session metrics", async ({ page }) => {
     page.getByRole("heading", { name: "Profiles", level: 1 }),
   ).toBeVisible()
   await expect(page.getByTestId("agents-card-grid")).toBeVisible()
+  await expect(page.getByTestId("candidate-profiles-section")).toBeVisible()
+  await expect(page.getByText("Orion", { exact: true })).toBeVisible()
   await expect(page.getByText("Jensen", { exact: true })).toBeVisible()
   await expect(page.getByText("Mira", { exact: true })).toBeVisible()
   await expect(page.getByTestId("agent-status-active").first()).toBeVisible()
@@ -712,4 +779,82 @@ test("profile detail exposes a retry state instead of not found", async ({
     page.getByRole("heading", { name: "Jensen", level: 1 }),
   ).toBeVisible()
   expect(attempts).toBe(2)
+})
+
+test("profiles header exposes auto-evolve toggle for org admins", async ({
+  page,
+}) => {
+  await mockAgentsShell(page)
+
+  await page.goto("/v2/profiles")
+
+  const toggle = page.getByTestId("profiles-auto-evolve-toggle")
+  await expect(toggle).toHaveText("On")
+
+  const patchResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/organizations/me") &&
+      response.request().method() === "PATCH",
+  )
+  await toggle.click()
+  expect(
+    await patchResponse.then((response) => response.request().postDataJSON()),
+  ).toMatchObject({ auto_evolve_enabled: false })
+  await expect(toggle).toHaveText("Off")
+})
+
+test("candidate profiles approve and dismiss update the grids", async ({
+  page,
+}) => {
+  await mockAgentsShell(page)
+
+  await page.goto("/v2/profiles")
+
+  await expect(page.getByTestId("candidate-profiles-section")).toBeVisible()
+  await expect(page.getByTestId("candidate-profile-orion")).toBeVisible()
+  await expect(
+    page.getByTestId("agents-card-grid").getByText("Orion", { exact: true }),
+  ).toHaveCount(0)
+
+  const approveResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/v2/agents/orion") &&
+      response.request().method() === "PATCH",
+  )
+  await page.getByTestId("candidate-approve-orion").click()
+  expect(
+    await approveResponse.then((response) => response.request().postDataJSON()),
+  ).toMatchObject({ status: "active" })
+
+  await expect(page.getByTestId("candidate-profile-orion")).toHaveCount(0)
+  await expect(
+    page.getByTestId("agents-card-grid").getByRole("link", {
+      name: /open profile orion/i,
+    }),
+  ).toBeVisible()
+  await expect(page.getByTestId("agent-status-active")).toHaveCount(3)
+})
+
+test("candidate profile dismiss archives the profile", async ({ page }) => {
+  await mockAgentsShell(page)
+
+  await page.goto("/v2/profiles")
+
+  const dismissResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/v2/agents/orion") &&
+      response.request().method() === "PATCH",
+  )
+  await page.getByTestId("candidate-dismiss-orion").click()
+  expect(
+    await dismissResponse.then((response) => response.request().postDataJSON()),
+  ).toMatchObject({ status: "archived" })
+
+  await expect(page.getByTestId("candidate-profile-orion")).toHaveCount(0)
+  await expect(
+    page
+      .getByTestId("agents-card-grid")
+      .getByRole("link", { name: /open profile orion/i })
+      .getByTestId("agent-status-archived"),
+  ).toBeVisible()
 })


### PR DESCRIPTION
## Summary
- **TF-269:** Add org-admin auto-evolve On/Off toggle to the `/v2/profiles` header, reusing `readMyOrganization` + `updateMyOrganization({ auto_evolve_enabled })` (same behavior as Org settings).
- **TF-270:** Split the profiles list into a **Candidate profiles** section (`status=proposed`) with Approve/Dismiss actions and an **Approved profiles** grid below. Approve → `PATCH { status: "active" }`; Dismiss → `PATCH { status: "archived" }`.
- Extends `AgentSpecialistStatus` with `proposed` and labels proposed badges as **Candidate**.

Closes epic **TF-268** (frontend-only; no backend changes).

## Test plan
- [x] `npx tsc -p tsconfig.build.json` passes locally
- [ ] Playwright `tests/agents-routing.spec.ts` (new cases: auto-evolve toggle, candidate approve, candidate dismiss)
- [ ] Manual: org admin sees Auto-evolve toggle on Profiles tab; toggling updates org setting
- [ ] Manual: proposed profile appears in candidate section; Approve moves to approved grid as active; Dismiss archives

## Jira
- Epic: [TF-268](https://alexlee4190.atlassian.net/browse/TF-268)
- Story: [TF-269](https://alexlee4190.atlassian.net/browse/TF-269)
- Story: [TF-270](https://alexlee4190.atlassian.net/browse/TF-270)

Made with [Cursor](https://cursor.com)