### PR TITLE
Align Ledger typography with v2 tab text scale

### DIFF
--- a/src/components/V2/Ledger/LedgerPage.module.css
+++ b/src/components/V2/Ledger/LedgerPage.module.css
@@ -1,12 +1,8 @@
 /*
  * Ledger surface — a faithful port of docs/ledger-target.html.
  *
- * Type and spacing are normalized to the rest of the v2 surface (Profiles /
- * Library): the mono eyebrow matches V2_TAB_EYEBROW_CLASS (12px), the page
- * title matches text-2xl (24px), horizontal insets come from V2_PAGE_CONTENT
- * padding on the page shell, and body/label sizes round to the standard
- * Tailwind scale
- * (12 / 14 / 16 / 24) so the page reads the same as every other tab.
+ * Type and spacing use the shared v2 typography tokens (`--text-v2-*`) and the
+ * `v2-tab-content` scale wrapper so body copy matches Profiles / Library.
  *
  * The standalone mock defined a `--tf-*` palette in a missing `_shared.css`;
  * we reconstruct that palette on `.app` from the app's own theme tokens so the
@@ -47,7 +43,7 @@
   background: var(--tf-bg);
   color: var(--tf-fg);
   font-family: var(--font-sans);
-  font-size: calc(16px * var(--v2-scale, 1));
+  font-size: var(--text-v2-body);
 }
 
 /* biome-ignore lint/correctness/noUnknownPseudoClass: CSS Modules :global() scope selector. */
@@ -77,7 +73,7 @@
 }
 .crumb {
   font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   /* Match Tailwind text-xs (16px) so the title stacks identically to Profiles. */
   line-height: 1rem;
   letter-spacing: 0.01em;
@@ -86,15 +82,6 @@
 }
 .h1NoEyebrow {
   margin-top: 0;
-}
-.h1 {
-  margin: 4px 0 0;
-  font-size: calc(24px * var(--v2-scale, 1));
-  /* Match Tailwind text-2xl line-height so the title baseline lines up with the
-     Profiles page title (which inherits Tailwind's controlled line-heights). */
-  line-height: 2rem;
-  letter-spacing: -0.018em;
-  font-weight: 600;
 }
 .tools {
   display: flex;
@@ -117,7 +104,7 @@
   border: 0;
   background: transparent;
   font-family: var(--font-mono);
-  font-size: calc(14px * var(--v2-scale, 1));
+  font-size: var(--text-v2-sm);
   color: var(--tf-fg);
   outline: none;
 }
@@ -131,7 +118,7 @@
   padding: 0 11px;
   border: 1px solid var(--tf-border);
   font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   color: var(--tf-muted-fg);
   display: flex;
   align-items: center;
@@ -151,7 +138,7 @@
   height: 100%;
   opacity: 0;
   cursor: pointer;
-  font-size: calc(14px * var(--v2-scale, 1));
+  font-size: var(--text-v2-sm);
 }
 
 /* Column header */
@@ -163,7 +150,7 @@
   padding: 11px var(--ledger-row-padding-inline, 1rem);
   border-bottom: 1px solid var(--tf-border);
   font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   letter-spacing: 0.01em;
   text-transform: none;
   color: var(--tf-faint-fg);
@@ -179,7 +166,7 @@
 }
 .dayLbl {
   font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   letter-spacing: 0.01em;
   text-transform: none;
   color: var(--tf-fg);
@@ -190,7 +177,7 @@
 }
 .dayCt {
   font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   color: var(--tf-faint-fg);
   font-variant-numeric: tabular-nums;
 }
@@ -215,13 +202,13 @@
 }
 .clock {
   font-family: var(--font-mono);
-  font-size: calc(14px * var(--v2-scale, 1));
+  font-size: var(--text-v2-sm);
   color: var(--tf-muted-fg);
   font-variant-numeric: tabular-nums;
 }
 .clock small {
   display: block;
-  font-size: calc(11px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   color: var(--tf-faint-fg);
   margin-top: 2px;
   letter-spacing: 0.04em;
@@ -230,7 +217,7 @@
   min-width: 0;
 }
 .ttl {
-  font-size: calc(16px * var(--v2-scale, 1));
+  font-size: var(--text-v2-base);
   font-weight: 500;
   letter-spacing: -0.005em;
   overflow: hidden;
@@ -240,7 +227,7 @@
 .sub {
   margin-top: 4px;
   font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   color: var(--tf-muted-fg);
   display: flex;
   align-items: center;
@@ -272,7 +259,7 @@
   min-width: 0;
 }
 .harnessH {
-  font-size: calc(14px * var(--v2-scale, 1));
+  font-size: var(--text-v2-sm);
   color: var(--tf-fg);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -280,7 +267,7 @@
 }
 .harnessAg {
   font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   color: var(--tf-faint-fg);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -288,7 +275,7 @@
 }
 .act {
   font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   color: var(--tf-muted-fg);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -300,7 +287,7 @@
   min-width: 0;
 }
 .backsLink {
-  font-size: calc(14px * var(--v2-scale, 1));
+  font-size: var(--text-v2-sm);
   color: var(--tf-primary);
   text-decoration: none;
   display: flex;
@@ -324,12 +311,12 @@
   color: var(--tf-faint-fg);
 }
 .backsNone {
-  font-size: calc(14px * var(--v2-scale, 1));
+  font-size: var(--text-v2-sm);
   color: var(--tf-faint-fg);
 }
 .chev {
   color: var(--tf-faint-fg);
-  font-size: calc(16px * var(--v2-scale, 1));
+  font-size: var(--text-v2-body);
   text-align: right;
 }
 
@@ -340,7 +327,7 @@
   gap: 8px;
   padding: 24px var(--ledger-row-padding-inline, 1rem);
   font-family: var(--font-mono);
-  font-size: calc(14px * var(--v2-scale, 1));
+  font-size: var(--text-v2-sm);
   color: var(--tf-muted-fg);
 }
 .empty {
@@ -348,7 +335,7 @@
   border: 1px dashed var(--tf-border);
   padding: 44px;
   text-align: center;
-  font-size: calc(14px * var(--v2-scale, 1));
+  font-size: var(--text-v2-sm);
   color: var(--tf-muted-fg);
 }
 
@@ -406,7 +393,7 @@
   margin-bottom: 20px;
   color: var(--ledger-detail-faint);
   font-family: var(--font-mono);
-  font-size: calc(11px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   letter-spacing: 0.02em;
   min-width: 0;
 }
@@ -472,7 +459,7 @@
 .detailTitle h1 {
   margin: 0;
   overflow-wrap: anywhere;
-  font-size: calc(22px * var(--v2-scale, 1));
+  font-size: 1.5rem;
   font-weight: 600;
   line-height: 1.25;
   letter-spacing: -0.015em;
@@ -484,7 +471,7 @@
   margin-top: 7px;
   color: var(--ledger-detail-faint);
   font-family: var(--font-mono);
-  font-size: calc(11.5px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   letter-spacing: 0.01em;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -499,7 +486,7 @@
   margin-top: 7px;
   color: var(--muted-foreground);
   font-family: var(--font-mono);
-  font-size: calc(11.5px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   letter-spacing: 0.02em;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -523,7 +510,7 @@
   margin-bottom: 14px;
   color: var(--ledger-detail-faint);
   font-family: var(--font-mono);
-  font-size: calc(11px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   font-weight: 500;
   letter-spacing: 0.01em;
 }
@@ -544,14 +531,14 @@
 }
 .eyebrow {
   font-family: var(--font-mono);
-  font-size: calc(12px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   letter-spacing: 0.01em;
   text-transform: none;
   color: var(--tf-muted-fg);
 }
 .tHead h2 {
   margin: 4px 0 0;
-  font-size: calc(24px * var(--v2-scale, 1));
+  font-size: 1.5rem;
   font-weight: 600;
   letter-spacing: -0.018em;
   max-width: 60ch;
@@ -597,7 +584,7 @@
 .evT {
   color: var(--tf-faint-fg);
   font-family: var(--font-mono);
-  font-size: calc(10.5px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.02em;
 }
@@ -613,7 +600,7 @@
   margin-top: 3px;
   max-width: 72ch;
   color: var(--tf-muted-fg);
-  font-size: calc(13px * var(--v2-scale, 1));
+  font-size: var(--text-v2-sm);
   line-height: 1.45;
   text-wrap: pretty;
 }
@@ -625,7 +612,7 @@
   margin-top: 4px;
   max-width: 72ch;
   color: var(--tf-faint-fg);
-  font-size: calc(12px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   line-height: 1.45;
   white-space: pre-wrap;
 }
@@ -650,7 +637,7 @@
   margin: 26px 0 14px;
   color: var(--ledger-detail-faint);
   font-family: var(--font-mono);
-  font-size: calc(11px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   font-weight: 500;
   letter-spacing: 0.01em;
 }
@@ -664,14 +651,14 @@
   padding: 9px 0;
   border-bottom: 1px solid var(--tf-hairline);
   font-family: var(--font-mono);
-  font-size: calc(11.5px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
 }
 .kv:last-child {
   border-bottom: 0;
 }
 .kvK {
   color: var(--ledger-detail-faint);
-  font-size: calc(11px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   font-weight: 500;
   letter-spacing: 0.01em;
 }
@@ -684,7 +671,7 @@
 }
 .kvVMono {
   font-family: var(--font-mono);
-  font-size: calc(11.5px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
 }
 
 .doc {
@@ -703,7 +690,7 @@
 }
 .docLink {
   color: var(--tf-fg);
-  font-size: calc(13px * var(--v2-scale, 1));
+  font-size: var(--text-v2-sm);
   line-height: 1.4;
   text-decoration: none;
   font-weight: 400;
@@ -718,7 +705,7 @@
   gap: 5px;
   margin-top: 5px;
   font-family: var(--font-mono);
-  font-size: calc(10.5px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   letter-spacing: 0.01em;
   text-transform: none;
 }
@@ -746,7 +733,7 @@
   background: transparent;
   color: var(--tf-muted-fg);
   font-family: var(--font-sans);
-  font-size: calc(12.5px * var(--v2-scale, 1));
+  font-size: var(--text-v2-xs);
   text-align: center;
   white-space: nowrap;
   cursor: pointer;

--- a/src/components/V2/Ledger/LedgerPage.tsx
+++ b/src/components/V2/Ledger/LedgerPage.tsx
@@ -394,7 +394,7 @@ export function LedgerPage({
     >
       <div className={cn(V2_PAGE_BODY, selectedSessionId && "pb-0")}>
         {selectedSessionId ? (
-          <div className={styles.app}>
+          <div className={cn(styles.app, "v2-tab-content")}>
             <LedgerDetail
               anchorEventId={searchFilters.event_id}
               detail={detailQuery.data}
@@ -408,7 +408,7 @@ export function LedgerPage({
           </div>
         ) : (
           <div
-            className={styles.app}
+            className={cn(styles.app, "v2-tab-content")}
             style={{ "--grid": GRID } as CSSProperties}
           >
             <div className={V2_TAB_HEADER_STACK_CLASS}>
@@ -419,7 +419,9 @@ export function LedgerPage({
                       ? `${ledgerQuery.data.total} sessions archived`
                       : null}
                   </div> */}
-                  <h1 className={cn(styles.h1, styles.h1NoEyebrow)}>Ledger</h1>
+                  <h1 className={cn("text-2xl font-semibold", styles.h1NoEyebrow)}>
+                    Ledger
+                  </h1>
                 </div>
                 <div className={styles.tools}>
                   <form className={styles.search} onSubmit={onSearchSubmit}>


### PR DESCRIPTION
## Summary
- Wrap ledger surfaces in `v2-tab-content` so they use the same typography scale as Profiles and Library
- Replace pixel-based `calc(Npx * var(--v2-scale))` sizes with shared `--text-v2-*` tokens
- Use `text-2xl font-semibold` for the Ledger page title to match other v2 tabs

## Test plan
- [x] `npx tsc -p tsconfig.build.json --noEmit`
- [ ] Ledger list row text matches Library/Profiles body copy size
- [ ] Ledger detail headings and metadata read at the same scale as other v2 tabs


Made with [Cursor](https://cursor.com)